### PR TITLE
Docker withouth /etc/hosts modification

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,59 @@
+version: '3'
+
+services:
+  admin:
+    build:
+      context: .
+      dockerfile: src/Skoruba.IdentityServer4.Admin/Dockerfile
+    ports:
+      - "5001:5001"
+    networks:
+      - host
+    environment:
+      - ASPNETCORE_ENVIRONMENT=Development
+      - ASPNETCORE_URLS=http://+:5001
+      - "ConnectionStrings:ConfigurationDbConnection=Server=db;Database=IdentityServer4Admin;User Id=sa;Password=Password_123;MultipleActiveResultSets=true"
+      - "ConnectionStrings:PersistedGrantDbConnection=Server=db;Database=IdentityServer4Admin;User Id=sa;Password=Password_123;MultipleActiveResultSets=true"
+      - "ConnectionStrings:IdentityDbConnection=Server=db;Database=IdentityServer4Admin;User Id=sa;Password=Password_123;MultipleActiveResultSets=true"
+      - "ConnectionStrings:AdminLogDbConnection=Server=db;Database=IdentityServer4Admin;User Id=sa;Password=Password_123;MultipleActiveResultSets=true"
+      - "AdminConfiguration:IdentityAdminBaseUrl=http://localhost:5001"
+      - "AdminConfiguration:IdentityAdminRedirectUri=http://localhost:5001/signin-oidc"
+      - "AdminConfiguration:IdentityServerBaseUrl=http://sts:5000"
+    command: dotnet Skoruba.IdentityServer4.Admin.dll 
+    depends_on:
+      - db
+      - sts
+
+  sts:
+    build:
+      context: .
+      dockerfile: src/Skoruba.IdentityServer4.STS.Identity/Dockerfile
+    ports:
+      - "5000:5000"
+    networks:
+      - host
+    depends_on:
+      - db
+    environment:
+      - ASPNETCORE_ENVIRONMENT=Development
+      - ASPNETCORE_URLS=http://+:5000
+      - IssuerUri=http://localhost:5000
+      - "ConnectionStrings:ConfigurationDbConnection=Server=db;Database=IdentityServer4Admin;User Id=sa;Password=Password_123;MultipleActiveResultSets=true"
+      - "ConnectionStrings:PersistedGrantDbConnection=Server=db;Database=IdentityServer4Admin;User Id=sa;Password=Password_123;MultipleActiveResultSets=true"
+      - "ConnectionStrings:IdentityDbConnection=Server=db;Database=IdentityServer4Admin;User Id=sa;Password=Password_123;MultipleActiveResultSets=true"
+
+  db:
+    image: "mcr.microsoft.com/mssql/server"
+    ports:
+      - 1433
+    networks:
+      - host
+    environment:
+      SA_PASSWORD: "Password_123"
+      ACCEPT_EULA: "Y"
+    volumes:
+      - /home/xmichaelx/mssql:/var/opt/mssql
+
+networks:
+  host:
+    driver: bridge

--- a/src/Skoruba.IdentityServer4.Admin/Dockerfile
+++ b/src/Skoruba.IdentityServer4.Admin/Dockerfile
@@ -1,0 +1,22 @@
+﻿FROM microsoft/dotnet:2.2-aspnetcore-runtime AS base
+WORKDIR /app
+
+FROM microsoft/dotnet:2.2-sdk AS build
+WORKDIR /src
+COPY src/Skoruba.IdentityServer4.Admin/Skoruba.IdentityServer4.Admin.csproj src/Skoruba.IdentityServer4.Admin/
+RUN dotnet restore src/Skoruba.IdentityServer4.Admin/Skoruba.IdentityServer4.Admin.csproj
+COPY . .
+WORKDIR /src/src/Skoruba.IdentityServer4.Admin
+RUN dotnet ef migrations add AspNetIdentityDbInit -c AdminIdentityDbContext -o Data/Migrations/Identity
+RUN dotnet ef migrations add LoggingDbInit  -c AdminLogDbContext  -o Data/Migrations/Logging
+RUN dotnet ef migrations add IdentityServerConfigurationDbInit  -c IdentityServerConfigurationDbContext -o Data/Migrations/IdentityServerConfiguration
+RUN dotnet ef migrations add IdentityServerPersistedGrantsDbInit  -c IdentityServerPersistedGrantDbContext -o Data/Migrations/IdentityServerGrants
+RUN dotnet build Skoruba.IdentityServer4.Admin.csproj -c Debug -o /app
+
+FROM build AS publish
+RUN dotnet publish Skoruba.IdentityServer4.Admin.csproj -c Debug -o /app
+
+FROM base AS final
+WORKDIR /app
+COPY --from=publish /app .
+ENTRYPOINT ["dotnet", "Skoruba.IdentityServer4.Admin.dll"]

--- a/src/Skoruba.IdentityServer4.STS.Identity/Dockerfile
+++ b/src/Skoruba.IdentityServer4.STS.Identity/Dockerfile
@@ -1,0 +1,18 @@
+﻿FROM microsoft/dotnet:2.2-aspnetcore-runtime AS base
+WORKDIR /app
+
+FROM microsoft/dotnet:2.2-sdk AS build
+WORKDIR /src
+COPY src/Skoruba.IdentityServer4.STS.Identity/Skoruba.IdentityServer4.STS.Identity.csproj src/Skoruba.IdentityServer4.STS.Identity/
+RUN dotnet restore src/Skoruba.IdentityServer4.STS.Identity/Skoruba.IdentityServer4.STS.Identity.csproj
+COPY . .
+WORKDIR /src/src/Skoruba.IdentityServer4.STS.Identity
+RUN dotnet build Skoruba.IdentityServer4.STS.Identity.csproj -c Debug -o /app
+
+FROM build AS publish
+RUN dotnet publish Skoruba.IdentityServer4.STS.Identity.csproj -c Debug -o /app
+
+FROM base AS final
+WORKDIR /app
+COPY --from=publish /app .
+ENTRYPOINT ["dotnet", "Skoruba.IdentityServer4.STS.Identity.dll"]

--- a/src/Skoruba.IdentityServer4.STS.Identity/Helpers/SkorubaDiscoveryResponseGenerator.cs
+++ b/src/Skoruba.IdentityServer4.STS.Identity/Helpers/SkorubaDiscoveryResponseGenerator.cs
@@ -1,0 +1,27 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using IdentityModel;
+using IdentityServer4.Configuration;
+using IdentityServer4.ResponseHandling;
+using IdentityServer4.Services;
+using IdentityServer4.Stores;
+using IdentityServer4.Validation;
+using Microsoft.Extensions.Logging;
+
+namespace Skoruba.IdentityServer4.STS.Identity.Helpers
+{
+    class SkorubaDiscoveryResponseGenerator : DiscoveryResponseGenerator
+    {
+        public SkorubaDiscoveryResponseGenerator(IdentityServerOptions options, IResourceStore resourceStore, IKeyMaterialService keys, ExtensionGrantValidator extensionGrants, SecretParser secretParsers, IResourceOwnerPasswordValidator resourceOwnerValidator, ILogger<DiscoveryResponseGenerator> logger) : base(options, resourceStore, keys, extensionGrants, secretParsers, resourceOwnerValidator, logger)
+        {
+        }
+
+        public override async Task<Dictionary<string, object>> CreateDiscoveryDocumentAsync(string baseUrl, string issuerUri) {
+            var result = await base.CreateDiscoveryDocumentAsync(baseUrl, issuerUri);
+
+            result[OidcConstants.Discovery.AuthorizationEndpoint] = issuerUri + "/connect/authorize";
+
+            return result;
+        }
+    }
+}

--- a/src/Skoruba.IdentityServer4.STS.Identity/Helpers/SkorubaDiscoveryResponseGenerator.cs
+++ b/src/Skoruba.IdentityServer4.STS.Identity/Helpers/SkorubaDiscoveryResponseGenerator.cs
@@ -20,7 +20,8 @@ namespace Skoruba.IdentityServer4.STS.Identity.Helpers
             var result = await base.CreateDiscoveryDocumentAsync(baseUrl, issuerUri);
 
             result[OidcConstants.Discovery.AuthorizationEndpoint] = issuerUri + "/connect/authorize";
-
+            result[OidcConstants.Discovery.EndSessionEndpoint] = issuerUri + "/connect/endsession";
+                            
             return result;
         }
     }

--- a/src/Skoruba.IdentityServer4.STS.Identity/Helpers/StartupHelpers.cs
+++ b/src/Skoruba.IdentityServer4.STS.Identity/Helpers/StartupHelpers.cs
@@ -2,6 +2,7 @@
 using System.Globalization;
 using System.Reflection;
 using IdentityServer4.EntityFramework.Interfaces;
+using IdentityServer4.ResponseHandling;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
@@ -237,6 +238,7 @@ namespace Skoruba.IdentityServer4.STS.Identity.Helpers
         {
             var builder = services.AddIdentityServer(options =>
                 {
+                    options.IssuerUri = configuration["IssuerUri"];
                     options.Events.RaiseErrorEvents = true;
                     options.Events.RaiseInformationEvents = true;
                     options.Events.RaiseFailureEvents = true;
@@ -244,6 +246,12 @@ namespace Skoruba.IdentityServer4.STS.Identity.Helpers
                 })
                 .AddAspNetIdentity<TUserIdentity>()
                 .AddIdentityServerStoresWithDbContexts<TConfigurationDbContext, TPersistedGrantDbContext>(configuration, hostingEnvironment);
+
+            builder.Services.Remove(new ServiceDescriptor(
+                typeof(IDiscoveryResponseGenerator), typeof(DiscoveryResponseGenerator),ServiceLifetime.Transient
+            ));
+
+            builder.Services.AddTransient<IDiscoveryResponseGenerator, SkorubaDiscoveryResponseGenerator>();
 
             builder.AddCustomSigningCredential(configuration, logger);
             builder.AddCustomValidationKey(configuration, logger);


### PR DESCRIPTION
I'm  tagging @Seaear because I've largely based this on his work. @Seaear if you want I can create a PR to your repo and then we can pull your older PR in.

We have two services:

- Skoruba.IdentityServer4.STS.Identity with `sts` hostname assigned inside default bridge network controller mapped to `localhost:5000`

- Skoruba.IdentityServer4.Admin with `admin` hostname ssigned inside default bridge network controller mapped to `localhost:5001`

But unfortunately Admin cannot perform requests to `localhost:5000` only to `sts:5000` so fine, let's put that in Admin configuration, but then what? 

Discovery endpoint generates everything prepended with `sts:5000` instead of `localhost:5000` including authorize endpoint to which we're redirected to type in our credentials and since we're not inside the internal network between the host we get nothing.

What was the solution? To use option added to IdentityServer to change the IssuerUri and use that changed IssuerUri to manually set the the base url for `authorize_endpoint` and `issuer` so it doesn't depend on who is asking. And this solved it. Everything works without any modifications to your /etc/hosts.

tl;dr modifying discovery document so this is what admin services sees within the docker network solved the issue:

```
{
  "issuer": "http://localhost:5000",
  "jwks_uri": "http://sts:5000/.well-known/openid-configuration/jwks",
  "authorization_endpoint": "http://localhost:5000/connect/authorize",
  "token_endpoint": "http://sts:5000/connect/token",
  "userinfo_endpoint": "http://sts:5000/connect/userinfo",
  "end_session_endpoint": "http://sts:5000/connect/endsession",
  "check_session_iframe": "http://sts:5000/connect/checksession",
  "revocation_endpoint": "http://sts:5000/connect/revocation",
  "introspection_endpoint": "http://sts:5000/connect/introspect",
  // ... the rest
}
```

