### PR TITLE
Added CertificateStore to config

### DIFF
--- a/docs/Configure-Azure-Deploy.md
+++ b/docs/Configure-Azure-Deploy.md
@@ -69,27 +69,23 @@ While we're at it we can allow only https traffic to our STS and admin:
 
 ![Always https](Images/https_always.PNG)
 
+Then head to "Application Settings" section within your Azure App Service and create a new Application setting with the following parameters:
+
+```
+Name: WEBSITE_LOAD_CERTIFICATES
+Value: *
+```
+
 Last step before deploy - we need to update `src/Skoruba.IdentityServer4.STS.Identity/appsettings.json` and modify following lines:
 
 ```json
 "CertificateConfiguration": {
     "UseTemporarySigningKeyForDevelopment": false,
+    "CertificateStoreLocation": "CurrentUser",
+    "CertificateValidOnly": false,
     "UseSigningCertificateThumbprint": true,
     "SigningCertificateThumbprint": "<enter here thumbprint from Azure>"
 }
 ```
-
-In `src/Skoruba.IdentityServer4.STS.Identity/Helpers/IdentityServerBuilderExtensions.cs` - change loading certificates from `StoreLocation.LocalMachine` to `StoreLocation.CurrentUser`.
-
-And change in method: `AddCustomSigningCredential` 
-from:
-```
-var certCollection = certStore.Certificates.Find(X509FindType.FindByThumbprint, certificateConfiguration.SigningCertificateThumbprint, true);
-```
-to:
-```
-var certCollection = certStore.Certificates.Find(X509FindType.FindByThumbprint, certificateConfiguration.SigningCertificateThumbprint, false);
-```
-
 
 Now we can (re)deploy both apps to Azure.

--- a/src/Skoruba.IdentityServer4.STS.Identity/Configuration/CertificateConfiguration.cs
+++ b/src/Skoruba.IdentityServer4.STS.Identity/Configuration/CertificateConfiguration.cs
@@ -4,6 +4,9 @@
     {
         public bool UseTemporarySigningKeyForDevelopment { get; set; }
 
+        public string CertificateStoreLocation { get; set; }
+        public bool CertificateValidOnly { get; set; }
+
         public bool UseSigningCertificateThumbprint { get; set; }
 
         public string SigningCertificateThumbprint { get; set; }

--- a/src/Skoruba.IdentityServer4.STS.Identity/Helpers/IdentityServerBuilderExtensions.cs
+++ b/src/Skoruba.IdentityServer4.STS.Identity/Helpers/IdentityServerBuilderExtensions.cs
@@ -36,10 +36,28 @@ namespace Skoruba.IdentityServer4.STS.Identity.Helpers
                     throw new Exception(SigningCertificateThumbprintNotFound);
                 }
 
-                var certStore = new X509Store(StoreName.My, StoreLocation.LocalMachine);
+                StoreLocation storeLocation = StoreLocation.LocalMachine;
+                bool validOnly = certificateConfiguration.CertificateValidOnly;
+
+                // Parse the Certificate StoreLocation
+                string certStoreLocationLower = certificateConfiguration.CertificateStoreLocation.ToLower();
+                if (certStoreLocationLower == StoreLocation.CurrentUser.ToString().ToLower() ||
+                    certificateConfiguration.CertificateStoreLocation == ((int)StoreLocation.CurrentUser).ToString())
+                {
+                    storeLocation = StoreLocation.CurrentUser;
+                }
+                else if (certStoreLocationLower == StoreLocation.LocalMachine.ToString().ToLower() ||
+                         certStoreLocationLower == ((int)StoreLocation.LocalMachine).ToString())
+                {
+                    storeLocation = StoreLocation.LocalMachine;
+                }
+                else { storeLocation = StoreLocation.LocalMachine; validOnly = true; }
+
+                // Open Certificate
+                var certStore = new X509Store(StoreName.My, storeLocation);
                 certStore.Open(OpenFlags.ReadOnly);
 
-                var certCollection = certStore.Certificates.Find(X509FindType.FindByThumbprint, certificateConfiguration.SigningCertificateThumbprint, true);
+                var certCollection = certStore.Certificates.Find(X509FindType.FindByThumbprint, certificateConfiguration.SigningCertificateThumbprint, validOnly);
                 if (certCollection.Count == 0)
                 {
                     throw new Exception(CertificateNotFound);

--- a/src/Skoruba.IdentityServer4.STS.Identity/appsettings.json
+++ b/src/Skoruba.IdentityServer4.STS.Identity/appsettings.json
@@ -36,6 +36,9 @@
 
         "UseTemporarySigningKeyForDevelopment": true,
 
+        "CertificateStoreLocation": "LocalMachine",
+        "CertificateValidOnly": true,
+
         "UseSigningCertificateThumbprint": false,
         "SigningCertificateThumbprint": "",
 


### PR DESCRIPTION
While going through the process of following the Azure tutorial, I had noticed that there was a section which involved messing with the AddCustomSigningCredential method. 

I wanted to be able to easily have this configured so I didn't need to make a code change between debugging on my local machine vs on the server version. So on my personal fork I had gone ahead and added this configuration addition in.

Let me know if its something you would like to add into the main codebase