### PR TITLE
Move client id and scopes to application.json for changeable after deploy.

### DIFF
--- a/src/Skoruba.IdentityServer4.Admin/Configuration/AdminConfiguration.cs
+++ b/src/Skoruba.IdentityServer4.Admin/Configuration/AdminConfiguration.cs
@@ -1,4 +1,5 @@
-﻿using Skoruba.IdentityServer4.Admin.Configuration.Interfaces;
+﻿using Skoruba.IdentityServer4.Admin.Configuration.Constants;
+using Skoruba.IdentityServer4.Admin.Configuration.Interfaces;
 
 namespace Skoruba.IdentityServer4.Admin.Configuration
 {
@@ -9,6 +10,7 @@ namespace Skoruba.IdentityServer4.Admin.Configuration
         public string IdentityAdminRedirectUri { get; set; } = "http://localhost:9000/signin-oidc";
 
         public string IdentityServerBaseUrl { get; set; } = "http://localhost:5000";
-        public string ClientId { get; set; } = "skoruba_identity_admin";
+        public string ClientId { get; set; } = AuthenticationConsts.OidcClientId;
+        public string[] Scopes { get; set; } = AuthenticationConsts.Scopes.ToArray();
     }
 }

--- a/src/Skoruba.IdentityServer4.Admin/Configuration/AdminConfiguration.cs
+++ b/src/Skoruba.IdentityServer4.Admin/Configuration/AdminConfiguration.cs
@@ -9,5 +9,6 @@ namespace Skoruba.IdentityServer4.Admin.Configuration
         public string IdentityAdminRedirectUri { get; set; } = "http://localhost:9000/signin-oidc";
 
         public string IdentityServerBaseUrl { get; set; } = "http://localhost:5000";
+        public string ClientId { get; set; } = "skoruba_identity_admin";
     }
 }

--- a/src/Skoruba.IdentityServer4.Admin/Configuration/AdminConfiguration.cs
+++ b/src/Skoruba.IdentityServer4.Admin/Configuration/AdminConfiguration.cs
@@ -12,5 +12,9 @@ namespace Skoruba.IdentityServer4.Admin.Configuration
         public string IdentityServerBaseUrl { get; set; } = "http://localhost:5000";
         public string ClientId { get; set; } = AuthenticationConsts.OidcClientId;
         public string[] Scopes { get; set; } = AuthenticationConsts.Scopes.ToArray();
+        public string ClientSecret { get; set; } = AuthenticationConsts.OidcClientSecret;
+        public string OidcResponseType { get; set; } = AuthenticationConsts.OidcResponseType;
+
+
     }
 }

--- a/src/Skoruba.IdentityServer4.Admin/Configuration/Constants/AuthenticationConsts.cs
+++ b/src/Skoruba.IdentityServer4.Admin/Configuration/Constants/AuthenticationConsts.cs
@@ -7,7 +7,6 @@ namespace Skoruba.IdentityServer4.Admin.Configuration.Constants
         public const string IdentityAdminCookieName = "IdentityServerAdmin";        
         public const string UserNameClaimType = "name";
         public const string SignInScheme = "Cookies";
-        public const string OidcClientId = "skoruba_identity_admin";
         public const string OidcAuthenticationScheme = "oidc";
         public const string OidcResponseType = "id_token";
         public static List<string> Scopes = new List<string> { "openid", "profile", "email", "roles" };

--- a/src/Skoruba.IdentityServer4.Admin/Configuration/Constants/AuthenticationConsts.cs
+++ b/src/Skoruba.IdentityServer4.Admin/Configuration/Constants/AuthenticationConsts.cs
@@ -4,13 +4,14 @@ namespace Skoruba.IdentityServer4.Admin.Configuration.Constants
 {
     public class AuthenticationConsts
     {
-        public const string IdentityAdminCookieName = "IdentityServerAdmin";        
+        public const string IdentityAdminCookieName = "IdentityServerAdmin";
         public const string UserNameClaimType = "name";
         public const string SignInScheme = "Cookies";
+        public const string OidcClientId = "skoruba_identity_admin";
         public const string OidcAuthenticationScheme = "oidc";
         public const string OidcResponseType = "id_token";
-        public static List<string> Scopes = new List<string> { "openid", "profile", "email", "roles" };
-        
+        public static List<string> Scopes = new List<string> { ScopeOpenId, ScopeProfile, ScopeEmail, ScopeRoles };
+
         public const string ScopeOpenId = "openid";
         public const string ScopeProfile = "profile";
         public const string ScopeEmail = "email";

--- a/src/Skoruba.IdentityServer4.Admin/Configuration/IdentityServer/Clients.cs
+++ b/src/Skoruba.IdentityServer4.Admin/Configuration/IdentityServer/Clients.cs
@@ -22,8 +22,8 @@ namespace Skoruba.IdentityServer4.Admin.Configuration.IdentityServer
 	            new Client
                 {
 
-                    ClientId = AuthenticationConsts.OidcClientId,
-                    ClientName = AuthenticationConsts.OidcClientId,
+                    ClientId =adminConfiguration.ClientId,
+                    ClientName =adminConfiguration.ClientId,
                     ClientUri = adminConfiguration.IdentityAdminBaseUrl,
 
                     AllowedGrantTypes = GrantTypes.Implicit,

--- a/src/Skoruba.IdentityServer4.Admin/Configuration/Interfaces/IAdminConfiguration.cs
+++ b/src/Skoruba.IdentityServer4.Admin/Configuration/Interfaces/IAdminConfiguration.cs
@@ -8,6 +8,8 @@
 
         string IdentityAdminBaseUrl { get; }
         string ClientId { get; }
+        string ClientSecret { get; }
+        string OidcResponseType { get; }
         string[] Scopes { get; }
     }
 }

--- a/src/Skoruba.IdentityServer4.Admin/Configuration/Interfaces/IAdminConfiguration.cs
+++ b/src/Skoruba.IdentityServer4.Admin/Configuration/Interfaces/IAdminConfiguration.cs
@@ -7,5 +7,6 @@
         string IdentityServerBaseUrl { get; }
 
         string IdentityAdminBaseUrl { get; }
+        string ClientId { get; }
     }
 }

--- a/src/Skoruba.IdentityServer4.Admin/Configuration/Interfaces/IAdminConfiguration.cs
+++ b/src/Skoruba.IdentityServer4.Admin/Configuration/Interfaces/IAdminConfiguration.cs
@@ -8,5 +8,6 @@
 
         string IdentityAdminBaseUrl { get; }
         string ClientId { get; }
+        string[] Scopes { get; }
     }
 }

--- a/src/Skoruba.IdentityServer4.Admin/Helpers/StartupHelpers.cs
+++ b/src/Skoruba.IdentityServer4.Admin/Helpers/StartupHelpers.cs
@@ -436,9 +436,9 @@ namespace Skoruba.IdentityServer4.Admin.Helpers
 #else
                         options.RequireHttpsMetadata = true;
 #endif
-                        options.ClientId = AuthenticationConsts.OidcClientId;
-                        options.ClientSecret = AuthenticationConsts.OidcClientSecret;
-                        options.ResponseType = AuthenticationConsts.OidcResponseType;
+                        options.ClientId = adminConfiguration.ClientId;
+                        options.ClientSecret = adminConfiguration.ClientSecret;
+                        options.ResponseType = adminConfiguration.OidcResponseType;
 
                         options.Scope.Clear();
                         foreach (var scope in adminConfiguration.Scopes)
@@ -451,7 +451,7 @@ namespace Skoruba.IdentityServer4.Admin.Helpers
                         options.SaveTokens = true;
 
                         options.GetClaimsFromUserInfoEndpoint = true;
-                        
+
                         options.TokenValidationParameters = new TokenValidationParameters
                         {
                             NameClaimType = JwtClaimTypes.Name,

--- a/src/Skoruba.IdentityServer4.Admin/Helpers/StartupHelpers.cs
+++ b/src/Skoruba.IdentityServer4.Admin/Helpers/StartupHelpers.cs
@@ -438,10 +438,10 @@ namespace Skoruba.IdentityServer4.Admin.Helpers
                         options.ClientId = adminConfiguration.ClientId;
 
                         options.Scope.Clear();
-                        options.Scope.Add(AuthenticationConsts.ScopeOpenId);
-                        options.Scope.Add(AuthenticationConsts.ScopeProfile);
-                        options.Scope.Add(AuthenticationConsts.ScopeEmail);
-                        options.Scope.Add(AuthenticationConsts.ScopeRoles);
+                        foreach (var scope in adminConfiguration.Scopes)
+                        {
+                            options.Scope.Add(scope);
+                        }
 
                         options.SaveTokens = true;
 

--- a/src/Skoruba.IdentityServer4.Admin/Helpers/StartupHelpers.cs
+++ b/src/Skoruba.IdentityServer4.Admin/Helpers/StartupHelpers.cs
@@ -435,7 +435,7 @@ namespace Skoruba.IdentityServer4.Admin.Helpers
 #else
                         options.RequireHttpsMetadata = true;
 #endif
-                        options.ClientId = AuthenticationConsts.OidcClientId;
+                        options.ClientId = adminConfiguration.ClientId;
 
                         options.Scope.Clear();
                         options.Scope.Add(AuthenticationConsts.ScopeOpenId);

--- a/src/Skoruba.IdentityServer4.Admin/appsettings.json
+++ b/src/Skoruba.IdentityServer4.Admin/appsettings.json
@@ -10,6 +10,8 @@
     "IdentityAdminRedirectUri": "http://localhost:9000/signin-oidc",
     "IdentityServerBaseUrl": "http://localhost:5000",
     "ClientId": "skoruba_identity_admin",
+    "ClientSecret": "skoruba_admin_client_secret",
+    "OidcResponseType": "code id_token",
     "Scopes": [
       "openid",
       "profile",

--- a/src/Skoruba.IdentityServer4.Admin/appsettings.json
+++ b/src/Skoruba.IdentityServer4.Admin/appsettings.json
@@ -9,7 +9,13 @@
     "IdentityAdminBaseUrl": "http://localhost:9000",
     "IdentityAdminRedirectUri": "http://localhost:9000/signin-oidc",
     "IdentityServerBaseUrl": "http://localhost:5000",
-    "ClientId": "skoruba_identity_admin"
+    "ClientId": "skoruba_identity_admin",
+    "Scopes": [
+      "openid",
+      "profile",
+      "email",
+      "roles"
+    ]
   },
   "Serilog": {
     "MinimumLevel": {

--- a/src/Skoruba.IdentityServer4.Admin/appsettings.json
+++ b/src/Skoruba.IdentityServer4.Admin/appsettings.json
@@ -5,11 +5,12 @@
         "IdentityDbConnection": "Server=(localdb)\\mssqllocaldb;Database=IdentityServer4Admin;Trusted_Connection=True;MultipleActiveResultSets=true",
         "AdminLogDbConnection": "Server=(localdb)\\mssqllocaldb;Database=IdentityServer4Admin;Trusted_Connection=True;MultipleActiveResultSets=true"
     },
-    "AdminConfiguration": {
-        "IdentityAdminBaseUrl": "http://localhost:9000",
-        "IdentityAdminRedirectUri": "http://localhost:9000/signin-oidc",
-        "IdentityServerBaseUrl": "http://localhost:5000"
-    },
+  "AdminConfiguration": {
+    "IdentityAdminBaseUrl": "http://localhost:9000",
+    "IdentityAdminRedirectUri": "http://localhost:9000/signin-oidc",
+    "IdentityServerBaseUrl": "http://localhost:5000",
+    "ClientId": "skoruba_identity_admin"
+  },
   "Serilog": {
     "MinimumLevel": {
       "Default": "Error",


### PR DESCRIPTION
As a developer, I would like to be able to change client id and scopes after deploy admin without re-build and re-deploy.