### PR TITLE
Converted Admin project to Razor Class Library

### DIFF
--- a/Skoruba.IdentityServer4.Admin.sln
+++ b/Skoruba.IdentityServer4.Admin.sln
@@ -29,8 +29,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Skoruba.IdentityServer4.Adm
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Skoruba.IdentityServer4.Admin.EntityFramework.DbContexts", "src\Skoruba.IdentityServer4.Admin.EntityFramework.DbContexts\Skoruba.IdentityServer4.Admin.EntityFramework.DbContexts.csproj", "{81019B1A-C554-44BA-A9EF-6BE6A223AD20}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Skoruba.IdentityServer4.Admin", "src\Skoruba.IdentityServer4.Admin\Skoruba.IdentityServer4.Admin.csproj", "{9814D0C2-0902-4685-8071-48FEE2DA8543}"
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Skoruba.IdentityServer4.STS.Identity.IntegrationTests", "tests\Skoruba.IdentityServer4.STS.Identity.IntegrationTests\Skoruba.IdentityServer4.STS.Identity.IntegrationTests.csproj", "{83319150-92D2-408C-A944-52DBE6AB8B37}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Skoruba.IdentityServer4.STS.Identity.IntegrationTests", "tests\Skoruba.IdentityServer4.STS.Identity.IntegrationTests\Skoruba.IdentityServer4.STS.Identity.IntegrationTests.csproj", "{83319150-92D2-408C-A944-52DBE6AB8B37}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Skoruba.IdentityServer4.Admin", "src\Skoruba.IdentityServer4.Admin\Skoruba.IdentityServer4.Admin.csproj", "{81E1CE83-58D2-45CF-86D3-91EF1341DFF9}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -78,14 +79,14 @@ Global
 		{81019B1A-C554-44BA-A9EF-6BE6A223AD20}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{81019B1A-C554-44BA-A9EF-6BE6A223AD20}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{81019B1A-C554-44BA-A9EF-6BE6A223AD20}.Release|Any CPU.Build.0 = Release|Any CPU
-		{9814D0C2-0902-4685-8071-48FEE2DA8543}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{9814D0C2-0902-4685-8071-48FEE2DA8543}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{9814D0C2-0902-4685-8071-48FEE2DA8543}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{9814D0C2-0902-4685-8071-48FEE2DA8543}.Release|Any CPU.Build.0 = Release|Any CPU
 		{83319150-92D2-408C-A944-52DBE6AB8B37}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{83319150-92D2-408C-A944-52DBE6AB8B37}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{83319150-92D2-408C-A944-52DBE6AB8B37}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{83319150-92D2-408C-A944-52DBE6AB8B37}.Release|Any CPU.Build.0 = Release|Any CPU
+		{81E1CE83-58D2-45CF-86D3-91EF1341DFF9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{81E1CE83-58D2-45CF-86D3-91EF1341DFF9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{81E1CE83-58D2-45CF-86D3-91EF1341DFF9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{81E1CE83-58D2-45CF-86D3-91EF1341DFF9}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -101,8 +102,8 @@ Global
 		{C360A0D5-1671-4738-BC5D-BED0E8A24D66} = {588205D4-3A30-4DA4-849D-C7422C396DAA}
 		{CA63CC7B-BE27-4737-AE91-42E43F729A1E} = {588205D4-3A30-4DA4-849D-C7422C396DAA}
 		{81019B1A-C554-44BA-A9EF-6BE6A223AD20} = {588205D4-3A30-4DA4-849D-C7422C396DAA}
-		{9814D0C2-0902-4685-8071-48FEE2DA8543} = {588205D4-3A30-4DA4-849D-C7422C396DAA}
 		{83319150-92D2-408C-A944-52DBE6AB8B37} = {0BC0CC4E-A0F1-45E8-B41A-AE0FA76BF3E5}
+		{81E1CE83-58D2-45CF-86D3-91EF1341DFF9} = {588205D4-3A30-4DA4-849D-C7422C396DAA}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {B3166EDE-037B-4C68-BEBA-5DE9C5E3DB82}

--- a/src/Skoruba.IdentityServer4.Admin/Helpers/Razor/StaticFileProvidersConfigureOptions.cs
+++ b/src/Skoruba.IdentityServer4.Admin/Helpers/Razor/StaticFileProvidersConfigureOptions.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.StaticFiles;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Options;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Skoruba.IdentityServer4.Admin.Helpers.Razor
+{
+	public class StaticFileProvidersConfigureOptions : IPostConfigureOptions<StaticFileOptions>
+	{
+		public StaticFileProvidersConfigureOptions(IHostingEnvironment environment)
+		{
+			Environment = environment;
+		}
+		public IHostingEnvironment Environment { get; }
+
+		public void PostConfigure(string name, StaticFileOptions options)
+		{
+			name = name ?? throw new ArgumentNullException(nameof(name));
+			options = options ?? throw new ArgumentNullException(nameof(options));
+
+			// Basic initialization in case the options weren't initialized by any other component
+			options.ContentTypeProvider = options.ContentTypeProvider ?? new FileExtensionContentTypeProvider();
+			if (options.FileProvider == null && Environment.WebRootFileProvider == null)
+			{
+				throw new InvalidOperationException("Missing FileProvider.");
+			}
+
+			options.FileProvider = options.FileProvider ?? Environment.WebRootFileProvider;
+
+			string basePath = "wwwroot";
+
+			IFileProvider filesProvider = new EmbeddedFileProvider(GetType().Assembly, basePath);
+			options.FileProvider = new CompositeFileProvider(options.FileProvider, filesProvider);
+		}
+	}
+}

--- a/src/Skoruba.IdentityServer4.Admin/Helpers/StartupHelpers.cs
+++ b/src/Skoruba.IdentityServer4.Admin/Helpers/StartupHelpers.cs
@@ -312,7 +312,7 @@ namespace Skoruba.IdentityServer4.Admin.Helpers
                 {
                     o.Conventions.Add(new GenericControllerRouteConvention());
                 })
-				.WithRazorPagesRoot("/Views")
+                .WithRazorPagesRoot("/Views")
                 .SetCompatibilityVersion(CompatibilityVersion.Version_2_1)
                 .AddViewLocalization(
                     LanguageViewLocationExpanderFormat.Suffix,

--- a/src/Skoruba.IdentityServer4.Admin/Helpers/StartupHelpers.cs
+++ b/src/Skoruba.IdentityServer4.Admin/Helpers/StartupHelpers.cs
@@ -34,6 +34,7 @@ using Skoruba.IdentityServer4.Admin.EntityFramework.Interfaces;
 using Skoruba.IdentityServer4.Admin.Helpers.Localization;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.AspNetCore.Mvc.Localization;
+using Skoruba.IdentityServer4.Admin.Helpers.Razor;
 
 namespace Skoruba.IdentityServer4.Admin.Helpers
 {
@@ -305,12 +306,13 @@ namespace Skoruba.IdentityServer4.Admin.Helpers
 
 			services.AddTransient<IViewLocalizer, ResourceViewLocalizer>();
 
-			services.Configure<RazorViewEngineOptions>(options => options.FileProviders.Add(new EmbeddedFileProvider(Assembly.GetExecutingAssembly())));
+			services.ConfigureOptions(typeof(StaticFileProvidersConfigureOptions));
 
             services.AddMvc(o =>
                 {
                     o.Conventions.Add(new GenericControllerRouteConvention());
                 })
+				.WithRazorPagesRoot("/Views")
                 .SetCompatibilityVersion(CompatibilityVersion.Version_2_1)
                 .AddViewLocalization(
                     LanguageViewLocationExpanderFormat.Suffix,

--- a/src/Skoruba.IdentityServer4.Admin/Skoruba.IdentityServer4.Admin.csproj
+++ b/src/Skoruba.IdentityServer4.Admin/Skoruba.IdentityServer4.Admin.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <EmbeddedResource Include="Views\**\*.cshtml" />
+    <Content Update="**\*.cshtml" Pack="false" />
     <EmbeddedResource Include="wwwroot\**\*" />
   </ItemGroup>
 


### PR DESCRIPTION
This PR converts the project type of Skoruba.IdentityServer4.Admin from netstandard 2 library to Razor Class Library, enabling in theory to override views in consuming applications and to overall facilitate deployment. 

Views have not been ported to Areas, so ```.WithRazorPagesRoot("/Views")``` is used to break away from the Razor default name "Pages".