### PR TITLE
Update launchSettings.json

### DIFF
--- a/src/Skoruba.IdentityServer4.Admin/Properties/launchSettings.json
+++ b/src/Skoruba.IdentityServer4.Admin/Properties/launchSettings.json
@@ -21,7 +21,7 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
-      "applicationUrl": "http://localhost:54080/"
+      "applicationUrl": "http://localhost:9000/"
     }
   }
 }


### PR DESCRIPTION
when launching using

```
dotnet run
```

the url with port number 54080 was taken and this resulted in issues because redirects by default are set to port 9000