### PR TITLE
Added DbContext interfaces for EF configuration and operational store

### DIFF
--- a/src/Skoruba.IdentityServer4.Admin/Data/DbContexts/AdminDbContext.cs
+++ b/src/Skoruba.IdentityServer4.Admin/Data/DbContexts/AdminDbContext.cs
@@ -1,5 +1,7 @@
-﻿using IdentityServer4.EntityFramework.Entities;
+﻿using System.Threading.Tasks;
+using IdentityServer4.EntityFramework.Entities;
 using IdentityServer4.EntityFramework.Extensions;
+using IdentityServer4.EntityFramework.Interfaces;
 using IdentityServer4.EntityFramework.Options;
 using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
@@ -9,7 +11,8 @@ using Skoruba.IdentityServer4.Admin.Data.Entities.Identity;
 
 namespace Skoruba.IdentityServer4.Admin.Data.DbContexts
 {
-    public class AdminDbContext : IdentityDbContext<UserIdentity, UserIdentityRole, int, UserIdentityUserClaim, UserIdentityUserRole, UserIdentityUserLogin, UserIdentityRoleClaim, UserIdentityUserToken>
+    public class AdminDbContext : IdentityDbContext<UserIdentity, UserIdentityRole, int, UserIdentityUserClaim, UserIdentityUserRole, UserIdentityUserLogin, UserIdentityRoleClaim, UserIdentityUserToken>,
+        IConfigurationDbContext, IPersistedGrantDbContext
     {
         private readonly ConfigurationStoreOptions _storeOptions;
         private readonly OperationalStoreOptions _operationalOptions;
@@ -60,6 +63,11 @@ namespace Skoruba.IdentityServer4.Admin.Data.DbContexts
         public DbSet<PersistedGrant> PersistedGrants { get; set; }
 
         public DbSet<Log> Logs { get; set; }
+
+        public Task<int> SaveChangesAsync()
+        {
+            return base.SaveChangesAsync();
+        }
 
         protected override void OnModelCreating(ModelBuilder builder)
         {


### PR DESCRIPTION
Hello, this is a small but useful change. 

By adding  `IConfigurationDbContext` and `IPersistedGrantDbContext` interfaces we can reuse `AdminDbContext` when registering EF configuration and operational store in IdentityServer.

Then you should be able to add this context using following code:

```
services.AddIdentityServer()
                .AddConfigurationStore<AdminDbContext>()
                .AddOperationalStore<AdminDbContext>();
```

since both AddConfigurationStore & AddOperationalStore have constraint on T to be of type `DbContext` and implement `IConfigurationDbContext` or `IPersistedGrantDbContext`.

It has an additional advantage of making sure that all relevant DbSets are implemented by AdminDbContext.

HTH