### PR TITLE
Added Information logging from Skoruba namespace only

### DIFF
--- a/src/Skoruba.IdentityServer4.STS.Identity/appsettings.json
+++ b/src/Skoruba.IdentityServer4.STS.Identity/appsettings.json
@@ -5,7 +5,12 @@
     "IdentityDbConnection": "Server=(localdb)\\mssqllocaldb;Database=IdentityServer4Admin;Trusted_Connection=True;MultipleActiveResultSets=true"
   },
   "Serilog": {
-    "MinimumLevel": "Information",
+    "MinimumLevel": {
+      "Default": "Error",
+      "Override": {
+        "Skoruba": "Information"
+      }
+    },
     "WriteTo": [
       {
         "Name": "File",


### PR DESCRIPTION
Changed so that `Information` verbosity level of logs is only reserved to logs from `Skoruba` namespaces, otherwise only errors are logged in STS.

Fixes #196 