### PR TITLE
Initial upgrade for .NET Core 3.0 and CORS

### DIFF
--- a/src/Skoruba.IdentityServer4.Admin.Api/Configuration/Authorization/AuthorizeCheckOperationFilter.cs
+++ b/src/Skoruba.IdentityServer4.Admin.Api/Configuration/Authorization/AuthorizeCheckOperationFilter.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.OpenApi.Models;
 using Swashbuckle.AspNetCore.Swagger;
 using Swashbuckle.AspNetCore.SwaggerGen;
 
@@ -15,7 +16,7 @@ namespace Skoruba.IdentityServer4.Admin.Api.Configuration.Authorization
             _adminApiConfiguration = adminApiConfiguration;
         }
 
-        public void Apply(Operation operation, OperationFilterContext context)
+        public void Apply(OpenApiOperation operation, OperationFilterContext context)
         {
             var hasAuthorize = context.MethodInfo.DeclaringType.GetCustomAttributes(true)
                 .Union(context.MethodInfo.GetCustomAttributes(true))
@@ -23,11 +24,18 @@ namespace Skoruba.IdentityServer4.Admin.Api.Configuration.Authorization
 
             if (hasAuthorize)
             {
-                operation.Responses.Add("401", new Response { Description = "Unauthorized" });
-                operation.Responses.Add("403", new Response { Description = "Forbidden" });
 
-                operation.Security = new List<IDictionary<string, IEnumerable<string>>> {
-                    new Dictionary<string, IEnumerable<string>> {{"oauth2", new[] { _adminApiConfiguration.OidcApiName } }}
+                operation.Responses.Add("401", new OpenApiResponse { Description = "Unauthorized" });
+                operation.Responses.Add("403", new OpenApiResponse { Description = "Forbidden" });
+                var oAuthScheme = new OpenApiSecurityScheme { 
+                    Reference = new OpenApiReference { 
+                        Type = ReferenceType.SecurityScheme, Id = "oauth2"
+                    } 
+                };
+                operation.Security = new List<OpenApiSecurityRequirement> {
+                    new OpenApiSecurityRequirement {
+                        [oAuthScheme] = new[] { _adminApiConfiguration.OidcApiName }
+                    } 
                 };
             }
         }

--- a/src/Skoruba.IdentityServer4.Admin.Api/Helpers/StartupHelpers.cs
+++ b/src/Skoruba.IdentityServer4.Admin.Api/Helpers/StartupHelpers.cs
@@ -56,8 +56,9 @@ namespace Skoruba.IdentityServer4.Admin.Api.Helpers
             services.AddMvc(o =>
                 {
                     o.Conventions.Add(new GenericControllerRouteConvention());
+                    o.EnableEndpointRouting = false;
                 })
-                .SetCompatibilityVersion(CompatibilityVersion.Version_2_1)
+                .SetCompatibilityVersion(CompatibilityVersion.Version_3_0)
                 .AddDataAnnotationsLocalization()
                 .ConfigureApplicationPartManager(m =>
                 {

--- a/src/Skoruba.IdentityServer4.Admin.Api/Properties/launchSettings.json
+++ b/src/Skoruba.IdentityServer4.Admin.Api/Properties/launchSettings.json
@@ -2,10 +2,10 @@
     "iisSettings": {
         "windowsAuthentication": false,
         "anonymousAuthentication": true,
-        "iisExpress": {
-            "applicationUrl": "http://localhost:5001",
-            "sslPort": 0
-        }
+      "iisExpress": {
+        "applicationUrl": "http://localhost:5001",
+        "sslPort": 44391
+      }
     },
     "$schema": "http://json.schemastore.org/launchsettings.json",
     "profiles": {

--- a/src/Skoruba.IdentityServer4.Admin.Api/Skoruba.IdentityServer4.Admin.Api.csproj
+++ b/src/Skoruba.IdentityServer4.Admin.Api/Skoruba.IdentityServer4.Admin.Api.csproj
@@ -1,18 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
     <UserSecretsId>1cc472a2-4e4b-48ce-846b-5219f71fc643</UserSecretsId>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoMapper" Version="8.0.0" />
-    <PackageReference Include="IdentityServer4.AccessTokenValidation" Version="2.7.0" />
-    <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.2.0" PrivateAssets="All" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="4.0.1" />
-    <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="4.0.1" />
+    <PackageReference Include="AutoMapper" Version="9.0.0" />
+    <PackageReference Include="IdentityServer4.AccessTokenValidation" Version="3.0.0-preview.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.0.0-preview8.19405.11" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="5.0.0-rc2" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="5.0.0-rc2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Skoruba.IdentityServer4.Admin.Api/Startup.cs
+++ b/src/Skoruba.IdentityServer4.Admin.Api/Startup.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.OpenApi.Models;
 using Skoruba.IdentityServer4.Admin.Api.Configuration;
 using Skoruba.IdentityServer4.Admin.Api.Configuration.Authorization;
 using Skoruba.IdentityServer4.Admin.Api.Configuration.Constants;
@@ -13,7 +14,8 @@ using Skoruba.IdentityServer4.Admin.Api.Mappers;
 using Skoruba.IdentityServer4.Admin.BusinessLogic.Identity.Dtos.Identity;
 using Skoruba.IdentityServer4.Admin.EntityFramework.Shared.DbContexts;
 using Skoruba.IdentityServer4.Admin.EntityFramework.Shared.Entities.Identity;
-using Swashbuckle.AspNetCore.Swagger;
+using Swashbuckle.AspNetCore;
+
 
 namespace Skoruba.IdentityServer4.Admin.Api
 {
@@ -21,6 +23,7 @@ namespace Skoruba.IdentityServer4.Admin.Api
     {
         public Startup(IHostingEnvironment env)
         {
+            
             var builder = new ConfigurationBuilder()
                 .SetBasePath(env.ContentRootPath)
                 .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true)
@@ -75,17 +78,20 @@ namespace Skoruba.IdentityServer4.Admin.Api
 
             services.AddSwaggerGen(options =>
             {
-                options.SwaggerDoc(ApiConfigurationConsts.ApiVersionV1, new Info { Title = ApiConfigurationConsts.ApiName, Version = ApiConfigurationConsts.ApiVersionV1 });
+                options.SwaggerDoc(ApiConfigurationConsts.ApiVersionV1, new OpenApiInfo { Title = ApiConfigurationConsts.ApiName, Version = ApiConfigurationConsts.ApiVersionV1 });
 
-                options.AddSecurityDefinition("oauth2", new OAuth2Scheme
+                options.AddSecurityDefinition("oauth2", new OpenApiSecurityScheme
                 {
-                    Flow = "implicit",
-                    AuthorizationUrl = $"{adminApiConfiguration.IdentityServerBaseUrl}/connect/authorize",
-                    Scopes = new Dictionary<string, string> {
-                        { adminApiConfiguration.OidcApiName, ApiConfigurationConsts.ApiName }
+                    Type = SecuritySchemeType.OAuth2,
+                    Flows = new OpenApiOAuthFlows {
+                        Implicit = new OpenApiOAuthFlow {
+                            AuthorizationUrl = new Uri($"{adminApiConfiguration.IdentityServerBaseUrl}/connect/authorize"),
+                            Scopes = new Dictionary<string, string> {
+                                { adminApiConfiguration.OidcApiName, ApiConfigurationConsts.ApiName }
+                            }
+                        } 
                     }
-                });
-
+                }) ;
                 options.OperationFilter<AuthorizeCheckOperationFilter>();
             });
         }

--- a/src/Skoruba.IdentityServer4.Admin.Api/appsettings.json
+++ b/src/Skoruba.IdentityServer4.Admin.Api/appsettings.json
@@ -5,9 +5,9 @@
         "IdentityDbConnection": "Server=(localdb)\\mssqllocaldb;Database=IdentityServer4Admin;Trusted_Connection=True;MultipleActiveResultSets=true",
         "AdminLogDbConnection": "Server=(localdb)\\mssqllocaldb;Database=IdentityServer4Admin;Trusted_Connection=True;MultipleActiveResultSets=true"
     },
-    "AdminApiConfiguration": {
-        "IdentityServerBaseUrl": "http://localhost:5000",
-        "OidcSwaggerUIClientId": "skoruba_identity_admin_api_swaggerui",
-        "OidcApiName": "skoruba_identity_admin_api"
-    }
+  "AdminApiConfiguration": {
+    "IdentityServerBaseUrl": "https://localhost:44398",
+    "OidcSwaggerUIClientId": "skoruba_identity_admin_api_swaggerui",
+    "OidcApiName": "skoruba_identity_admin_api"
+  }
 }

--- a/src/Skoruba.IdentityServer4.Admin.BusinessLogic.Identity/Skoruba.IdentityServer4.Admin.BusinessLogic.Identity.csproj
+++ b/src/Skoruba.IdentityServer4.Admin.BusinessLogic.Identity/Skoruba.IdentityServer4.Admin.BusinessLogic.Identity.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>netstandard2.0</TargetFramework>
+		<TargetFramework>netcoreapp3.0</TargetFramework>
 		<Version>1.0.0-beta7</Version>
 		<Authors>Jan Škoruba</Authors>
 		<Description>Business Logic layer for the administration of the Asp.Net Core Identity and IdentityServer4</Description>
@@ -12,8 +12,8 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="IdentityServer4.EntityFramework" Version="2.4.0" />
-		<PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="2.2.0" />
+		<PackageReference Include="IdentityServer4.EntityFramework" Version="3.0.0-preview7.33" />
+		<PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="3.0.0-preview8.19405.7" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Skoruba.IdentityServer4.Admin.BusinessLogic.Shared/Skoruba.IdentityServer4.Admin.BusinessLogic.Shared.csproj
+++ b/src/Skoruba.IdentityServer4.Admin.BusinessLogic.Shared/Skoruba.IdentityServer4.Admin.BusinessLogic.Shared.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
 	  <Version>1.0.0-beta7</Version>
 	  <Authors>Jan Škoruba</Authors>
 	  <PackageTags>IdentityServer4 Admin OpenIDConnect OAuth2 Identity</PackageTags>

--- a/src/Skoruba.IdentityServer4.Admin.BusinessLogic/Skoruba.IdentityServer4.Admin.BusinessLogic.csproj
+++ b/src/Skoruba.IdentityServer4.Admin.BusinessLogic/Skoruba.IdentityServer4.Admin.BusinessLogic.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <Version>1.0.0-beta7</Version>
     <Authors>Jan Škoruba</Authors>
     <Description>Business Logic layer for the administration of the IdentityServer4</Description>
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="IdentityServer4.EntityFramework" Version="2.4.0" />
+    <PackageReference Include="IdentityServer4.EntityFramework" Version="3.0.0-preview7.33" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Skoruba.IdentityServer4.Admin.EntityFramework.Extensions/Skoruba.IdentityServer4.Admin.EntityFramework.Extensions.csproj
+++ b/src/Skoruba.IdentityServer4.Admin.EntityFramework.Extensions/Skoruba.IdentityServer4.Admin.EntityFramework.Extensions.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netstandard2.0</TargetFramework>
+        <TargetFramework>netcoreapp3.0</TargetFramework>
         <Version>1.0.0-beta7</Version>
         <Authors>Jan Škoruba</Authors>
         <PackageTags>IdentityServer4 Admin OpenIDConnect OAuth2 Identity</PackageTags>

--- a/src/Skoruba.IdentityServer4.Admin.EntityFramework.Identity/Skoruba.IdentityServer4.Admin.EntityFramework.Identity.csproj
+++ b/src/Skoruba.IdentityServer4.Admin.EntityFramework.Identity/Skoruba.IdentityServer4.Admin.EntityFramework.Identity.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>netstandard2.0</TargetFramework>
+		<TargetFramework>netcoreapp3.0</TargetFramework>
 		<Version>1.0.0-beta7</Version>
 		<Authors>Jan Škoruba</Authors>
 		<Description>Entity Framework layer for the administration of the Asp.Net Core Identity and IdentityServer4</Description>
@@ -12,8 +12,8 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="IdentityServer4.EntityFramework" Version="2.4.0" />
-		<PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="2.2.0" />
+		<PackageReference Include="IdentityServer4.EntityFramework" Version="3.0.0-preview7.33" />
+		<PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="3.0.0-preview8.19405.7" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Skoruba.IdentityServer4.Admin.EntityFramework.Shared/Skoruba.IdentityServer4.Admin.EntityFramework.Shared.csproj
+++ b/src/Skoruba.IdentityServer4.Admin.EntityFramework.Shared/Skoruba.IdentityServer4.Admin.EntityFramework.Shared.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netstandard2.0</TargetFramework>
+        <TargetFramework>netcoreapp3.0</TargetFramework>
         <Version>1.0.0-beta7</Version>
         <Authors>Jan Škoruba</Authors>
         <PackageTags>IdentityServer4 Admin OpenIDConnect OAuth2 Identity</PackageTags>

--- a/src/Skoruba.IdentityServer4.Admin.EntityFramework/Skoruba.IdentityServer4.Admin.EntityFramework.csproj
+++ b/src/Skoruba.IdentityServer4.Admin.EntityFramework/Skoruba.IdentityServer4.Admin.EntityFramework.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
 	  <Version>1.0.0-beta7</Version>
 	  <Authors>Jan Škoruba</Authors>
 	  <PackageTags>IdentityServer4 Admin OpenIDConnect OAuth2 Identity</PackageTags>
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="IdentityServer4.EntityFramework" Version="2.4.0" />
+    <PackageReference Include="IdentityServer4.EntityFramework" Version="3.0.0-preview7.33" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Skoruba.IdentityServer4.Admin/Configuration/AdminConfiguration.cs
+++ b/src/Skoruba.IdentityServer4.Admin/Configuration/AdminConfiguration.cs
@@ -5,15 +5,15 @@ namespace Skoruba.IdentityServer4.Admin.Configuration
 {
     public class AdminConfiguration : IAdminConfiguration
     {
-        public string IdentityAdminBaseUrl { get; set; } = "http://localhost:9000";
-        public string IdentityAdminRedirectUri { get; set; } = "http://localhost:9000/signin-oidc";
+        public string IdentityAdminBaseUrl { get; set; } = "https://localhost:44390";
+        public string IdentityAdminRedirectUri { get; set; } = "https://localhost:44390/signin-oidc";
 
-        public string IdentityServerBaseUrl { get; set; } = "http://localhost:5000";
+        public string IdentityServerBaseUrl { get; set; } = "https://localhost:44398";
         public string ClientId { get; set; } = AuthenticationConsts.OidcClientId;
         public string[] Scopes { get; set; }
 
         public string IdentityAdminApiSwaggerUIClientId { get; } = AuthenticationConsts.IdentityAdminApiSwaggerClientId;
-        public string IdentityAdminApiSwaggerUIRedirectUrl { get; } = "http://localhost:5001/swagger/oauth2-redirect.html";
+        public string IdentityAdminApiSwaggerUIRedirectUrl { get; } = "https://localhost:44391/swagger/oauth2-redirect.html";
         public string IdentityAdminApiScope { get; } = AuthenticationConsts.IdentityAdminApiScope;
 
         public string ClientSecret { get; set; } = AuthenticationConsts.OidcClientSecret;

--- a/src/Skoruba.IdentityServer4.Admin/Helpers/StartupHelpers.cs
+++ b/src/Skoruba.IdentityServer4.Admin/Helpers/StartupHelpers.cs
@@ -348,8 +348,9 @@ namespace Skoruba.IdentityServer4.Admin.Helpers
             services.AddMvc(o =>
                 {
                     o.Conventions.Add(new GenericControllerRouteConvention());
+                    o.EnableEndpointRouting = false;
                 })
-                .SetCompatibilityVersion(CompatibilityVersion.Version_2_1)
+                .SetCompatibilityVersion(CompatibilityVersion.Version_3_0)
                 .AddViewLocalization(
                     LanguageViewLocationExpanderFormat.Suffix,
                     opts => { opts.ResourcesPath = ConfigurationConsts.ResourcesPath; })

--- a/src/Skoruba.IdentityServer4.Admin/Program.cs
+++ b/src/Skoruba.IdentityServer4.Admin/Program.cs
@@ -32,7 +32,6 @@ namespace Skoruba.IdentityServer4.Admin
 
         public static IWebHost BuildWebHost(string[] args) =>
             WebHost.CreateDefaultBuilder(args)
-                   .UseKestrel(c => c.AddServerHeader = false)
                    .UseStartup<Startup>()
                    .UseSerilog()
                    .Build();

--- a/src/Skoruba.IdentityServer4.Admin/Properties/launchSettings.json
+++ b/src/Skoruba.IdentityServer4.Admin/Properties/launchSettings.json
@@ -2,10 +2,10 @@
     "iisSettings": {
         "windowsAuthentication": false,
         "anonymousAuthentication": true,
-        "iisExpress": {
-            "applicationUrl": "http://localhost:9000/",
-            "sslPort": 0
-        }
+      "iisExpress": {
+        "applicationUrl": "http://localhost:9000/",
+        "sslPort": 44390
+      }
     },
     "profiles": {
         "IIS Express": {

--- a/src/Skoruba.IdentityServer4.Admin/Skoruba.IdentityServer4.Admin.csproj
+++ b/src/Skoruba.IdentityServer4.Admin/Skoruba.IdentityServer4.Admin.csproj
@@ -1,23 +1,23 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
 	<PropertyGroup>
-		<TargetFramework>netcoreapp2.2</TargetFramework>
+		<TargetFramework>netcoreapp3.0</TargetFramework>
 		<LangVersion>latest</LangVersion>
 		<UserSecretsId>8fe260ca-ef4c-4fa3-9364-029146f8d339</UserSecretsId>
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.AspNetCore.App" />
-		<PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.2.0" PrivateAssets="All" />
-		<PackageReference Include="AutoMapper" Version="8.0.0" />
-		<PackageReference Include="IdentityServer4.EntityFramework" Version="2.4.0" />
+		<PackageReference Include="AutoMapper" Version="9.0.0" />
+		<PackageReference Include="IdentityServer4.EntityFramework" Version="3.0.0-preview7.33" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.0.0-preview8.19405.11" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.0.0-preview8.19405.11" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools.DotNet" Version="2.0.3" />
-		<PackageReference Include="Microsoft.Extensions.Options" Version="2.2.0" />
-		<PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.2.0" />
+		<PackageReference Include="Microsoft.Extensions.Options" Version="3.0.0-preview8.19405.4" />
+		<PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.0.0-preview8-19413-06" />
 		<PackageReference Include="NWebsec.AspNetCore.Middleware" Version="2.0.0" />
-		<PackageReference Include="Serilog.AspNetCore" Version="2.1.1" />
-		<PackageReference Include="Serilog.Settings.Configuration" Version="3.0.1" />
-		<PackageReference Include="Serilog.Sinks.File" Version="4.0.0" />
+		<PackageReference Include="Serilog.AspNetCore" Version="3.0.0-dev-00059" />
+		<PackageReference Include="Serilog.Settings.Configuration" Version="3.1.1-dev-00209" />
+		<PackageReference Include="Serilog.Sinks.File" Version="4.1.0-dev-00847" />
 		<PackageReference Include="Serilog.Sinks.MSSqlServer" Version="5.1.3-dev-00236" />
 	</ItemGroup>
 

--- a/src/Skoruba.IdentityServer4.Admin/appsettings.json
+++ b/src/Skoruba.IdentityServer4.Admin/appsettings.json
@@ -5,23 +5,23 @@
         "IdentityDbConnection": "Server=(localdb)\\mssqllocaldb;Database=IdentityServer4Admin;Trusted_Connection=True;MultipleActiveResultSets=true",
         "AdminLogDbConnection": "Server=(localdb)\\mssqllocaldb;Database=IdentityServer4Admin;Trusted_Connection=True;MultipleActiveResultSets=true"
     },
-    "AdminConfiguration": {
-        "IdentityAdminBaseUrl": "http://localhost:9000",
-        "IdentityAdminRedirectUri": "http://localhost:9000/signin-oidc",
-        "IdentityServerBaseUrl": "http://localhost:5000",
-        "ClientId": "skoruba_identity_admin",
-        "ClientSecret": "skoruba_admin_client_secret",
-        "OidcResponseType": "code id_token",
-        "Scopes": [
-            "openid",
-            "profile",
-            "email",
-            "roles"
-        ],
-        "IdentityAdminApiSwaggerUIClientId": "skoruba_identity_admin_api_swaggerui",
-        "IdentityAdminApiSwaggerUIRedirectUrl": "http://localhost:5001/swagger/oauth2-redirect.html",
-        "IdentityAdminApiScope": "skoruba_identity_admin_api"
-    },
+  "AdminConfiguration": {
+    "IdentityAdminBaseUrl": "https://localhost:44390",
+    "IdentityAdminRedirectUri": "https://localhost:44390/signin-oidc",
+    "IdentityServerBaseUrl": "https://localhost:44398",
+    "ClientId": "skoruba_identity_admin",
+    "ClientSecret": "skoruba_admin_client_secret",
+    "OidcResponseType": "code id_token",
+    "Scopes": [
+      "openid",
+      "profile",
+      "email",
+      "roles"
+    ],
+    "IdentityAdminApiSwaggerUIClientId": "skoruba_identity_admin_api_swaggerui",
+    "IdentityAdminApiSwaggerUIRedirectUrl": "https://localhost:44391/swagger/oauth2-redirect.html",
+    "IdentityAdminApiScope": "skoruba_identity_admin_api"
+  },
     "Serilog": {
         "MinimumLevel": {
             "Default": "Error",

--- a/src/Skoruba.IdentityServer4.Admin/web.config
+++ b/src/Skoruba.IdentityServer4.Admin/web.config
@@ -7,8 +7,12 @@
     <handlers>
       <add name="aspNetCore" path="*" verb="*" modules="AspNetCoreModuleV2" resourceType="Unspecified" />
     </handlers>
-    <aspNetCore processPath="%LAUNCHER_PATH%" arguments="%LAUNCHER_ARGS%" stdoutLogEnabled="false" stdoutLogFile=".\logs\stdout" forwardWindowsAuthToken="false">
-      <environmentVariables />
+    <aspNetCore processPath="%LAUNCHER_PATH%" arguments="%LAUNCHER_ARGS%" stdoutLogEnabled="false" stdoutLogFile=".\logs\stdout" forwardWindowsAuthToken="false" hostingModel="InProcess">
+      <environmentVariables>
+        <environmentVariable name="ASPNETCORE_HTTPS_PORT" value="44390" />
+        <environmentVariable name="COMPLUS_ForceENC" value="1" />
+        <environmentVariable name="ASPNETCORE_ENVIRONMENT" value="Development" />
+      </environmentVariables>
     </aspNetCore>
   </system.webServer>
 </configuration>

--- a/src/Skoruba.IdentityServer4.STS.Identity/Configuration/AdminConfiguration.cs
+++ b/src/Skoruba.IdentityServer4.STS.Identity/Configuration/AdminConfiguration.cs
@@ -4,6 +4,6 @@ namespace Skoruba.IdentityServer4.STS.Identity.Configuration
 {
     public class AdminConfiguration : IAdminConfiguration
     {
-        public string IdentityAdminBaseUrl { get; set; } = "http://localhost:9000";
+        public string IdentityAdminBaseUrl { get; set; } = "https://localhost:44390";
     }
 }

--- a/src/Skoruba.IdentityServer4.STS.Identity/Helpers/StartupHelpers.cs
+++ b/src/Skoruba.IdentityServer4.STS.Identity/Helpers/StartupHelpers.cs
@@ -46,8 +46,9 @@ namespace Skoruba.IdentityServer4.STS.Identity.Helpers
             services.AddMvc(o =>
                 {
                     o.Conventions.Add(new GenericControllerRouteConvention());
+                    o.EnableEndpointRouting = false;
                 })
-                .SetCompatibilityVersion(CompatibilityVersion.Version_2_1)
+                .SetCompatibilityVersion(CompatibilityVersion.Version_3_0)
                 .AddViewLocalization(
                     LanguageViewLocationExpanderFormat.Suffix,
                     opts => { opts.ResourcesPath = ConfigurationConsts.ResourcesPath; })

--- a/src/Skoruba.IdentityServer4.STS.Identity/Properties/launchSettings.json
+++ b/src/Skoruba.IdentityServer4.STS.Identity/Properties/launchSettings.json
@@ -4,7 +4,7 @@
         "anonymousAuthentication": true,
         "iisExpress": {
             "applicationUrl": "http://localhost:5000",
-            "sslPort": 0
+            "sslPort": 44398
         }
     },
     "profiles": {

--- a/src/Skoruba.IdentityServer4.STS.Identity/Skoruba.IdentityServer4.STS.Identity.csproj
+++ b/src/Skoruba.IdentityServer4.STS.Identity/Skoruba.IdentityServer4.STS.Identity.csproj
@@ -1,21 +1,22 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
 	<PropertyGroup>
-		<TargetFramework>netcoreapp2.2</TargetFramework>
+		<TargetFramework>netcoreapp3.0</TargetFramework>
 		<UserSecretsId>9c91d295-54c5-4d09-9bd6-fa56fb74011b</UserSecretsId>
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="AspNet.Security.OAuth.GitHub" Version="2.0.1" />
-		<PackageReference Include="Microsoft.AspNetCore.App" />
-		<PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.2.0" PrivateAssets="All" />
-		<PackageReference Include="IdentityServer4.AspNetIdentity" Version="2.4.0" />
-		<PackageReference Include="IdentityServer4.EntityFramework" Version="2.4.0" />
+		<PackageReference Include="AspNet.Security.OAuth.GitHub" Version="2.1.0" />
+		<PackageReference Include="IdentityServer4.AspNetIdentity" Version="3.0.0-preview7.33" />
+		<PackageReference Include="IdentityServer4.EntityFramework" Version="3.0.0-preview7.33" />
+		<PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="3.0.0-preview8.19405.7" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.0.0-preview8.19405.11" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.0.0-preview8.19405.11" />
 		<PackageReference Include="NWebsec.AspNetCore.Middleware" Version="2.0.0" />
-		<PackageReference Include="Sendgrid" Version="9.10.0" />
-		<PackageReference Include="Serilog.AspNetCore" Version="2.1.1" />
-		<PackageReference Include="Serilog.Settings.Configuration" Version="3.0.1" />
-		<PackageReference Include="Serilog.Sinks.File" Version="4.0.0" />
+		<PackageReference Include="Sendgrid" Version="9.11.0" />
+		<PackageReference Include="Serilog.AspNetCore" Version="3.0.0-dev-00059" />
+		<PackageReference Include="Serilog.Settings.Configuration" Version="3.1.1-dev-00209" />
+		<PackageReference Include="Serilog.Sinks.File" Version="4.1.0-dev-00847" />
 		<PackageReference Include="Serilog.Sinks.MSSqlServer" Version="5.1.3-dev-00236" />
 	</ItemGroup>
 

--- a/src/Skoruba.IdentityServer4.STS.Identity/Startup.cs
+++ b/src/Skoruba.IdentityServer4.STS.Identity/Startup.cs
@@ -35,6 +35,16 @@ namespace Skoruba.IdentityServer4.STS.Identity
 
         public void ConfigureServices(IServiceCollection services)
         {
+            services.AddCors(options =>
+            {
+                // this defines a CORS policy called "default"
+                options.AddPolicy("default", policy =>
+                {
+                    policy.WithOrigins("https://localhost:3000", "https://localhost:44353");
+                    policy.AllowAnyHeader();
+                    policy.AllowAnyMethod();
+                });
+            });
             services.ConfigureRootConfiguration(Configuration);
 
             // Add DbContext for Asp.Net Core Identity
@@ -57,13 +67,14 @@ namespace Skoruba.IdentityServer4.STS.Identity
 
         public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)
         {
+            app.UseHttpsRedirection();
             app.AddLogging(loggerFactory, Configuration);
 
             if (env.IsDevelopment())
             {
                 app.UseDeveloperExceptionPage();
             }
-
+            app.UseCors("default");
             // Add custom security headers
             app.UseSecurityHeaders();
 

--- a/src/Skoruba.IdentityServer4.STS.Identity/appsettings.json
+++ b/src/Skoruba.IdentityServer4.STS.Identity/appsettings.json
@@ -72,6 +72,6 @@
         "ResolutionPolicy": "Username"
     },
     "AdminConfiguration": {
-        "IdentityAdminBaseUrl": "http://localhost:9000"
+        "IdentityAdminBaseUrl": "https://localhost:44390"
     }
 }

--- a/tests/Skoruba.IdentityServer4.Admin.IntegrationTests/Skoruba.IdentityServer4.Admin.IntegrationTests.csproj
+++ b/tests/Skoruba.IdentityServer4.Admin.IntegrationTests/Skoruba.IdentityServer4.Admin.IntegrationTests.csproj
@@ -1,26 +1,25 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>netcoreapp2.2</TargetFramework>
+		<TargetFramework>netcoreapp3.0</TargetFramework>
 		<PreserveCompilationContext>true</PreserveCompilationContext>
 		<IsPackable>false</IsPackable>
 		<DebugType>Full</DebugType>
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="coverlet.msbuild" Version="2.5.0">
+		<PackageReference Include="coverlet.msbuild" Version="2.6.3">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="FluentAssertions" Version="5.5.3" />
-		<PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.2.0" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+		<PackageReference Include="FluentAssertions" Version="5.8.0" />
+		<PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.0.0-preview8.19405.7" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0-preview-20190808-03" />
 		<PackageReference Include="xunit" Version="2.4.1" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.AspNetCore.App" />
 		<DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
 	</ItemGroup>
 

--- a/tests/Skoruba.IdentityServer4.Admin.UnitTests/Skoruba.IdentityServer4.Admin.UnitTests.csproj
+++ b/tests/Skoruba.IdentityServer4.Admin.UnitTests/Skoruba.IdentityServer4.Admin.UnitTests.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>netcoreapp2.2</TargetFramework>
+		<TargetFramework>netcoreapp3.0</TargetFramework>
 		<DebugType>Full</DebugType>
 		<IsPackable>false</IsPackable>
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="coverlet.msbuild" Version="2.5.0">
+		<PackageReference Include="coverlet.msbuild" Version="2.6.3">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 		</PackageReference>
@@ -17,11 +17,10 @@
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 		</PackageReference>
 		<DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
-		<PackageReference Include="Bogus" Version="25.0.2" />
-		<PackageReference Include="FluentAssertions" Version="4.19.4" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-		<PackageReference Include="Moq" Version="4.10.1" />
-		<PackageReference Include="Microsoft.AspNetCore.App" />
+		<PackageReference Include="Bogus" Version="28.0.2" />
+		<PackageReference Include="FluentAssertions" Version="5.8.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0-preview-20190808-03" />
+		<PackageReference Include="Moq" Version="4.12.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/tests/Skoruba.IdentityServer4.STS.Identity.IntegrationTests/Skoruba.IdentityServer4.STS.Identity.IntegrationTests.csproj
+++ b/tests/Skoruba.IdentityServer4.STS.Identity.IntegrationTests/Skoruba.IdentityServer4.STS.Identity.IntegrationTests.csproj
@@ -1,24 +1,23 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp2.2</TargetFramework>
+        <TargetFramework>netcoreapp3.0</TargetFramework>
         <PreserveCompilationContext>true</PreserveCompilationContext>
         <IsPackable>false</IsPackable>
         <DebugType>Full</DebugType>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="5.5.3" />
-        <PackageReference Include="HtmlAgilityPack" Version="1.9.0" />
-        <PackageReference Include="IdentityModel" Version="3.10.6" />
-        <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.2.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+        <PackageReference Include="FluentAssertions" Version="5.8.0" />
+        <PackageReference Include="HtmlAgilityPack" Version="1.11.12" />
+        <PackageReference Include="IdentityModel" Version="4.0.0-preview.3" />
+        <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.0.0-preview8.19405.7" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0-preview-20190808-03" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.AspNetCore.App" />
         <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
     </ItemGroup>
 


### PR DESCRIPTION
This PR includes minimum upgrade path explained by [Migrate from ASP.NET Core 2.2 to 3.0](https://docs.microsoft.com/en-us/aspnet/core/migration/22-to-30?view=aspnetcore-2.2&tabs=visual-studio).
It also includes nuget package upgrades to the latest previews.