### PR TITLE
SmtpEmailSender default credentials

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -278,3 +278,5 @@ __pycache__/
 !/src/Skoruba.IdentityServer4.Admin/Resources/Views/Log/
 !/src/Skoruba.IdentityServer4.Admin.BusinessLogic/Dtos/Log/
 !/src/Skoruba.IdentityServer4.Admin/Views/Log/
+/src/Skoruba.IdentityServer4.STS.Identity/compilerconfig.json.defaults
+/src/Skoruba.IdentityServer4.STS.Identity/compilerconfig.json

--- a/src/Skoruba.IdentityServer4.Admin.BusinessLogic.Identity/Dtos/Identity/Interfaces/IUserDto.cs
+++ b/src/Skoruba.IdentityServer4.Admin.BusinessLogic.Identity/Dtos/Identity/Interfaces/IUserDto.cs
@@ -13,5 +13,6 @@ namespace Skoruba.IdentityServer4.Admin.BusinessLogic.Identity.Dtos.Identity.Int
         bool TwoFactorEnabled { get; set; }
         int AccessFailedCount { get; set; }
         DateTimeOffset? LockoutEnd { get; set; }
+        string PhotoUrl { get; set; }
     }
 }

--- a/src/Skoruba.IdentityServer4.Admin.BusinessLogic.Identity/Dtos/Identity/UserDto.cs
+++ b/src/Skoruba.IdentityServer4.Admin.BusinessLogic.Identity/Dtos/Identity/UserDto.cs
@@ -28,5 +28,7 @@ namespace Skoruba.IdentityServer4.Admin.BusinessLogic.Identity.Dtos.Identity
         public int AccessFailedCount { get; set; }
 
         public DateTimeOffset? LockoutEnd { get; set; }
+
+        public string PhotoUrl { get; set; }
     }
 }

--- a/src/Skoruba.IdentityServer4.Admin.BusinessLogic.Identity/Services/IdentityService.cs
+++ b/src/Skoruba.IdentityServer4.Admin.BusinessLogic.Identity/Services/IdentityService.cs
@@ -74,7 +74,11 @@ namespace Skoruba.IdentityServer4.Admin.BusinessLogic.Identity.Services
         {
             var pagedList = await IdentityRepository.GetUsersAsync(search, page, pageSize);
             var usersDto = Mapper.Map<TUsersDto>(pagedList);
-
+            foreach (var userDto in usersDto.Users)
+            {
+                userDto.PhotoUrl = (await IdentityRepository.GetUserClaimByType(userDto.Id.ToString(), IdentityModel.JwtClaimTypes.Picture))
+                    .FirstOrDefault()?.ClaimValue;
+            }
             return usersDto;
         }
 
@@ -152,7 +156,7 @@ namespace Skoruba.IdentityServer4.Admin.BusinessLogic.Identity.Services
             if (identity == null) throw new UserFriendlyErrorPageException(string.Format(IdentityServiceResources.UserDoesNotExist().Description, userId), IdentityServiceResources.UserDoesNotExist().Description);
 
             var userDto = Mapper.Map<TUserDto>(identity);
-
+            userDto.PhotoUrl = (await IdentityRepository.GetUserClaimByType(userId, IdentityModel.JwtClaimTypes.Picture)).FirstOrDefault()?.ClaimValue;
             return userDto;
         }
 

--- a/src/Skoruba.IdentityServer4.Admin.EntityFramework.Identity/Repositories/IdentityRepository.cs
+++ b/src/Skoruba.IdentityServer4.Admin.EntityFramework.Identity/Repositories/IdentityRepository.cs
@@ -254,6 +254,14 @@ namespace Skoruba.IdentityServer4.Admin.EntityFramework.Identity.Repositories
             return pagedList;
         }
 
+        public virtual Task<List<TUserClaim>> GetUserClaimByType(string userId, string claimType)
+        {
+            var userIdConverted = ConvertUserKeyFromString(userId);
+
+            return DbContext.Set<TUserClaim>().Where(x => x.UserId.Equals(userIdConverted) && x.ClaimType == claimType)
+                .ToListAsync();
+        }
+
         public virtual Task<TUserClaim> GetUserClaimAsync(string userId, int claimId)
         {
             var userIdConverted = ConvertUserKeyFromString(userId);

--- a/src/Skoruba.IdentityServer4.Admin.EntityFramework.Identity/Repositories/Interfaces/IIdentityRepository.cs
+++ b/src/Skoruba.IdentityServer4.Admin.EntityFramework.Identity/Repositories/Interfaces/IIdentityRepository.cs
@@ -50,6 +50,7 @@ namespace Skoruba.IdentityServer4.Admin.EntityFramework.Identity.Repositories.In
 
         Task<PagedList<TUserClaim>> GetUserClaimsAsync(string userId, int page = 1, int pageSize = 10);
 
+        Task<List<TUserClaim>> GetUserClaimByType(string userId, string claimType);
         Task<TUserClaim> GetUserClaimAsync(string userId, int claimId);
 
         Task<IdentityResult> CreateUserClaimsAsync(TUserClaim claims);

--- a/src/Skoruba.IdentityServer4.Admin/Views/Identity/UserProfile.cshtml
+++ b/src/Skoruba.IdentityServer4.Admin/Views/Identity/UserProfile.cshtml
@@ -49,7 +49,14 @@
 
             <div class="row">
                 <div class="col-lg-2 mb-3">
-                    <img-gravatar email="@Model.Email" class="img-thumbnail" size="150" />
+                    @if (!string.IsNullOrEmpty(Model.PhotoUrl))
+                    {
+                        <img class="img-thumbnail" size="150" src="@Model.PhotoUrl" />
+                    }
+                    else
+                    {
+                        <img-gravatar email="@Model.Email" class="img-thumbnail" size="150" />
+                    }                    
                 </div>
                 <div class="col-sm-10">
                     <!--Input - text -->

--- a/src/Skoruba.IdentityServer4.Admin/Views/Identity/Users.cshtml
+++ b/src/Skoruba.IdentityServer4.Admin/Views/Identity/Users.cshtml
@@ -41,7 +41,14 @@
                                 <a class="btn btn-primary" asp-action="UserProfile" asp-route-id="@user.Id">@Localizer["ActionEditUser"]</a>
                             </td>
                             <td class="align-middle">
-                                <img-gravatar email="@user.Email" class="gravatar-image img-thumbnail" />
+                                @if (!string.IsNullOrEmpty(user.PhotoUrl))
+                                {
+                                    <img class="img-thumbnail" size="150" src="@user.PhotoUrl" />
+                                }
+                                else
+                                {
+                                    <img-gravatar email="@user.Email" class="img-thumbnail" size="150" />
+                                }                                
                             </td>
                             <td class="align-middle">@user.Id</td>
                             <td class="align-middle">@user.UserName</td>

--- a/src/Skoruba.IdentityServer4.STS.Identity/Configuration/AccountOptions.cs
+++ b/src/Skoruba.IdentityServer4.STS.Identity/Configuration/AccountOptions.cs
@@ -19,8 +19,6 @@ namespace Skoruba.IdentityServer4.STS.Identity.Configuration
 
         // specify the Windows authentication scheme being used
         public static readonly string WindowsAuthenticationSchemeName = Microsoft.AspNetCore.Server.IISIntegration.IISDefaults.AuthenticationScheme;
-        // if user uses windows auth, should we load the groups from windows
-        public static bool IncludeWindowsGroups = false;
 
         public static string InvalidCredentialsErrorMessage = "Invalid username or password";
     }

--- a/src/Skoruba.IdentityServer4.STS.Identity/Configuration/LoginConfiguration.cs
+++ b/src/Skoruba.IdentityServer4.STS.Identity/Configuration/LoginConfiguration.cs
@@ -3,5 +3,18 @@
     public class LoginConfiguration
     {
         public LoginResolutionPolicy ResolutionPolicy { get; set; } = LoginResolutionPolicy.Username;
+
+        // When integrated Windows authentication is enabled, automatically prefer it to login when request is coming from same domain
+        public bool AutomaticWindowsLogin { get; set; } = false;
+
+        // if user uses Windows authentication, should we load the groups from Windows
+        public bool IncludeWindowsGroups { get; set; } = false;
+
+        // if we load the groups from Windows, load only the groups that start with this prefix
+        public string WindowsGroupsPrefix { get; set; } = null;
+
+        // if we load the groups from Windows, load only the groups under this OU.
+        // It is possible to specify multiple OUs separating them by a pipe character ('|')
+        public string WindowsGroupsOURoot { get; set; } = null;
     }
 }

--- a/src/Skoruba.IdentityServer4.STS.Identity/Controllers/AccountController.cs
+++ b/src/Skoruba.IdentityServer4.STS.Identity/Controllers/AccountController.cs
@@ -367,6 +367,16 @@ namespace Skoruba.IdentityServer4.STS.Identity.Controllers
                 return RedirectToAction(nameof(Login));
             }
 
+            var externalResult = await HttpContext.AuthenticateAsync(IdentityConstants.ExternalScheme);
+            if (externalResult.Succeeded)
+            {
+                if (externalResult.Properties.Items.ContainsKey("returnUrl"))
+                    returnUrl = externalResult.Properties.Items["returnUrl"];
+
+                // We no longer need the external cookie
+                await HttpContext.SignOutAsync(IdentityConstants.ExternalScheme);
+            }
+
             // Sign in the user with this external login provider if the user already has a login.
             var result = await _signInManager.ExternalLoginSignInAsync(info.LoginProvider, info.ProviderKey, isPersistent: false);
             if (result.Succeeded)

--- a/src/Skoruba.IdentityServer4.STS.Identity/Controllers/ManageController.cs
+++ b/src/Skoruba.IdentityServer4.STS.Identity/Controllers/ManageController.cs
@@ -15,7 +15,7 @@ using Skoruba.IdentityServer4.STS.Identity.Helpers.Localization;
 using Skoruba.IdentityServer4.STS.Identity.ViewModels.Manage;
 
 namespace Skoruba.IdentityServer4.STS.Identity.Controllers
-{    
+{
     [Authorize]
     public class ManageController<TUser, TKey> : Controller
         where TUser : IdentityUser<TKey>, new()
@@ -58,7 +58,7 @@ namespace Skoruba.IdentityServer4.STS.Identity.Controllers
 
             return View(model);
         }
-        
+
         [HttpPost]
         [ValidateAntiForgeryToken]
         public async Task<IActionResult> Index(IndexViewModel model)
@@ -93,14 +93,14 @@ namespace Skoruba.IdentityServer4.STS.Identity.Controllers
                     throw new ApplicationException(_localizer["ErrorSettingPhone", user.Id]);
                 }
             }
-            
+
             await UpdateUserClaimsAsync(model, user);
 
             StatusMessage = _localizer["ProfileUpdated"];
 
             return RedirectToAction(nameof(Index));
         }
-        
+
         [HttpPost]
         [ValidateAntiForgeryToken]
         public async Task<IActionResult> SendVerificationEmail(IndexViewModel model)
@@ -640,7 +640,8 @@ namespace Skoruba.IdentityServer4.STS.Identity.Controllers
                 Region = profile.Region,
                 PostalCode = profile.PostalCode,
                 Locality = profile.Locality,
-                StreetAddress = profile.StreetAddress
+                StreetAddress = profile.StreetAddress,
+                PhotoUrl = profile.Picture
             };
             return model;
         }

--- a/src/Skoruba.IdentityServer4.STS.Identity/Helpers/ADUtilities/ADProperties.cs
+++ b/src/Skoruba.IdentityServer4.STS.Identity/Helpers/ADUtilities/ADProperties.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Skoruba.IdentityServer4.STS.Identity.Helpers.ADUtilities
+{
+    public class ADProperties
+    {
+        public string DisplayName { get; set; }
+        public string GivenName { get; set; }
+        public string FamilyName { get; set; }
+        public string Email { get; set; }
+        public string Photo { get; set; }
+        public string WebSite { get; set; }
+        public string PhoneNumber { get; set; }
+        public string Country { get; set; }
+        public string StreetAddress { get; set; }
+
+        public List<string> Groups { get; set; } = new List<string>();
+    }
+}

--- a/src/Skoruba.IdentityServer4.STS.Identity/Helpers/ADUtilities/ADUtilities.cs
+++ b/src/Skoruba.IdentityServer4.STS.Identity/Helpers/ADUtilities/ADUtilities.cs
@@ -1,0 +1,137 @@
+﻿using Skoruba.IdentityServer4.STS.Identity.Configuration;
+using System;
+using System.Collections.Generic;
+using System.DirectoryServices;
+using System.Linq;
+using System.Security.Principal;
+using System.Threading.Tasks;
+
+namespace Skoruba.IdentityServer4.STS.Identity.Helpers.ADUtilities
+{
+    public class ADUtilities : IADUtilities
+    {
+        protected readonly LoginConfiguration _loginConfiguration;
+
+        protected readonly List<string> _AllowedWindowsGroups = new List<string>();
+        
+        public ADUtilities(LoginConfiguration loginConfiguration)
+        {
+            _loginConfiguration = loginConfiguration;
+
+            if (!string.IsNullOrEmpty(_loginConfiguration.WindowsGroupsOURoot))
+            {
+                foreach (var searchRoot in _loginConfiguration.WindowsGroupsOURoot.Split('|', StringSplitOptions.RemoveEmptyEntries))
+                {
+                    try
+                    {
+                        _AllowedWindowsGroups.AddRange(ReadADGroupsFromRoot(searchRoot));
+                    }
+                    catch (Exception ex)
+                    {
+                        throw new Exception($"Error reading AD subtree of {searchRoot}", ex);
+                    }
+                }
+            }
+        }
+        public ADProperties GetUserInfoFromAD(string userId)
+        {
+            var ret = new ADProperties();
+            var userIdParts = userId.Split('\\', StringSplitOptions.RemoveEmptyEntries);
+            var domainName = userIdParts.Length > 1 ? userIdParts.First().ToLower() : string.Empty;
+            var userName = userIdParts.Last().ToLower();
+            var searcher = new DirectorySearcher($"LDAP://{domainName}")
+            {
+                Filter = $"(&(ObjectClass=person)(sAMAccountName={userName}))"
+            };
+
+            var result = searcher.FindOne();
+            if (result != null)
+            {
+                ret.DisplayName = ReadADProperty(result.Properties, "displayName");
+                ret.GivenName = ReadADProperty(result.Properties, "givenName");
+                ret.FamilyName = ReadADProperty(result.Properties, "sn");
+                ret.Email = ReadADProperty(result.Properties, "mail");
+                ret.PhoneNumber = ReadADProperty(result.Properties, "telephoneNumber");
+                ret.WebSite = ReadADProperty(result.Properties, "wWWHomePage");
+                ret.Country = ReadADProperty(result.Properties, "co", "c");
+                ret.StreetAddress = ReadADProperty(result.Properties, "street");
+
+                var photoBytes = result.Properties["thumbnailPhoto"]?[0] as byte[];
+
+                ret.Photo = $"data:image/png;base64,{Convert.ToBase64String(photoBytes)}";
+
+                if (_loginConfiguration.IncludeWindowsGroups)
+                {
+                    foreach (string dn in result.Properties["memberOf"])
+                    {
+                        int equalsIndex = dn.IndexOf("=", 1);
+                        int commaIndex = dn.IndexOf(",", 1);
+                        if (equalsIndex >= 0)
+                        {
+                            if (commaIndex >= 0)
+                                ret.Groups.Add(dn.Substring(equalsIndex + 1, commaIndex - equalsIndex - 1));
+                            else
+                                ret.Groups.Add(dn.Substring(equalsIndex + 1));
+                        }
+                    }
+
+                    ret.Groups = new List<string>(FilterADGroups(ret.Groups));
+                }
+            }
+            return ret;
+        }
+
+        private IEnumerable<string> ReadADGroupsFromRoot(string searchroot)
+        {
+            DirectorySearcher ds = new DirectorySearcher();
+            var adsearchRoot = new DirectoryEntry(string.Format("LDAP://{0}", searchroot));
+            ds.SearchRoot = adsearchRoot;
+            ds.SearchScope = SearchScope.Subtree;
+            ds.Filter = "(objectCategory=group)";
+            var sr = ds.FindAll();
+            foreach (var entry in sr)
+            {
+                if (entry is SearchResult res)
+                {
+                    if (res.Properties.Contains("cn") && res.Properties["cn"].Count > 0)
+                    {
+                        yield return ((string)res.Properties["cn"][0]).ToLower();
+                    }
+                }
+            }
+        }
+
+        private IEnumerable<string> FilterADGroups(IEnumerable<string> adGroups)
+        {
+            if (_loginConfiguration.IncludeWindowsGroups)
+            {
+                foreach (var group in adGroups)
+                {
+                    if (string.IsNullOrEmpty(_loginConfiguration.WindowsGroupsPrefix) || group.ToLower().StartsWith(_loginConfiguration.WindowsGroupsPrefix))
+                    {
+                        if (_AllowedWindowsGroups == null || _AllowedWindowsGroups.Count == 0)
+                            yield return group;
+                        else
+                        {
+                            int indexOfDomainSeparator = group.IndexOf('\\');
+
+                            var groupNameWithoutDomain = (indexOfDomainSeparator >= 0 ? group.Substring(indexOfDomainSeparator + 1) : group).ToLower();
+                            if (_AllowedWindowsGroups.Contains(groupNameWithoutDomain))
+                                yield return group;
+                        }
+                    }
+                }
+            }
+        }
+
+        private string ReadADProperty(ResultPropertyCollection properties, params string[] propertyName)
+        {
+            foreach (var p in propertyName)
+            {
+                if (properties[p] != null && properties[p].Count > 0 && properties[p][0] != null)
+                    return properties[p][0].ToString();
+            }
+            return null;
+        }        
+    }
+}

--- a/src/Skoruba.IdentityServer4.STS.Identity/Helpers/ADUtilities/IADUtilities.cs
+++ b/src/Skoruba.IdentityServer4.STS.Identity/Helpers/ADUtilities/IADUtilities.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Principal;
+using System.Threading.Tasks;
+
+namespace Skoruba.IdentityServer4.STS.Identity.Helpers.ADUtilities
+{
+    public interface IADUtilities
+    {
+        ADProperties GetUserInfoFromAD(string userId);
+    }
+}

--- a/src/Skoruba.IdentityServer4.STS.Identity/Helpers/HttpRequestExtensions.cs
+++ b/src/Skoruba.IdentityServer4.STS.Identity/Helpers/HttpRequestExtensions.cs
@@ -1,0 +1,67 @@
+﻿using Microsoft.AspNetCore.Http;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.NetworkInformation;
+using System.Threading.Tasks;
+
+namespace Skoruba.IdentityServer4.STS.Identity.Helpers
+{
+    public static class HttpRequestExtensions
+    {
+        public static bool IsLocal(this HttpRequest req)
+        {
+            var connection = req.HttpContext.Connection;
+            if (connection.RemoteIpAddress != null)
+            {
+                if (connection.RemoteIpAddress.ToString() == "::1" || connection.RemoteIpAddress.ToString() == "127.0.0.1")
+                    return true;
+
+                if (connection.LocalIpAddress != null)
+                {
+                    return connection.RemoteIpAddress.Equals(connection.LocalIpAddress);
+                }
+                else
+                {
+                    return IPAddress.IsLoopback(connection.RemoteIpAddress);
+                }
+            }
+
+            // for in memory TestServer or when dealing with default connection info
+            if (connection.RemoteIpAddress == null && connection.LocalIpAddress == null)
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        public static bool IsFromLocalSubnet(this HttpRequest req)
+        {
+            if (req.IsLocal())
+                return true;
+
+            var connection = req.HttpContext.Connection;
+            if (connection.RemoteIpAddress != null)
+            {
+                var clientIPv4 = connection.RemoteIpAddress.MapToIPv4();
+
+                foreach (NetworkInterface ni in NetworkInterface.GetAllNetworkInterfaces())
+                {
+                    if (ni.OperationalStatus == OperationalStatus.Up)
+                    {
+                        foreach (UnicastIPAddressInformation uipi in ni.GetIPProperties().UnicastAddresses)
+                        {
+                            if (clientIPv4.IsInSameSubnet(uipi.Address.MapToIPv4(), uipi.IPv4Mask))
+                                return true;
+                        }
+                    }
+                }
+
+                return false;
+            }
+            return false;
+        }
+    }
+}

--- a/src/Skoruba.IdentityServer4.STS.Identity/Helpers/IPAddressExtensions.cs
+++ b/src/Skoruba.IdentityServer4.STS.Identity/Helpers/IPAddressExtensions.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+
+namespace Skoruba.IdentityServer4.STS.Identity.Helpers
+{
+    public static class IPAddressExtensions
+    {
+        public static IPAddress GetNetworkAddress(this IPAddress address, IPAddress subnetMask)
+        {
+            byte[] ipAdressBytes = address.GetAddressBytes();
+            byte[] subnetMaskBytes = subnetMask.GetAddressBytes();
+
+            if (ipAdressBytes.Length != subnetMaskBytes.Length)
+                throw new ArgumentException("Lengths of IP address and subnet mask do not match.");
+
+            byte[] broadcastAddress = new byte[ipAdressBytes.Length];
+            for (int i = 0; i < broadcastAddress.Length; i++)
+            {
+                broadcastAddress[i] = (byte)(ipAdressBytes[i] & (subnetMaskBytes[i]));
+            }
+            return new IPAddress(broadcastAddress);
+        }
+
+        public static bool IsInSameSubnet(this IPAddress address2, IPAddress address, IPAddress subnetMask)
+        {
+            IPAddress network1 = address.GetNetworkAddress(subnetMask);
+            IPAddress network2 = address2.GetNetworkAddress(subnetMask);
+
+            return network1.Equals(network2);
+        }
+    }
+}

--- a/src/Skoruba.IdentityServer4.STS.Identity/Helpers/OpenIDProfile.cs
+++ b/src/Skoruba.IdentityServer4.STS.Identity/Helpers/OpenIDProfile.cs
@@ -10,5 +10,6 @@
         public string Region { get; internal set; }
         public string PostalCode { get; internal set; }
         public string Country { get; internal set; }
+        public string Picture { get; internal set; }
     }
 }

--- a/src/Skoruba.IdentityServer4.STS.Identity/Helpers/OpenidClaimHelpers.cs
+++ b/src/Skoruba.IdentityServer4.STS.Identity/Helpers/OpenidClaimHelpers.cs
@@ -16,27 +16,27 @@ namespace Skoruba.IdentityServer4.STS.Identity.Helpers
             var addressJson = new JObject();
             if (!string.IsNullOrWhiteSpace(profile.StreetAddress))
             {
-                 addressJson[AddressClaimConstants.StreetAddress] = profile.StreetAddress;
+                addressJson[AddressClaimConstants.StreetAddress] = profile.StreetAddress;
             }
 
             if (!string.IsNullOrWhiteSpace(profile.Locality))
             {
-                 addressJson[AddressClaimConstants.Locality] = profile.Locality;
+                addressJson[AddressClaimConstants.Locality] = profile.Locality;
             }
 
             if (!string.IsNullOrWhiteSpace(profile.Region))
             {
-                 addressJson[AddressClaimConstants.Region] = profile.Region;
+                addressJson[AddressClaimConstants.Region] = profile.Region;
             }
 
             if (!string.IsNullOrWhiteSpace(profile.PostalCode))
             {
-                 addressJson[AddressClaimConstants.PostalCode] = profile.PostalCode;
+                addressJson[AddressClaimConstants.PostalCode] = profile.PostalCode;
             }
 
             if (!string.IsNullOrWhiteSpace(profile.Country))
             {
-                 addressJson[AddressClaimConstants.Country] = profile.Country;
+                addressJson[AddressClaimConstants.Country] = profile.Country;
             }
 
 
@@ -54,7 +54,8 @@ namespace Skoruba.IdentityServer4.STS.Identity.Helpers
             {
                 FullName = claims.FirstOrDefault(x => x.Type == JwtClaimTypes.Name)?.Value,
                 Website = claims.FirstOrDefault(x => x.Type == JwtClaimTypes.WebSite)?.Value,
-                Profile = claims.FirstOrDefault(x => x.Type == JwtClaimTypes.Profile)?.Value
+                Profile = claims.FirstOrDefault(x => x.Type == JwtClaimTypes.Profile)?.Value,
+                Picture = claims.FirstOrDefault(x => x.Type == JwtClaimTypes.Picture)?.Value
             };
 
             var address = claims.FirstOrDefault(x => x.Type == JwtClaimTypes.Address)?.Value;
@@ -175,7 +176,7 @@ namespace Skoruba.IdentityServer4.STS.Identity.Helpers
         /// <param name="oldClaims"></param>
         /// <param name="newProfile"></param>
         /// <returns></returns>
-        public static IList<Tuple<Claim,Claim>> ExtractClaimsToReplace(IList<Claim> oldClaims, OpenIdProfile newProfile)
+        public static IList<Tuple<Claim, Claim>> ExtractClaimsToReplace(IList<Claim> oldClaims, OpenIdProfile newProfile)
         {
             var oldProfile = ExtractProfileInfo(oldClaims);
             var claimsToReplace = new List<Tuple<Claim, Claim>>();

--- a/src/Skoruba.IdentityServer4.STS.Identity/Helpers/StartupHelpers.cs
+++ b/src/Skoruba.IdentityServer4.STS.Identity/Helpers/StartupHelpers.cs
@@ -23,6 +23,7 @@ using Skoruba.IdentityServer4.STS.Identity.Configuration;
 using Skoruba.IdentityServer4.STS.Identity.Configuration.ApplicationParts;
 using Skoruba.IdentityServer4.STS.Identity.Configuration.Constants;
 using Skoruba.IdentityServer4.STS.Identity.Configuration.Intefaces;
+using Skoruba.IdentityServer4.STS.Identity.Helpers.ADUtilities;
 using Skoruba.IdentityServer4.STS.Identity.Helpers.Localization;
 using Skoruba.IdentityServer4.STS.Identity.Services;
 using ILogger = Microsoft.Extensions.Logging.ILogger;
@@ -44,9 +45,9 @@ namespace Skoruba.IdentityServer4.STS.Identity.Helpers
             services.TryAddTransient(typeof(IGenericControllerLocalizer<>), typeof(GenericControllerLocalizer<>));
 
             services.AddMvc(o =>
-                {
-                    o.Conventions.Add(new GenericControllerRouteConvention());
-                })
+            {
+                o.Conventions.Add(new GenericControllerRouteConvention());
+            })
                 .SetCompatibilityVersion(CompatibilityVersion.Version_2_1)
                 .AddViewLocalization(
                     LanguageViewLocationExpanderFormat.Suffix,
@@ -142,6 +143,7 @@ namespace Skoruba.IdentityServer4.STS.Identity.Helpers
             services
                 .AddSingleton(registrationConfiguration)
                 .AddSingleton(loginConfiguration)
+                .AddSingleton<IADUtilities, ADUtilities.ADUtilities>()
                 .AddScoped<UserResolver<TUserIdentity>>()
                 .AddIdentity<TUserIdentity, TUserIdentityRole>(options =>
                 {
@@ -235,12 +237,12 @@ namespace Skoruba.IdentityServer4.STS.Identity.Helpers
             where TConfigurationDbContext : DbContext, IConfigurationDbContext
         {
             var builder = services.AddIdentityServer(options =>
-                {
-                    options.Events.RaiseErrorEvents = true;
-                    options.Events.RaiseInformationEvents = true;
-                    options.Events.RaiseFailureEvents = true;
-                    options.Events.RaiseSuccessEvents = true;
-                })
+            {
+                options.Events.RaiseErrorEvents = true;
+                options.Events.RaiseInformationEvents = true;
+                options.Events.RaiseFailureEvents = true;
+                options.Events.RaiseSuccessEvents = true;
+            })
                 .AddAspNetIdentity<TUserIdentity>()
                 .AddIdentityServerStoresWithDbContexts<TConfigurationDbContext, TPersistedGrantDbContext>(configuration, hostingEnvironment);
 

--- a/src/Skoruba.IdentityServer4.STS.Identity/Properties/launchSettings.json
+++ b/src/Skoruba.IdentityServer4.STS.Identity/Properties/launchSettings.json
@@ -1,6 +1,6 @@
 {
     "iisSettings": {
-        "windowsAuthentication": false,
+        "windowsAuthentication": true,
         "anonymousAuthentication": true,
         "iisExpress": {
             "applicationUrl": "http://localhost:5000",

--- a/src/Skoruba.IdentityServer4.STS.Identity/Services/SmtpEmailSender.cs
+++ b/src/Skoruba.IdentityServer4.STS.Identity/Services/SmtpEmailSender.cs
@@ -1,4 +1,5 @@
-﻿using System.Net.Mail;
+﻿using System;
+using System.Net.Mail;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Identity.UI.Services;
 using Microsoft.Extensions.Logging;
@@ -21,9 +22,12 @@ namespace Skoruba.IdentityServer4.STS.Identity.Services
                 Host = _configuration.Host,
                 Port = _configuration.Port,
                 DeliveryMethod = SmtpDeliveryMethod.Network,
-                EnableSsl = _configuration.UseSSL,
-                Credentials = new System.Net.NetworkCredential(_configuration.Login, _configuration.Password)
+                EnableSsl = _configuration.UseSSL
             };
+            if (!string.IsNullOrEmpty(_configuration.Password))
+                _client.Credentials = new System.Net.NetworkCredential(_configuration.Login, _configuration.Password);
+            else
+                _client.UseDefaultCredentials = true;
         }
 
         public Task SendEmailAsync(string email, string subject, string htmlMessage)
@@ -39,7 +43,7 @@ namespace Skoruba.IdentityServer4.STS.Identity.Services
                 _logger.LogInformation($"Email: {email}, subject: {subject}, message: {htmlMessage} successfully sent");
                 return Task.CompletedTask;
             }
-            catch (SmtpException ex)
+            catch (Exception ex)
             {
                 _logger.LogError($"Exception {ex} during sending email: {email}, subject: {subject}");
                 throw;

--- a/src/Skoruba.IdentityServer4.STS.Identity/Skoruba.IdentityServer4.STS.Identity.csproj
+++ b/src/Skoruba.IdentityServer4.STS.Identity/Skoruba.IdentityServer4.STS.Identity.csproj
@@ -17,6 +17,7 @@
 		<PackageReference Include="Serilog.Settings.Configuration" Version="3.0.1" />
 		<PackageReference Include="Serilog.Sinks.File" Version="4.0.0" />
 		<PackageReference Include="Serilog.Sinks.MSSqlServer" Version="5.1.3-dev-00236" />
+		<PackageReference Include="System.DirectoryServices" Version="4.5.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Skoruba.IdentityServer4.STS.Identity/ViewModels/Manage/IndexViewModel.cs
+++ b/src/Skoruba.IdentityServer4.STS.Identity/ViewModels/Manage/IndexViewModel.cs
@@ -48,5 +48,8 @@ namespace Skoruba.IdentityServer4.STS.Identity.ViewModels.Manage
         [MaxLength(255)]
         [Display(Name = "Country")]
         public string Country { get; set; }
+
+        [Display(Name = "Photo URL")]
+        public string PhotoUrl { get; set; }
     }
 }

--- a/src/Skoruba.IdentityServer4.STS.Identity/Views/Manage/Index.cshtml
+++ b/src/Skoruba.IdentityServer4.STS.Identity/Views/Manage/Index.cshtml
@@ -1,16 +1,19 @@
 ﻿@inject IViewLocalizer Localizer
 @using Microsoft.AspNetCore.Mvc.Localization
 @model Skoruba.IdentityServer4.STS.Identity.ViewModels.Manage.IndexViewModel
-
 <h4>@Localizer["Title"]</h4>
-
 @await Html.PartialAsync("_ValidationSummary")
-
 @await Html.PartialAsync("_StatusMessage", Model.StatusMessage)
-
 <div class="row">
     <div class="col-lg-2">
-        <img-gravatar email="@Model.Email" class="img-thumbnail" size="150" />
+        @if (!string.IsNullOrEmpty(Model.PhotoUrl))
+        {
+            <img class="img-thumbnail" size="150" src="@Model.PhotoUrl" />
+        }
+        else
+        {
+            <img-gravatar email="@Model.Email" class="img-thumbnail" size="150" />
+        }
     </div>
     <div class="col-sm-10">
         <form method="post">
@@ -39,55 +42,46 @@
                 <input asp-for="PhoneNumber" class="form-control" />
                 <span asp-validation-for="PhoneNumber" class="text-danger"></span>
             </div>
-
             <div class="form-group">
                 <label asp-for="Name">@Localizer["Name"]</label>
                 <input asp-for="Name" class="form-control" />
                 <span asp-validation-for="Name" class="text-danger"></span>
             </div>
-
             <div class="form-group">
                 <label asp-for="Website">@Localizer["Website"]</label>
                 <input asp-for="Website" class="form-control" />
                 <span asp-validation-for="Website" class="text-danger"></span>
             </div>
-
             <div class="form-group">
                 <label asp-for="Profile">@Localizer["Profile"]</label>
                 <input asp-for="Profile" class="form-control" />
                 <span asp-validation-for="Profile" class="text-danger"></span>
             </div>
-
             <div class="form-group">
                 <label asp-for="StreetAddress">@Localizer["StreetAddress"]</label>
                 <input asp-for="StreetAddress" class="form-control" />
                 <span asp-validation-for="StreetAddress" class="text-danger"></span>
             </div>
-
             <div class="form-group">
                 <label asp-for="Locality">@Localizer["Locality"]</label>
                 <input asp-for="Locality" class="form-control" />
                 <span asp-validation-for="Locality" class="text-danger"></span>
             </div>
-
             <div class="form-group">
                 <label asp-for="Region">@Localizer["Region"]</label>
                 <input asp-for="Region" class="form-control" />
                 <span asp-validation-for="Region" class="text-danger"></span>
             </div>
-
             <div class="form-group">
                 <label asp-for="PostalCode">@Localizer["PostalCode"]</label>
                 <input asp-for="PostalCode" class="form-control" />
                 <span asp-validation-for="PostalCode" class="text-danger"></span>
             </div>
-
             <div class="form-group">
                 <label asp-for="Country">@Localizer["Country"]</label>
                 <input asp-for="Country" class="form-control" />
                 <span asp-validation-for="Country" class="text-danger"></span>
             </div>
-
             <button type="submit" class="btn btn-primary">@Localizer["Save"]</button>
         </form>
     </div>

--- a/src/Skoruba.IdentityServer4.STS.Identity/appsettings.json
+++ b/src/Skoruba.IdentityServer4.STS.Identity/appsettings.json
@@ -68,9 +68,13 @@
         "SourceEmail": "",
         "SourceName": ""
     },
-    "LoginConfiguration": {
-        "ResolutionPolicy": "Username"
-    },
+  "LoginConfiguration": {
+    "ResolutionPolicy": "Username",
+    "AutomaticWindowsLogin": false,
+    "IncludeWindowsGroups": true,
+    "WindowsGroupsPrefix": "",
+    "WindowsGroupsOURoot": ""
+  },
     "AdminConfiguration": {
         "IdentityAdminBaseUrl": "http://localhost:9000"
     }

--- a/src/Skoruba.IdentityServer4.STS.Identity/package-lock.json
+++ b/src/Skoruba.IdentityServer4.STS.Identity/package-lock.json
@@ -1359,8 +1359,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -1403,8 +1402,7 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
@@ -1415,8 +1413,7 @@
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1533,8 +1530,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1546,7 +1542,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -1576,7 +1571,6 @@
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -1595,7 +1589,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -1696,7 +1689,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -1782,8 +1774,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -1819,7 +1810,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -1839,7 +1829,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -1883,14 +1872,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },


### PR DESCRIPTION
If SmtpConfiguration.Password was not configured, set SmtpClient.UseDefaultCredentials = true. This way the credentials to send the email will be the those of the user running the Identity Server.

Fix: Catch all exception types when trying to send an email: if for example the configured Login is not valid, the exception thrown will not be an SmtpException, but it will be still worth logging.