### PR TITLE
Append 'Async' to name of async methods

### DIFF
--- a/src/Skoruba.IdentityServer4.Admin.BusinessLogic.Identity/Repositories/Interfaces/IPersistedGrantAspNetIdentityRepository.cs
+++ b/src/Skoruba.IdentityServer4.Admin.BusinessLogic.Identity/Repositories/Interfaces/IPersistedGrantAspNetIdentityRepository.cs
@@ -9,8 +9,8 @@ namespace Skoruba.IdentityServer4.Admin.BusinessLogic.Identity.Repositories.Inte
 {
 	public interface IPersistedGrantAspNetIdentityRepository
     {
-		Task<PagedList<PersistedGrantDataView>> GetPersistedGrantsByUsers(string search, int page = 1, int pageSize = 10);
-		Task<PagedList<PersistedGrant>> GetPersistedGrantsByUser(string subjectId, int page = 1, int pageSize = 10);
+		Task<PagedList<PersistedGrantDataView>> GetPersistedGrantsByUsersAsync(string search, int page = 1, int pageSize = 10);
+		Task<PagedList<PersistedGrant>> GetPersistedGrantsByUserAsync(string subjectId, int page = 1, int pageSize = 10);
 	    Task<PersistedGrant> GetPersistedGrantAsync(string key);
 	    Task<int> DeletePersistedGrantAsync(string key);
 	    Task<int> DeletePersistedGrantsAsync(string userId);

--- a/src/Skoruba.IdentityServer4.Admin.BusinessLogic.Identity/Repositories/PersistedGrantAspNetIdentityRepository.cs
+++ b/src/Skoruba.IdentityServer4.Admin.BusinessLogic.Identity/Repositories/PersistedGrantAspNetIdentityRepository.cs
@@ -38,7 +38,7 @@ namespace Skoruba.IdentityServer4.Admin.BusinessLogic.Identity.Repositories
             PersistedGrantDbContext = persistedGrantDbContext;
         }
 
-        public virtual Task<PagedList<PersistedGrantDataView>> GetPersistedGrantsByUsers(string search, int page = 1, int pageSize = 10)
+        public virtual Task<PagedList<PersistedGrantDataView>> GetPersistedGrantsByUsersAsync(string search, int page = 1, int pageSize = 10)
         {
             return Task.Run(() =>
             {
@@ -74,7 +74,7 @@ namespace Skoruba.IdentityServer4.Admin.BusinessLogic.Identity.Repositories
             });
         }
 
-        public virtual async Task<PagedList<PersistedGrant>> GetPersistedGrantsByUser(string subjectId, int page = 1, int pageSize = 10)
+        public virtual async Task<PagedList<PersistedGrant>> GetPersistedGrantsByUserAsync(string subjectId, int page = 1, int pageSize = 10)
         {
             var pagedList = new PagedList<PersistedGrant>();
 

--- a/src/Skoruba.IdentityServer4.Admin.BusinessLogic.Identity/Services/Interfaces/IPersistedGrantAspNetIdentityService.cs
+++ b/src/Skoruba.IdentityServer4.Admin.BusinessLogic.Identity/Services/Interfaces/IPersistedGrantAspNetIdentityService.cs
@@ -5,8 +5,8 @@ namespace Skoruba.IdentityServer4.Admin.BusinessLogic.Identity.Services.Interfac
 {
     public interface IPersistedGrantAspNetIdentityService
     {
-        Task<PersistedGrantsDto> GetPersistedGrantsByUsers(string search, int page = 1, int pageSize = 10);
-        Task<PersistedGrantsDto> GetPersistedGrantsByUser(string subjectId, int page = 1, int pageSize = 10);
+        Task<PersistedGrantsDto> GetPersistedGrantsByUsersAsync(string search, int page = 1, int pageSize = 10);
+        Task<PersistedGrantsDto> GetPersistedGrantsByUserAsync(string subjectId, int page = 1, int pageSize = 10);
         Task<PersistedGrantDto> GetPersistedGrantAsync(string key);
         Task<int> DeletePersistedGrantAsync(string key);
         Task<int> DeletePersistedGrantsAsync(string userId);

--- a/src/Skoruba.IdentityServer4.Admin.BusinessLogic.Identity/Services/PersistedGrantAspNetIdentityService.cs
+++ b/src/Skoruba.IdentityServer4.Admin.BusinessLogic.Identity/Services/PersistedGrantAspNetIdentityService.cs
@@ -20,20 +20,20 @@ namespace Skoruba.IdentityServer4.Admin.BusinessLogic.Identity.Services
             PersistedGrantAspNetIdentityServiceResources = persistedGrantAspNetIdentityServiceResources;
         }
 
-        public virtual async Task<PersistedGrantsDto> GetPersistedGrantsByUsers(string search, int page = 1, int pageSize = 10)
+        public virtual async Task<PersistedGrantsDto> GetPersistedGrantsByUsersAsync(string search, int page = 1, int pageSize = 10)
         {
-            var pagedList = await PersistedGrantAspNetIdentityRepository.GetPersistedGrantsByUsers(search, page, pageSize);
+            var pagedList = await PersistedGrantAspNetIdentityRepository.GetPersistedGrantsByUsersAsync(search, page, pageSize);
             var persistedGrantsDto = pagedList.ToModel();
 
             return persistedGrantsDto;
         }
 
-        public virtual async Task<PersistedGrantsDto> GetPersistedGrantsByUser(string subjectId, int page = 1, int pageSize = 10)
+        public virtual async Task<PersistedGrantsDto> GetPersistedGrantsByUserAsync(string subjectId, int page = 1, int pageSize = 10)
         {
             var exists = await PersistedGrantAspNetIdentityRepository.ExistsPersistedGrantsAsync(subjectId);
             if (!exists) throw new UserFriendlyErrorPageException(string.Format(PersistedGrantAspNetIdentityServiceResources.PersistedGrantWithSubjectIdDoesNotExist().Description, subjectId), PersistedGrantAspNetIdentityServiceResources.PersistedGrantWithSubjectIdDoesNotExist().Description);
 
-            var pagedList = await PersistedGrantAspNetIdentityRepository.GetPersistedGrantsByUser(subjectId, page, pageSize);
+            var pagedList = await PersistedGrantAspNetIdentityRepository.GetPersistedGrantsByUserAsync(subjectId, page, pageSize);
             var persistedGrantsDto = pagedList.ToModel();
 
             return persistedGrantsDto;

--- a/src/Skoruba.IdentityServer4.Admin.BusinessLogic/Repositories/Interfaces/IPersistedGrantRepository.cs
+++ b/src/Skoruba.IdentityServer4.Admin.BusinessLogic/Repositories/Interfaces/IPersistedGrantRepository.cs
@@ -7,8 +7,8 @@ namespace Skoruba.IdentityServer4.Admin.BusinessLogic.Repositories.Interfaces
 {
 	public interface IPersistedGrantRepository
     {
-		Task<PagedList<PersistedGrantDataView>> GetPersistedGrantsByUsers(string search, int page = 1, int pageSize = 10);
-		Task<PagedList<PersistedGrant>> GetPersistedGrantsByUser(string subjectId, int page = 1, int pageSize = 10);
+		Task<PagedList<PersistedGrantDataView>> GetPersistedGrantsByUsersAsync(string search, int page = 1, int pageSize = 10);
+		Task<PagedList<PersistedGrant>> GetPersistedGrantsByUserAsync(string subjectId, int page = 1, int pageSize = 10);
 	    Task<PersistedGrant> GetPersistedGrantAsync(string key);
 	    Task<int> DeletePersistedGrantAsync(string key);
 	    Task<int> DeletePersistedGrantsAsync(string userId);

--- a/src/Skoruba.IdentityServer4.Admin.BusinessLogic/Repositories/PersistedGrantRepository.cs
+++ b/src/Skoruba.IdentityServer4.Admin.BusinessLogic/Repositories/PersistedGrantRepository.cs
@@ -26,7 +26,7 @@ namespace Skoruba.IdentityServer4.Admin.BusinessLogic.Repositories
             DbContext = dbContext;
         }
 
-        public virtual async Task<PagedList<PersistedGrantDataView>> GetPersistedGrantsByUsers(string search, int page = 1, int pageSize = 10)
+        public virtual async Task<PagedList<PersistedGrantDataView>> GetPersistedGrantsByUsersAsync(string search, int page = 1, int pageSize = 10)
         {
             var pagedList = new PagedList<PersistedGrantDataView>();
 
@@ -49,7 +49,7 @@ namespace Skoruba.IdentityServer4.Admin.BusinessLogic.Repositories
             return pagedList;
         }
 
-        public virtual async Task<PagedList<PersistedGrant>> GetPersistedGrantsByUser(string subjectId, int page = 1, int pageSize = 10)
+        public virtual async Task<PagedList<PersistedGrant>> GetPersistedGrantsByUserAsync(string subjectId, int page = 1, int pageSize = 10)
         {
             var pagedList = new PagedList<PersistedGrant>();
 

--- a/src/Skoruba.IdentityServer4.Admin.BusinessLogic/Services/Interfaces/IPersistedGrantService.cs
+++ b/src/Skoruba.IdentityServer4.Admin.BusinessLogic/Services/Interfaces/IPersistedGrantService.cs
@@ -5,8 +5,8 @@ namespace Skoruba.IdentityServer4.Admin.BusinessLogic.Services.Interfaces
 {
     public interface IPersistedGrantService
     {
-        Task<PersistedGrantsDto> GetPersistedGrantsByUsers(string search, int page = 1, int pageSize = 10);
-        Task<PersistedGrantsDto> GetPersistedGrantsByUser(string subjectId, int page = 1, int pageSize = 10);
+        Task<PersistedGrantsDto> GetPersistedGrantsByUsersAsync(string search, int page = 1, int pageSize = 10);
+        Task<PersistedGrantsDto> GetPersistedGrantsByUserAsync(string subjectId, int page = 1, int pageSize = 10);
         Task<PersistedGrantDto> GetPersistedGrantAsync(string key);
         Task<int> DeletePersistedGrantAsync(string key);
         Task<int> DeletePersistedGrantsAsync(string userId);

--- a/src/Skoruba.IdentityServer4.Admin.BusinessLogic/Services/PersistedGrantService.cs
+++ b/src/Skoruba.IdentityServer4.Admin.BusinessLogic/Services/PersistedGrantService.cs
@@ -20,20 +20,20 @@ namespace Skoruba.IdentityServer4.Admin.BusinessLogic.Services
             PersistedGrantServiceResources = persistedGrantServiceResources;
         }
 
-        public virtual async Task<PersistedGrantsDto> GetPersistedGrantsByUsers(string search, int page = 1, int pageSize = 10)
+        public virtual async Task<PersistedGrantsDto> GetPersistedGrantsByUsersAsync(string search, int page = 1, int pageSize = 10)
         {
-            var pagedList = await PersistedGrantRepository.GetPersistedGrantsByUsers(search, page, pageSize);
+            var pagedList = await PersistedGrantRepository.GetPersistedGrantsByUsersAsync(search, page, pageSize);
             var persistedGrantsDto = pagedList.ToModel();
 
             return persistedGrantsDto;
         }
 
-        public virtual async Task<PersistedGrantsDto> GetPersistedGrantsByUser(string subjectId, int page = 1, int pageSize = 10)
+        public virtual async Task<PersistedGrantsDto> GetPersistedGrantsByUserAsync(string subjectId, int page = 1, int pageSize = 10)
         {
             var exists = await PersistedGrantRepository.ExistsPersistedGrantsAsync(subjectId);
             if (!exists) throw new UserFriendlyErrorPageException(string.Format(PersistedGrantServiceResources.PersistedGrantWithSubjectIdDoesNotExist().Description, subjectId), PersistedGrantServiceResources.PersistedGrantWithSubjectIdDoesNotExist().Description);
 
-            var pagedList = await PersistedGrantRepository.GetPersistedGrantsByUser(subjectId, page, pageSize);
+            var pagedList = await PersistedGrantRepository.GetPersistedGrantsByUserAsync(subjectId, page, pageSize);
             var persistedGrantsDto = pagedList.ToModel();
 
             return persistedGrantsDto;

--- a/src/Skoruba.IdentityServer4.Admin/Controllers/GrantController.cs
+++ b/src/Skoruba.IdentityServer4.Admin/Controllers/GrantController.cs
@@ -30,7 +30,7 @@ namespace Skoruba.IdentityServer4.Admin.Controllers
         public async Task<IActionResult> PersistedGrants(int? page, string search)
         {
             ViewBag.Search = search;
-            var persistedGrants = await _persistedGrantService.GetPersistedGrantsByUsers(search, page ?? 1);
+            var persistedGrants = await _persistedGrantService.GetPersistedGrantsByUsersAsync(search, page ?? 1);
 
             return View(persistedGrants);
         }
@@ -73,7 +73,7 @@ namespace Skoruba.IdentityServer4.Admin.Controllers
         [HttpGet]
         public async Task<IActionResult> PersistedGrant(string id, int? page)
         {
-            var persistedGrants = await _persistedGrantService.GetPersistedGrantsByUser(id, page ?? 1);
+            var persistedGrants = await _persistedGrantService.GetPersistedGrantsByUserAsync(id, page ?? 1);
             persistedGrants.SubjectId = id;
 
             return View(persistedGrants);

--- a/tests/Skoruba.IdentityServer4.Admin.UnitTests/Repositories/PersistedGrantRepositoryTests.cs
+++ b/tests/Skoruba.IdentityServer4.Admin.UnitTests/Repositories/PersistedGrantRepositoryTests.cs
@@ -124,7 +124,7 @@ namespace Skoruba.IdentityServer4.Admin.UnitTests.Repositories
                     //Try delete persisted grant
                     await persistedGrantRepository.DeletePersistedGrantsAsync(subjectId.ToString());
 
-                    var grant = await persistedGrantRepository.GetPersistedGrantsByUser(subjectId.ToString());
+                    var grant = await persistedGrantRepository.GetPersistedGrantsByUserAsync(subjectId.ToString());
 
                     //Assert
                     grant.TotalCount.Should().Be(0);

--- a/tests/Skoruba.IdentityServer4.Admin.UnitTests/Services/PersistedGrantServiceTests.cs
+++ b/tests/Skoruba.IdentityServer4.Admin.UnitTests/Services/PersistedGrantServiceTests.cs
@@ -151,7 +151,7 @@ namespace Skoruba.IdentityServer4.Admin.UnitTests.Services
                     //Try delete persisted grant
                     await persistedGrantService.DeletePersistedGrantsAsync(subjectId.ToString());
 
-                    var grant = await persistedGrantRepository.GetPersistedGrantsByUser(subjectId.ToString());
+                    var grant = await persistedGrantRepository.GetPersistedGrantsByUserAsync(subjectId.ToString());
 
                     //Assert
                     grant.TotalCount.Should().Be(0);


### PR DESCRIPTION
Some methods that return a Task<T> were missing the 'Async' part in their name (e.g. GetPersistedGrantByUser). 

They have been renamed to GetPersistedGrantByUser**Async** and the like.