### PR TITLE
Support for single quotes in PickerTag labels.

### DIFF
--- a/src/Skoruba.IdentityServer4.Admin/Helpers/TagHelpers/PickerTagHelper.cs
+++ b/src/Skoruba.IdentityServer4.Admin/Helpers/TagHelpers/PickerTagHelper.cs
@@ -90,7 +90,7 @@ namespace Skoruba.IdentityServer4.Admin.Helpers.TagHelpers
                 }
             };
 
-            var rawPickerHtml = new HtmlString($"<div data-bind='component: {JsonConvert.SerializeObject(component)}'></div>");
+            var rawPickerHtml = new HtmlString($"<div data-bind='component: {JsonConvert.SerializeObject(component, new JsonSerializerSettings() { StringEscapeHandling = StringEscapeHandling.EscapeHtml })}'></div>");
 
             output.Content.AppendHtml(rawPickerHtml);
         }


### PR DESCRIPTION
Currently, if an apostrophe is used in a label of the PickerTag, it generates invalid html. 
It is invalid because the generated div has a data-bind attribute which has it's value inside single-quotes. This is obviously done because the value contains JSON, thus it has many double-quotes and should not be encased in double-quotes. 
 
Fix escapes characters, like the single quote.
Useful for french, which has apostrophe in words.
For example : "The item" becomes "L'item"
