### PR TITLE
Improvements in error handling

### DIFF
--- a/src/Skoruba.IdentityServer4.STS.Identity/Controllers/AccountController.cs
+++ b/src/Skoruba.IdentityServer4.STS.Identity/Controllers/AccountController.cs
@@ -281,10 +281,16 @@ namespace Skoruba.IdentityServer4.STS.Identity.Controllers
                 var code = await _userManager.GeneratePasswordResetTokenAsync(user);
                 var callbackUrl = Url.Action("ResetPassword", "Account", new { userId = user.Id, code }, HttpContext.Request.Scheme);
 
-                await _emailSender.SendEmailAsync(model.Email, _localizer["ResetPasswordTitle"], _localizer["ResetPasswordBody", HtmlEncoder.Default.Encode(callbackUrl)]);
+                try
+                {
+                    await _emailSender.SendEmailAsync(model.Email, _localizer["ResetPasswordTitle"], _localizer["ResetPasswordBody", HtmlEncoder.Default.Encode(callbackUrl)]);
 
-
-                return View("ForgotPasswordConfirmation");
+                    return View("ForgotPasswordConfirmation");
+                }
+                catch(Exception ex)
+                {
+                    ModelState.AddModelError("", _localizer["ErrorSendingResetEmail", ex.Message]);
+                }                
             }
 
             return View(model);
@@ -566,12 +572,21 @@ namespace Skoruba.IdentityServer4.STS.Identity.Controllers
                 var code = await _userManager.GenerateEmailConfirmationTokenAsync(user);
                 var callbackUrl = Url.Action("ConfirmEmail", "Account", new { userId = user.Id, code }, HttpContext.Request.Scheme);
 
-                await _emailSender.SendEmailAsync(model.Email, _localizer["ConfirmEmailTitle"], _localizer["ConfirmEmailBody", HtmlEncoder.Default.Encode(callbackUrl)]);
+                try
+                {
+                    await _emailSender.SendEmailAsync(model.Email, _localizer["ConfirmEmailTitle"], _localizer["ConfirmEmailBody", HtmlEncoder.Default.Encode(callbackUrl)]);
+                }
+                catch (Exception ex)
+                {
+                    ModelState.AddModelError("", _localizer["ErrorSendingVerificationEmail", ex.Message]);
+                    return View(model);
+                }
+
                 await _signInManager.SignInAsync(user, isPersistent: false);
 
                 return RedirectToLocal(returnUrl);
             }
-
+            
             AddErrors(result);
 
             // If we got this far, something failed, redisplay form

--- a/src/Skoruba.IdentityServer4.STS.Identity/Controllers/ManageController.cs
+++ b/src/Skoruba.IdentityServer4.STS.Identity/Controllers/ManageController.cs
@@ -111,9 +111,17 @@ namespace Skoruba.IdentityServer4.STS.Identity.Controllers
             var code = await _userManager.GenerateEmailConfirmationTokenAsync(user);
             var callbackUrl = Url.Action("ConfirmEmail", "Account", new { userId = user.Id, code }, HttpContext.Request.Scheme);
 
-            await _emailSender.SendEmailAsync(model.Email, _localizer["ConfirmEmailTitle"], _localizer["ConfirmEmailBody", HtmlEncoder.Default.Encode(callbackUrl)]);
-
             var status = new StatusViewModel { Message = _localizer["VerificationSent"] };
+            try
+            {
+                await _emailSender.SendEmailAsync(model.Email, _localizer["ConfirmEmailTitle"], _localizer["ConfirmEmailBody", HtmlEncoder.Default.Encode(callbackUrl)]);
+            }
+            catch (Exception ex)
+            {
+                status = new StatusViewModel { IsSuccess = false, Message = _localizer["ErrorSendingVerificationEmail"]};
+                status.ErrorsDetails.Add(ex.Message);
+            }
+            
 
             return RedirectToAction(nameof(Index), status);
         }

--- a/src/Skoruba.IdentityServer4.STS.Identity/Resources/Controllers/AccountController.en.resx
+++ b/src/Skoruba.IdentityServer4.STS.Identity/Resources/Controllers/AccountController.en.resx
@@ -129,6 +129,12 @@
   <data name="ErrorExternalProvider" xml:space="preserve">
     <value>Error from external provider: {0}</value>
   </data>
+  <data name="ErrorSendingResetEmail" xml:space="preserve">
+    <value>An error occurred sending the email with the instructions to reset your password: {0}</value>
+  </data>
+  <data name="ErrorSendingVerificationEmail" xml:space="preserve">
+    <value>An error occurred sending the verification email: {0}</value>
+  </data>
   <data name="InvalidAuthenticatorCode" xml:space="preserve">
     <value>Invalid authenticator code.</value>
   </data>

--- a/src/Skoruba.IdentityServer4.STS.Identity/Resources/Controllers/ManageController.en.resx
+++ b/src/Skoruba.IdentityServer4.STS.Identity/Resources/Controllers/ManageController.en.resx
@@ -156,6 +156,9 @@
   <data name="ErrorRemovingExternalLogin" xml:space="preserve">
     <value>Unexpected error occurred removing external login for user with ID {0}.</value>
   </data>
+  <data name="ErrorSendingVerificationEmail" xml:space="preserve">
+    <value>An error occurred sending the verification email.</value>
+  </data>
   <data name="ErrorSettingEmail" xml:space="preserve">
     <value>Unexpected error occurred setting email for user with ID {0}.</value>
   </data>

--- a/src/Skoruba.IdentityServer4.STS.Identity/Resources/Controllers/ManageController.en.resx
+++ b/src/Skoruba.IdentityServer4.STS.Identity/Resources/Controllers/ManageController.en.resx
@@ -135,6 +135,9 @@
   <data name="Error2FANotEnabled" xml:space="preserve">
     <value>Cannot generate recovery codes for user with ID {0} because they do not have 2FA enabled.</value>
   </data>
+  <data name="ErrorChangingPassword" xml:space="preserve">
+    <value>Error changing password.</value>
+  </data>
   <data name="ErrorCode" xml:space="preserve">
     <value>Code</value>
   </data>
@@ -155,6 +158,9 @@
   </data>
   <data name="ErrorSettingEmail" xml:space="preserve">
     <value>Unexpected error occurred setting email for user with ID {0}.</value>
+  </data>
+  <data name="ErrorSettingPassword" xml:space="preserve">
+    <value>Error setting password.</value>
   </data>
   <data name="ErrorSettingPhone" xml:space="preserve">
     <value>Unexpected error occurred setting phone number for user with ID {0}.</value>

--- a/src/Skoruba.IdentityServer4.STS.Identity/ViewModels/Manage/ChangePasswordViewModel.cs
+++ b/src/Skoruba.IdentityServer4.STS.Identity/ViewModels/Manage/ChangePasswordViewModel.cs
@@ -17,6 +17,6 @@ namespace Skoruba.IdentityServer4.STS.Identity.ViewModels.Manage
         [Compare("NewPassword")]
         public string ConfirmPassword { get; set; }
 
-        public string StatusMessage { get; set; }
+        public StatusViewModel Status { get; set; }
     }
 }

--- a/src/Skoruba.IdentityServer4.STS.Identity/ViewModels/Manage/ExternalLoginsViewModel.cs
+++ b/src/Skoruba.IdentityServer4.STS.Identity/ViewModels/Manage/ExternalLoginsViewModel.cs
@@ -12,6 +12,6 @@ namespace Skoruba.IdentityServer4.STS.Identity.ViewModels.Manage
 
         public bool ShowRemoveButton { get; set; }
 
-        public string StatusMessage { get; set; }
+        public StatusViewModel Status { get; set; }
     }
 }

--- a/src/Skoruba.IdentityServer4.STS.Identity/ViewModels/Manage/IndexViewModel.cs
+++ b/src/Skoruba.IdentityServer4.STS.Identity/ViewModels/Manage/IndexViewModel.cs
@@ -16,7 +16,7 @@ namespace Skoruba.IdentityServer4.STS.Identity.ViewModels.Manage
         [Display(Name = "Phone number")]
         public string PhoneNumber { get; set; }
 
-        public string StatusMessage { get; set; }
+        public StatusViewModel Status { get; set; }
         [MaxLength(255)]
         [Display(Name = "Full Name")]
         public string Name { get; set; }

--- a/src/Skoruba.IdentityServer4.STS.Identity/ViewModels/Manage/SetPasswordViewModel.cs
+++ b/src/Skoruba.IdentityServer4.STS.Identity/ViewModels/Manage/SetPasswordViewModel.cs
@@ -13,6 +13,6 @@ namespace Skoruba.IdentityServer4.STS.Identity.ViewModels.Manage
         [Compare("NewPassword")]
         public string ConfirmPassword { get; set; }
 
-        public string StatusMessage { get; set; }
+        public StatusViewModel Status { get; set; }
     }
 }

--- a/src/Skoruba.IdentityServer4.STS.Identity/ViewModels/Manage/StatusViewModel.cs
+++ b/src/Skoruba.IdentityServer4.STS.Identity/ViewModels/Manage/StatusViewModel.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Skoruba.IdentityServer4.STS.Identity.ViewModels.Manage
+{
+    [Serializable]
+    public class StatusViewModel
+    {
+        public bool IsSuccess { get; set; } = true;
+        public string Message { get; set; }
+
+        public List<string> ErrorsDetails { get; set; } = new List<string>();
+    }
+}

--- a/src/Skoruba.IdentityServer4.STS.Identity/ViewModels/Manage/StatusViewModel.cs
+++ b/src/Skoruba.IdentityServer4.STS.Identity/ViewModels/Manage/StatusViewModel.cs
@@ -5,7 +5,6 @@ using System.Threading.Tasks;
 
 namespace Skoruba.IdentityServer4.STS.Identity.ViewModels.Manage
 {
-    [Serializable]
     public class StatusViewModel
     {
         public bool IsSuccess { get; set; } = true;

--- a/src/Skoruba.IdentityServer4.STS.Identity/ViewModels/Manage/TwoFactorAuthenticationViewModel.cs
+++ b/src/Skoruba.IdentityServer4.STS.Identity/ViewModels/Manage/TwoFactorAuthenticationViewModel.cs
@@ -9,5 +9,7 @@
         public bool Is2faEnabled { get; set; }
 
         public bool IsMachineRemembered { get; set; }
+
+        public StatusViewModel Status { get; set; }
     }
 }

--- a/src/Skoruba.IdentityServer4.STS.Identity/Views/Manage/ChangePassword.cshtml
+++ b/src/Skoruba.IdentityServer4.STS.Identity/Views/Manage/ChangePassword.cshtml
@@ -9,7 +9,7 @@
 
 @await Html.PartialAsync("_ValidationSummary")
 
-@await Html.PartialAsync("_StatusMessage", Model.StatusMessage)
+@await Html.PartialAsync("_StatusMessage", Model.Status)
 
 <div class="row">
     <div class="col-md-6">

--- a/src/Skoruba.IdentityServer4.STS.Identity/Views/Manage/ExternalLogins.cshtml
+++ b/src/Skoruba.IdentityServer4.STS.Identity/Views/Manage/ExternalLogins.cshtml
@@ -5,7 +5,7 @@
     ViewData["Title"] = Localizer["Title"];
 }
 
-@await Html.PartialAsync("_StatusMessage", Model.StatusMessage)
+@await Html.PartialAsync("_StatusMessage", Model.Status)
 
 @if (Model.CurrentLogins?.Count > 0)
 {

--- a/src/Skoruba.IdentityServer4.STS.Identity/Views/Manage/Index.cshtml
+++ b/src/Skoruba.IdentityServer4.STS.Identity/Views/Manage/Index.cshtml
@@ -6,7 +6,7 @@
 
 @await Html.PartialAsync("_ValidationSummary")
 
-@await Html.PartialAsync("_StatusMessage", Model.StatusMessage)
+@await Html.PartialAsync("_StatusMessage", Model.Status)
 
 <div class="row">
     <div class="col-lg-2">
@@ -16,21 +16,21 @@
         <form method="post">
             <div class="form-group">
                 <label asp-for="Username">@Localizer["UserName"]</label>
-                <input asp-for="Username" class="form-control" disabled />
+                <input asp-for="Username" class="form-control" readonly />
             </div>
             <div class="form-group">
                 <label asp-for="Email">@Localizer["Email"]</label>
                 <input type="hidden" asp-for="IsEmailConfirmed" />
                 @if (Model.IsEmailConfirmed)
                 {
-                    <div class="input-group">
-                        <input asp-for="Email" class="form-control" />
-                    </div>
+                <div class="input-group">
+                    <input asp-for="Email" class="form-control" />
+                </div>
                 }
                 else
                 {
-                    <input asp-for="Email" class="form-control" />
-                    <button asp-action="SendVerificationEmail" class="btn btn-link">@Localizer["SendVerificationEmail"]</button>
+                <input asp-for="Email" class="form-control" />
+                <button id="SendVerificationEmailBtn" asp-action="SendVerificationEmail" class="btn btn-link">@Localizer["SendVerificationEmail"]</button>
                 }
                 <span asp-validation-for="Email" class="text-danger"></span>
             </div>
@@ -92,3 +92,15 @@
         </form>
     </div>
 </div>
+
+@section scripts
+{
+<script>
+    $(document).ready(function() {
+        $("#Email").on('input', function() {
+            $("#SendVerificationEmailBtn").hide();
+        });
+    });
+
+</script>
+}

--- a/src/Skoruba.IdentityServer4.STS.Identity/Views/Manage/SetPassword.cshtml
+++ b/src/Skoruba.IdentityServer4.STS.Identity/Views/Manage/SetPassword.cshtml
@@ -6,7 +6,7 @@
 }
 
 <h4>@Localizer["SubTitle"]</h4>
-@await Html.PartialAsync("_StatusMessage", Model.StatusMessage)
+@await Html.PartialAsync("_StatusMessage", Model.Status)
 
 <div class="alert alert-info" role="alert">
     @Localizer["Info"]

--- a/src/Skoruba.IdentityServer4.STS.Identity/Views/Manage/TwoFactorAuthentication.cshtml
+++ b/src/Skoruba.IdentityServer4.STS.Identity/Views/Manage/TwoFactorAuthentication.cshtml
@@ -6,10 +6,10 @@
 }
 
 <div class="row">
-
     <div class="col-12">
         <h3>@ViewData["Title"]</h3>
     </div>
+    @await Html.PartialAsync("_StatusMessage", Model.Status)
 
     @if (Model.Is2faEnabled)
     {
@@ -55,7 +55,6 @@
             <a asp-action="GenerateRecoveryCodesWarning" class="btn btn-danger">@Localizer["ResetCodes"]</a>
         </div>
     }
-
 </div>
 
 <div class="row">

--- a/src/Skoruba.IdentityServer4.STS.Identity/Views/Manage/_StatusMessage.cshtml
+++ b/src/Skoruba.IdentityServer4.STS.Identity/Views/Manage/_StatusMessage.cshtml
@@ -1,10 +1,22 @@
-﻿@model string
+﻿@model Skoruba.IdentityServer4.STS.Identity.ViewModels.Manage.StatusViewModel
 
-@if (!String.IsNullOrEmpty(Model))
+@if (Model != null && !String.IsNullOrEmpty(Model.Message))
 {
-    var statusMessageClass = Model.StartsWith("Error") ? "danger" : "success";
+    var statusMessageClass = Model.IsSuccess ? "success" : "danger";
 <div class="alert alert-@statusMessageClass alert-dismissible" role="alert">
     <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-    @Model
+    @Model.Message
+    @if (Model.ErrorsDetails.Count > 0)
+    {
+    <div>
+        Details:
+        <ul>
+            @foreach (var detail in Model.ErrorsDetails)
+            {
+                <li>@detail</li>
+            }
+        </ul>
+    </div>
+    }
 </div>
 }

--- a/tests/Skoruba.IdentityServer4.STS.Identity.IntegrationTests/Tests/ManageControllerTests.cs
+++ b/tests/Skoruba.IdentityServer4.STS.Identity.IntegrationTests/Tests/ManageControllerTests.cs
@@ -86,10 +86,7 @@ namespace Skoruba.IdentityServer4.STS.Identity.IntegrationTests.Tests
             var responseMessage = await _client.SendAsync(requestWithIdentityCookie);
 
             // Assert      
-            responseMessage.StatusCode.Should().Be(HttpStatusCode.Redirect);
-
-            //The redirect to login
-            responseMessage.Headers.Location.ToString().Should().Be("/Manage");
+            responseMessage.StatusCode.Should().Be(HttpStatusCode.OK);
         }
     }
 }


### PR DESCRIPTION
A few changes in the way the errors are handled, mainly in the profile management. This PR tackles the issue #351 

- If some error occurs updating the user profile, the error is now shown to the user
- In the ManageController, the status message is now a class and it's possible to distinguish between error or success messages using the IsSuccess property. Before, a message was considered an error only if it started with the word "Error"
- Added Status property to TwoFactorAuthenticationViewModel, so any feedback to the user can be displayed in the 2fa page too
- SendVerificationEmailBtn is hidden if the user email address was changed but not saved yet, to avoid confusion
- Updated UserIsAbleToUpdateProfile integration test because now because of the changes above when the profile is correctly updated the result is not a redirect but a 200 success code
- If an error occurs sending an email, the application notifies the user instead of just crashing

Some messages were added in the English localization, it would be great to have them translated in the other languages too.