### PR TITLE
Update identityserver4 and automapper versions

### DIFF
--- a/src/Skoruba.IdentityServer4.Admin.Api/Skoruba.IdentityServer4.Admin.Api.csproj
+++ b/src/Skoruba.IdentityServer4.Admin.Api/Skoruba.IdentityServer4.Admin.Api.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoMapper" Version="8.0.0" />
+    <PackageReference Include="AutoMapper" Version="8.1.1" />
     <PackageReference Include="IdentityServer4.AccessTokenValidation" Version="2.7.0" />
     <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.2.0" PrivateAssets="All" />

--- a/src/Skoruba.IdentityServer4.Admin.BusinessLogic.Identity/Skoruba.IdentityServer4.Admin.BusinessLogic.Identity.csproj
+++ b/src/Skoruba.IdentityServer4.Admin.BusinessLogic.Identity/Skoruba.IdentityServer4.Admin.BusinessLogic.Identity.csproj
@@ -12,7 +12,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="IdentityServer4.EntityFramework" Version="2.4.0" />
+		<PackageReference Include="IdentityServer4.EntityFramework" Version="2.5.0" />
 		<PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="2.2.0" />
 	</ItemGroup>
 

--- a/src/Skoruba.IdentityServer4.Admin.BusinessLogic/Skoruba.IdentityServer4.Admin.BusinessLogic.csproj
+++ b/src/Skoruba.IdentityServer4.Admin.BusinessLogic/Skoruba.IdentityServer4.Admin.BusinessLogic.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="IdentityServer4.EntityFramework" Version="2.4.0" />
+    <PackageReference Include="IdentityServer4.EntityFramework" Version="2.5.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Skoruba.IdentityServer4.Admin.EntityFramework.Identity/Skoruba.IdentityServer4.Admin.EntityFramework.Identity.csproj
+++ b/src/Skoruba.IdentityServer4.Admin.EntityFramework.Identity/Skoruba.IdentityServer4.Admin.EntityFramework.Identity.csproj
@@ -12,7 +12,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="IdentityServer4.EntityFramework" Version="2.4.0" />
+		<PackageReference Include="IdentityServer4.EntityFramework" Version="2.5.0" />
 		<PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="2.2.0" />
 	</ItemGroup>
 

--- a/src/Skoruba.IdentityServer4.Admin.EntityFramework/Skoruba.IdentityServer4.Admin.EntityFramework.csproj
+++ b/src/Skoruba.IdentityServer4.Admin.EntityFramework/Skoruba.IdentityServer4.Admin.EntityFramework.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="IdentityServer4.EntityFramework" Version="2.4.0" />
+    <PackageReference Include="IdentityServer4.EntityFramework" Version="2.5.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Skoruba.IdentityServer4.Admin/Skoruba.IdentityServer4.Admin.csproj
+++ b/src/Skoruba.IdentityServer4.Admin/Skoruba.IdentityServer4.Admin.csproj
@@ -9,8 +9,8 @@
 	<ItemGroup>
 		<PackageReference Include="Microsoft.AspNetCore.App" />
 		<PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.2.0" PrivateAssets="All" />
-		<PackageReference Include="AutoMapper" Version="8.0.0" />
-		<PackageReference Include="IdentityServer4.EntityFramework" Version="2.4.0" />
+		<PackageReference Include="AutoMapper" Version="8.1.1" />
+		<PackageReference Include="IdentityServer4.EntityFramework" Version="2.5.0" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools.DotNet" Version="2.0.3" />
 		<PackageReference Include="Microsoft.Extensions.Options" Version="2.2.0" />
 		<PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.2.0" />

--- a/src/Skoruba.IdentityServer4.STS.Identity/Skoruba.IdentityServer4.STS.Identity.csproj
+++ b/src/Skoruba.IdentityServer4.STS.Identity/Skoruba.IdentityServer4.STS.Identity.csproj
@@ -9,8 +9,8 @@
 		<PackageReference Include="AspNet.Security.OAuth.GitHub" Version="2.0.1" />
 		<PackageReference Include="Microsoft.AspNetCore.App" />
 		<PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.2.0" PrivateAssets="All" />
-		<PackageReference Include="IdentityServer4.AspNetIdentity" Version="2.4.0" />
-		<PackageReference Include="IdentityServer4.EntityFramework" Version="2.4.0" />
+		<PackageReference Include="IdentityServer4.AspNetIdentity" Version="2.5.0" />
+		<PackageReference Include="IdentityServer4.EntityFramework" Version="2.5.0" />
 		<PackageReference Include="NWebsec.AspNetCore.Middleware" Version="2.0.0" />
 		<PackageReference Include="Sendgrid" Version="9.10.0" />
 		<PackageReference Include="Serilog.AspNetCore" Version="2.1.1" />

--- a/tests/Skoruba.IdentityServer4.STS.Identity.IntegrationTests/Skoruba.IdentityServer4.STS.Identity.IntegrationTests.csproj
+++ b/tests/Skoruba.IdentityServer4.STS.Identity.IntegrationTests/Skoruba.IdentityServer4.STS.Identity.IntegrationTests.csproj
@@ -10,7 +10,7 @@
     <ItemGroup>
         <PackageReference Include="FluentAssertions" Version="5.5.3" />
         <PackageReference Include="HtmlAgilityPack" Version="1.9.0" />
-        <PackageReference Include="IdentityModel" Version="3.10.6" />
+        <PackageReference Include="IdentityModel" Version="3.10.10" />
         <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.2.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
         <PackageReference Include="xunit" Version="2.4.1" />


### PR DESCRIPTION
Upgrades IdentityServer4 from 2.4.0 -> 2.5.0 and AutoMapper from 8.0.0 -> 8.1.1 to satisfy dependency of https://www.nuget.org/packages/IdentityServer4.EntityFramework.Storage/.

Resolves breaking change introduced by AutoMapper between 8.0 and 8.1
https://github.com/AutoMapper/AutoMapper/issues/3117

Fixes issues https://github.com/skoruba/IdentityServer4.Admin/issues/283, https://github.com/skoruba/IdentityServer4.Admin/issues/314

All tests pass and I manually verified that the `/Configuration/Clients` endpoint functions once again.