### PR TITLE
Added autocomplete=off for secret values for scopes and clients

### DIFF
--- a/src/Skoruba.IdentityServer4.Admin/Views/Configuration/ApiSecrets.cshtml
+++ b/src/Skoruba.IdentityServer4.Admin/Views/Configuration/ApiSecrets.cshtml
@@ -46,7 +46,7 @@
 							@await Html.PartialAsync("Client/Section/Label", "SecretValue")
 						</label>
 						<div class="col-sm-9">
-							<input type="text" required class="form-control" asp-for="Value">
+							<input type="text"  autocomplete="off" required class="form-control" asp-for="Value">
 							<span asp-validation-for="Value" class="text-danger"></span>
 						</div>
 					</div>

--- a/src/Skoruba.IdentityServer4.Admin/Views/Configuration/ClientSecrets.cshtml
+++ b/src/Skoruba.IdentityServer4.Admin/Views/Configuration/ClientSecrets.cshtml
@@ -42,7 +42,7 @@
 							@await Html.PartialAsync("Client/Section/Label", "SecretValue")
 						</label>
 						<div class="col-sm-9">
-							<input type="text" required class="form-control" asp-for="Value">
+							<input type="text" autocomplete="off" required class="form-control" asp-for="Value">
 							<span asp-validation-for="Value" class="text-danger"></span>
 						</div>
 					</div>


### PR DESCRIPTION
So that when typing in a new secret we don't get a list of previously typed in secrets.