### PR TITLE
Fixed writing accesses that bypass manager classes

### DIFF
--- a/src/Skoruba.IdentityServer4.Admin.EntityFramework.Identity/Repositories/IdentityRepository.cs
+++ b/src/Skoruba.IdentityServer4.Admin.EntityFramework.Identity/Repositories/IdentityRepository.cs
@@ -284,18 +284,20 @@ namespace Skoruba.IdentityServer4.Admin.EntityFramework.Identity.Repositories
 
         public virtual async Task<int> DeleteUserClaimsAsync(string userId, int claimId)
         {
+            var user = await UserManager.FindByIdAsync(userId).ConfigureAwait(false);;
             var userClaim = await DbContext.Set<TUserClaim>().Where(x => x.Id == claimId).SingleOrDefaultAsync();
 
-            DbContext.UserClaims.Remove(userClaim);
+            await UserManager.RemoveClaimAsync(user, new Claim(userClaim.ClaimType, userClaim.ClaimValue)).ConfigureAwait(false);
 
             return await AutoSaveChangesAsync();
         }
 
         public virtual async Task<int> DeleteRoleClaimsAsync(string roleId, int claimId)
         {
+            var role = await RoleManager.FindByIdAsync(roleId).ConfigureAwait(false);
             var roleClaim = await DbContext.Set<TRoleClaim>().Where(x => x.Id == claimId).SingleOrDefaultAsync();
 
-            DbContext.Set<TRoleClaim>().Remove(roleClaim);
+            await RoleManager.RemoveClaimAsync(role, new Claim(roleClaim.ClaimType, roleClaim.ClaimValue)).ConfigureAwait(false);
 
             return await AutoSaveChangesAsync();
         }


### PR DESCRIPTION
In our custom IdentityServer implementation, we need to create events for every change on the users and roles.

For that, we decorated the `UserStore<TUser>` of the AspNetCore Identity model and create our events on every write access. The AspNetCore.Identities `UserManager` and `RoleManager` both use the `IUserStore` and `IRoleStore` for write access exclusively, so that is the only good place to intercept changes to the users and roles.

In your `IIdentityRepository` you use the manager classes to _create_ user claims and role claims, but for deleting these you bypass the `UserManager` / `RoleManager` classes and use the `IdentityDbContext` directly to delete `UserClaims` and `RoleClaims`.

This pull request changes this to also use the manager classes (and thus internally the Store) to write these changes to the database, so that we are capable of intercepting them and creating the required events when a user or a role changes.