### PR TITLE
Simplified applying configuration in options

### DIFF
--- a/src/Skoruba.IdentityServer4.Admin/Configuration/DependencyInjection/IdentityServerAdminOptions.cs
+++ b/src/Skoruba.IdentityServer4.Admin/Configuration/DependencyInjection/IdentityServerAdminOptions.cs
@@ -56,9 +56,9 @@ namespace Microsoft.Extensions.DependencyInjection
 			this.RootConfiguration = new RootConfiguration();
 		}
 
-		public void ApplyConfiguration(IConfigurationRoot configurationRoot)
+		public void ApplyConfiguration(IConfiguration configuration)
 		{
-			configurationRoot.Bind(RootConfiguration);
+			configuration.Bind(RootConfiguration);
 		}
 
 		public void ApplyHostingEnvironment(IHostingEnvironment env)


### PR DESCRIPTION
Refactored options ApplyConfiguration method to take IConfiguration instead of IConfigurationRoot in order to be easier to use with DI in Startup (IConfiguration can be DI'd, not IConfigurationRoot).