### PR TITLE
fixed user claim add form

### DIFF
--- a/templates/template-publish/content/src/SkorubaIdentityServer4Admin.Admin/Views/Identity/UserClaims.cshtml
+++ b/templates/template-publish/content/src/SkorubaIdentityServer4Admin.Admin/Views/Identity/UserClaims.cshtml
@@ -40,18 +40,7 @@
 							@await Html.PartialAsync("User/Section/Label", "Type")
 						</label>
 						<div class="col-sm-9">
-							<picker id="ClaimType" multiple-select="false" min-search-text="2"
-							        selected-item="@Model.ClaimType" url="@Url.Action("SearchClaims", "Configuration")?claim"
-							        search-input-placeholder="@Localizer["PickerSearchItemPlaceholder"].Value"
-							        selected-items-title="@Localizer["PickerSelectedItemsTitle"].Value" 
-							        search-result-title="@Localizer["PickerSearchResultTitle"].Value"
-							        suggested-items-title="@Localizer["PickerSuggestedItemsTitle"].Value" 
-							        no-item-selected-title="@Localizer["PickerNoItemSelectedTitle"].Value" 
-							        show-all-items-title="@Localizer["PickerShowAllItemsTitle"].Value"
-							        item-already-selected-title="@Localizer["PickerItemAlreadySelectedTitle"].Value"
-							        required="true" required-message="@Localizer["PickerRequiredMessage"].Value">
-							</picker>
-
+							<input type="text" required class="form-control" asp-for="ClaimType">
 							<span asp-validation-for="ClaimType" class="text-danger"></span>
 						</div>
 					</div>


### PR DESCRIPTION
When adding a user claim I was always getting the error "Claim Type is required".
This is because the deserilisation of Model.ClaimType is not working properly, resulting in a non-functioning multi-select control.
Multi-select is not required in this case anyway. So I replaced it by a text field instead