### PR TITLE
Batch import of all AD users

### DIFF
--- a/src/Skoruba.IdentityServer4.STS.Identity/Helpers/ADUtilities/IADUtilities.cs
+++ b/src/Skoruba.IdentityServer4.STS.Identity/Helpers/ADUtilities/IADUtilities.cs
@@ -12,5 +12,6 @@ namespace Skoruba.IdentityServer4.STS.Identity.Helpers.ADUtilities
         // Given a list of roles, returns only those that are Windows groups that comply with the configured policy
         IEnumerable<string> FilterADGroups(IEnumerable<string> adGroups);
         WindowsIdentity LogonWindowsUser(string username, string password, string domain = null);
+        IEnumerable<string> ReadAllUsernamesFromAD();
     }
 }

--- a/src/Skoruba.IdentityServer4.STS.Identity/Resources/Views/Account/ImportAllWindowsUsers.en.resx
+++ b/src/Skoruba.IdentityServer4.STS.Identity/Resources/Views/Account/ImportAllWindowsUsers.en.resx
@@ -117,52 +117,13 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="ConfirmEmailBody" xml:space="preserve">
-    <value>Please confirm your account by &lt;a href='{0}'&gt;clicking here&lt;/a&gt;.</value>
+  <data name="Description" xml:space="preserve">
+    <value>Import all the Windows users to the IdentityServer database. This is not necessary in order to let the users authenticate using their Windows login; use this functionality only if you need to know in advance all the possible users. The import process could be long, please be patient.</value>
   </data>
-  <data name="ConfirmEmailTitle" xml:space="preserve">
-    <value>Confirm your email</value>
+  <data name="StartImport" xml:space="preserve">
+    <value>Start import</value>
   </data>
-  <data name="EmailNotFound" xml:space="preserve">
-    <value>The user does not exist or is not confirmed</value>
-  </data>
-  <data name="ErrorAddingRoleClaim" xml:space="preserve">
-    <value>It was not possible to add role claim '{0}' for user '{1}'</value>
-  </data>
-  <data name="ErrorExternalProvider" xml:space="preserve">
-    <value>Error from external provider: {0}</value>
-  </data>
-  <data name="ErrorRemovingRoleClaim" xml:space="preserve">
-    <value>It was not possible to remove role claim '{0}' from user '{1}'</value>
-  </data>
-  <data name="ErrorSyncingUserProfile" xml:space="preserve">
-    <value>It was not possible to update profile of user '{0}' with the new values coming from AD</value>
-  </data>
-  <data name="ErrorUpdatingClaim" xml:space="preserve">
-    <value>It was not possible to update claim of type '{0}' for user '{1}' with new value '{2}'</value>
-  </data>
-  <data name="InvalidAuthenticatorCode" xml:space="preserve">
-    <value>Invalid authenticator code.</value>
-  </data>
-  <data name="InvalidRecoveryCode" xml:space="preserve">
-    <value>Invalid recovery code entered.</value>
-  </data>
-  <data name="InvalidUsernameFormat" xml:space="preserve">
-    <value>Invalid username format</value>
-  </data>
-  <data name="ResetPasswordBody" xml:space="preserve">
-    <value>Please reset your password by &lt;a href='{0}'&gt;clicking here&lt;/a&gt;.</value>
-  </data>
-  <data name="ResetPasswordTitle" xml:space="preserve">
-    <value>Reset Password</value>
-  </data>
-  <data name="Unable2FA" xml:space="preserve">
-    <value>Unable to load two-factor authentication user.</value>
-  </data>
-  <data name="WindowsAuthenticationFailed" xml:space="preserve">
-    <value>Windows authentication failed</value>
-  </data>
-  <data name="WindowsUsersImported" xml:space="preserve">
-    <value>Windows users import finished: {0} new users imported, {1} users updated, {2} errors (check the logs)</value>
+  <data name="Title" xml:space="preserve">
+    <value>Import Windows users</value>
   </data>
 </root>

--- a/src/Skoruba.IdentityServer4.STS.Identity/ViewModels/Account/ImportAllWindowsUsersViewModel.cs
+++ b/src/Skoruba.IdentityServer4.STS.Identity/ViewModels/Account/ImportAllWindowsUsersViewModel.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Localization;
+
+namespace Skoruba.IdentityServer4.STS.Identity.ViewModels.Account
+{
+    public class ImportAllWindowsUsersViewModel
+    {
+        public string StatusMessage { get; set; }
+    }
+}

--- a/src/Skoruba.IdentityServer4.STS.Identity/Views/Account/ImportAllWindowsUsers.cshtml
+++ b/src/Skoruba.IdentityServer4.STS.Identity/Views/Account/ImportAllWindowsUsers.cshtml
@@ -1,0 +1,23 @@
+﻿@using Microsoft.AspNetCore.Mvc.Localization
+@inject IViewLocalizer Localizer
+@model Skoruba.IdentityServer4.STS.Identity.ViewModels.Account.ImportAllWindowsUsersViewModel
+
+@await Html.PartialAsync("_StatusMessage", Model.StatusMessage)
+
+<div>
+    <div class="page-header">
+        <h1>@Localizer["Title"]</h1>
+    </div>
+    <div class="row">
+        @Localizer["Description"]
+    </div>
+    <div class="row">
+        <form asp-action="ImportAllWindowsUsers">
+            <fieldset>
+                <div class="form-group">
+                    <button class="btn btn-primary">@Localizer["StartImport"]</button>
+                </div>
+            </fieldset>
+        </form>
+    </div>
+</div>

--- a/src/Skoruba.IdentityServer4.STS.Identity/Views/Shared/_Layout.cshtml
+++ b/src/Skoruba.IdentityServer4.STS.Identity/Views/Shared/_Layout.cshtml
@@ -2,18 +2,24 @@
 @using Microsoft.AspNetCore.Identity
 @using Microsoft.AspNetCore.Mvc.Localization
 @using Skoruba.IdentityServer4.Admin.EntityFramework.Shared.Entities.Identity
+@using Skoruba.IdentityServer4.STS.Identity.Configuration
 @inject IViewLocalizer Localizer
 @{
     string name = null;
-    if (!true.Equals(ViewData["signed-out"]))
-    {
-        name = Context.User?.GetDisplayName();
-    }
+ if (!true.Equals(ViewData["signed-out"]))
+ {
+     name = Context.User?.GetDisplayName();
+ }
 }
+@using Microsoft.AspNetCore.Authorization
+@using Skoruba.IdentityServer4.STS.Identity.Configuration.Constants
+@inject IAuthorizationService AuthorizationService
 
 @inject SignInManager<UserIdentity> SignInManager
 @{
     var hasExternalLogins = (await SignInManager.GetExternalAuthenticationSchemesAsync()).Any();
+    var hasWindowsLogins = hasExternalLogins && (await SignInManager.GetExternalAuthenticationSchemesAsync()).Any(
+        scheme => scheme.Name == AccountOptions.WindowsAuthenticationSchemeName);
 }
 <!DOCTYPE html>
 <html>
@@ -45,6 +51,11 @@
         <!--Menu item -->
         @if (User.Identity.IsAuthenticated)
         {
+            <!--Menu item -->
+            @if (hasWindowsLogins && (await AuthorizationService.AuthorizeAsync(User, AuthorizationConsts.AdministrationPolicy)).Succeeded)
+            {
+                <a class="menu-item my-2 btn btn-outline-primary" asp-action="ImportAllWindowsUsers" asp-controller="Account">@Localizer["ImportWindowsUsers"]</a>
+            }
             <!--Menu item -->
             <vc:identity-server-admin-link></vc:identity-server-admin-link>
 


### PR DESCRIPTION
There are cases when we need to have all the Windows users registered in the database, so that for example calling the Admin API to retrieve all the users we get all the AD users instead of just those who logged in at least once.
I have added a button in the Identity Server top menu to launch a massive import from AD, but I am not 100% sure this is the best place: probably putting it in the Admin menu or even calling it during the seed operation would be a better option, but for the moment it was easier for me to leave it in the IdentityServer project (all the Windows auth classes are there).
I open this PR looking for some feedback and ideas to refactor it.