### PR TITLE
Initial IStringLocalizer based localization of ASP.NET Core Identity

### DIFF
--- a/src/Skoruba.IdentityServer4.Admin/Helpers/Identity/IdentityErrorMessages.cs
+++ b/src/Skoruba.IdentityServer4.Admin/Helpers/Identity/IdentityErrorMessages.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Localization;
 
 namespace Skoruba.IdentityServer4.Admin.Helpers.Identity
 {
@@ -9,7 +10,235 @@ namespace Skoruba.IdentityServer4.Admin.Helpers.Identity
     /// Or install package with specific language - https://www.nuget.org/packages?q=Microsoft.AspNet.Identity.Core
     /// </summary>
     public class IdentityErrorMessages : IdentityErrorDescriber
-    {        
+    {
+        private readonly IStringLocalizer _stringLocalizer;
 
+        public IdentityErrorMessages(IStringLocalizer<IdentityErrorMessages> stringLocalizer)
+        {
+            _stringLocalizer = stringLocalizer;
+        }
+
+        /// <summary>
+        /// Returns an <see cref="IdentityError" /> indicating a concurrency failure.
+        /// </summary>
+        /// <returns>An <see cref="IdentityError" /> indicating a concurrency failure.</returns>
+        public override IdentityError ConcurrencyFailure()
+        {
+            return CreateNamedError(nameof(ConcurrencyFailure));
+        }
+
+        /// <summary>
+        /// Returns the default <see cref="IdentityError" />.
+        /// </summary>
+        /// <returns>The default <see cref="IdentityError" />.</returns>
+        public override IdentityError DefaultError()
+        {
+            return CreateNamedError(nameof(DefaultError));
+        }
+
+        /// <summary>
+        /// Returns an <see cref="IdentityError" /> indicating the specified <paramref name="email" /> is already associated with an account.
+        /// </summary>
+        /// <param name="email">The email that is already associated with an account.</param>
+        /// <returns>An <see cref="IdentityError" /> indicating the specified <paramref name="email" /> is already associated with an account.</returns>
+        public override IdentityError DuplicateEmail(string email)
+        {
+            return CreateNamedError(nameof(DuplicateEmail));
+        }
+
+        /// <summary>
+        /// Returns an <see cref="IdentityError" /> indicating the specified <paramref name="role" /> name already exists.
+        /// </summary>
+        /// <param name="role">The duplicate role.</param>
+        /// <returns>An <see cref="IdentityError" /> indicating the specific role <paramref name="role" /> name already exists.</returns>
+        public override IdentityError DuplicateRoleName(string role)
+        {
+            return CreateNamedError(nameof(DuplicateRoleName));
+        }
+
+        /// <summary>
+        /// Returns an <see cref="IdentityError" /> indicating the specified <paramref name="userName" /> already exists.
+        /// </summary>
+        /// <param name="userName">The user name that already exists.</param>
+        /// <returns>An <see cref="IdentityError" /> indicating the specified <paramref name="userName" /> already exists.</returns>
+        public override IdentityError DuplicateUserName(string userName)
+        {
+            return CreateNamedError(nameof(DuplicateUserName));
+        }
+
+        /// <summary>
+        /// Returns an <see cref="IdentityError" /> indicating the specified <paramref name="email" /> is invalid.
+        /// </summary>
+        /// <param name="email">The email that is invalid.</param>
+        /// <returns>An <see cref="IdentityError" /> indicating the specified <paramref name="email" /> is invalid.</returns>
+        public override IdentityError InvalidEmail(string email)
+        {
+            return CreateNamedError(nameof(InvalidEmail));
+        }
+
+        /// <summary>
+        /// Returns an <see cref="IdentityError" /> indicating the specified <paramref name="role" /> name is invalid.
+        /// </summary>
+        /// <param name="role">The invalid role.</param>
+        /// <returns>An <see cref="IdentityError" /> indicating the specific role <paramref name="role" /> name is invalid.</returns>
+        public override IdentityError InvalidRoleName(string role)
+        {
+            return CreateNamedError(nameof(InvalidRoleName));
+        }
+
+        /// <summary>
+        /// Returns an <see cref="IdentityError" /> indicating an invalid token.
+        /// </summary>
+        /// <returns>An <see cref="IdentityError" /> indicating an invalid token.</returns>
+        public override IdentityError InvalidToken()
+        {
+            return CreateNamedError(nameof(InvalidToken));
+        }
+
+        /// <summary>
+        /// Returns an <see cref="IdentityError" /> indicating the specified user <paramref name="userName" /> is invalid.
+        /// </summary>
+        /// <param name="userName">The user name that is invalid.</param>
+        /// <returns>An <see cref="IdentityError" /> indicating the specified user <paramref name="userName" /> is invalid.</returns>
+        public override IdentityError InvalidUserName(string userName)
+        {
+            return CreateNamedError(nameof(InvalidUserName));
+        }
+
+        /// <summary>
+        /// Returns an <see cref="IdentityError" /> indicating an external login is already associated with an account.
+        /// </summary>
+        /// <returns>An <see cref="IdentityError" /> indicating an external login is already associated with an account.</returns>
+        public override IdentityError LoginAlreadyAssociated()
+        {
+            return CreateNamedError(nameof(LoginAlreadyAssociated));
+        }
+
+        /// <summary>
+        /// Returns an <see cref="IdentityError" /> indicating a password mismatch.
+        /// </summary>
+        /// <returns>An <see cref="IdentityError" /> indicating a password mismatch.</returns>
+        public override IdentityError PasswordMismatch()
+        {
+            return CreateNamedError(nameof(PasswordMismatch));
+        }
+
+        /// <summary>
+        /// Returns an <see cref="IdentityError" /> indicating a password entered does not contain a numeric character, which is required by the password policy.
+        /// </summary>
+        /// <returns>An <see cref="IdentityError" /> indicating a password entered does not contain a numeric character.</returns>
+        public override IdentityError PasswordRequiresDigit()
+        {
+            return CreateNamedError(nameof(PasswordRequiresDigit));
+        }
+
+        /// <summary>
+        /// Returns an <see cref="IdentityError" /> indicating a password entered does not contain a lower case letter, which is required by the password policy.
+        /// </summary>
+        /// <returns>An <see cref="IdentityError" /> indicating a password entered does not contain a lower case letter.</returns>
+        public override IdentityError PasswordRequiresLower()
+        {
+            return CreateNamedError(nameof(PasswordRequiresLower));
+        }
+
+        /// <summary>
+        /// Returns an <see cref="IdentityError" /> indicating a password entered does not contain a non-alphanumeric character, which is required by the password policy.
+        /// </summary>
+        /// <returns>An <see cref="IdentityError" /> indicating a password entered does not contain a non-alphanumeric character.</returns>
+        public override IdentityError PasswordRequiresNonAlphanumeric()
+        {
+            return CreateNamedError(nameof(PasswordRequiresNonAlphanumeric));
+        }
+
+        /// <summary>
+        /// Returns an <see cref="IdentityError" /> indicating a password does not meet the minimum number <paramref name="uniqueChars" /> of unique chars.
+        /// </summary>
+        /// <param name="uniqueChars">The number of different chars that must be used.</param>
+        /// <returns>An <see cref="IdentityError" /> indicating a password does not meet the minimum number <paramref name="uniqueChars" /> of unique chars.</returns>
+        public override IdentityError PasswordRequiresUniqueChars(int uniqueChars)
+        {
+            return CreateNamedError(nameof(PasswordRequiresUniqueChars));
+        }
+
+        /// <summary>
+        /// Returns an <see cref="IdentityError" /> indicating a password entered does not contain an upper case letter, which is required by the password policy.
+        /// </summary>
+        /// <returns>An <see cref="IdentityError" /> indicating a password entered does not contain an upper case letter.</returns>
+        public override IdentityError PasswordRequiresUpper()
+        {
+            return CreateNamedError(nameof(PasswordRequiresUpper));
+        }
+
+        /// <summary>
+        /// Returns an <see cref="IdentityError" /> indicating a password of the specified <paramref name="length" /> does not meet the minimum length requirements.
+        /// </summary>
+        /// <param name="length">The length that is not long enough.</param>
+        /// <returns>An <see cref="IdentityError" /> indicating a password of the specified <paramref name="length" /> does not meet the minimum length requirements.</returns>
+        public override IdentityError PasswordTooShort(int length)
+        {
+            return CreateNamedError(nameof(PasswordTooShort));
+        }
+
+        /// <summary>
+        /// Returns an <see cref="IdentityError" /> indicating a recovery code was not redeemed.
+        /// </summary>
+        /// <returns>An <see cref="IdentityError" /> indicating a recovery code was not redeemed.</returns>
+        public override IdentityError RecoveryCodeRedemptionFailed()
+        {
+            return CreateNamedError(nameof(RecoveryCodeRedemptionFailed));
+        }
+
+        /// <summary>
+        /// Returns an <see cref="IdentityError" /> indicating a user already has a password.
+        /// </summary>
+        /// <returns>An <see cref="IdentityError" /> indicating a user already has a password.</returns>
+        public override IdentityError UserAlreadyHasPassword()
+        {
+            return CreateNamedError(nameof(UserAlreadyHasPassword));
+        }
+
+        /// <summary>
+        /// Returns an <see cref="IdentityError" /> indicating a user is already in the specified <paramref name="role" />.
+        /// </summary>
+        /// <param name="role">The duplicate role.</param>
+        /// <returns>An <see cref="IdentityError" /> indicating a user is already in the specified <paramref name="role" />.</returns>
+        public override IdentityError UserAlreadyInRole(string role)
+        {
+            return CreateNamedError(nameof(UserAlreadyInRole));
+        }
+
+        /// <summary>
+        /// Returns an <see cref="IdentityError" /> indicating user lockout is not enabled.
+        /// </summary>
+        /// <returns>An <see cref="IdentityError" /> indicating user lockout is not enabled.</returns>
+        public override IdentityError UserLockoutNotEnabled()
+        {
+            return CreateNamedError(nameof(UserLockoutNotEnabled));
+        }
+
+        /// <summary>
+        /// Returns an <see cref="IdentityError" /> indicating a user is not in the specified <paramref name="role" />.
+        /// </summary>
+        /// <param name="role">The duplicate role.</param>
+        /// <returns>An <see cref="IdentityError" /> indicating a user is not in the specified <paramref name="role" />.</returns>
+        public override IdentityError UserNotInRole(string role)
+        {
+            return CreateNamedError(nameof(UserNotInRole));
+        }
+
+        /// <summary>
+        /// Generates <see cref="IdentityError"/> with <see cref="IdentityError.Code"/> named as <paramref name="name"/>
+        /// And error description which uses <paramref name="name"/> as lookup key for <see cref="IStringLocalizer{T}"/>
+        /// </summary>
+        /// <param name="name"></param>
+        /// <returns>An <see cref="IdentityError"/> that is used in another method return with specific indication for what this error was created</returns>
+        private IdentityError CreateNamedError(string name)
+        {
+            return new IdentityError
+            {
+                Code = name,
+                Description = _stringLocalizer.GetString(name)
+            };
+        }
     }
 }

--- a/src/Skoruba.IdentityServer4.Admin/Resources/Helpers/Identity/IdentityErrorMessages.en.resx
+++ b/src/Skoruba.IdentityServer4.Admin/Resources/Helpers/Identity/IdentityErrorMessages.en.resx
@@ -1,0 +1,228 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="ConcurrencyFailure" xml:space="preserve">
+    <value>Optimistic concurrency failure, object has been modified.</value>
+    <comment>Error when optimistic concurrency fails</comment>
+  </data>
+  <data name="DefaultError" xml:space="preserve">
+    <value>An unknown failure has occurred.</value>
+    <comment>Default identity result error message</comment>
+  </data>
+  <data name="DuplicateEmail" xml:space="preserve">
+    <value>Email '{0}' is already taken.</value>
+    <comment>Error for duplicate emails</comment>
+  </data>
+  <data name="DuplicateRoleName" xml:space="preserve">
+    <value>Role name '{0}' is already taken.</value>
+    <comment>Error for duplicate roles</comment>
+  </data>
+  <data name="DuplicateUserName" xml:space="preserve">
+    <value>User name '{0}' is already taken.</value>
+    <comment>Error for duplicate user names</comment>
+  </data>
+  <data name="InvalidEmail" xml:space="preserve">
+    <value>Email '{0}' is invalid.</value>
+    <comment>Invalid email</comment>
+  </data>
+  <data name="InvalidPasswordHasherCompatibilityMode" xml:space="preserve">
+    <value>The provided PasswordHasherCompatibilityMode is invalid.</value>
+    <comment>Error when the password hasher doesn't understand the format it's being asked to produce.</comment>
+  </data>
+  <data name="InvalidPasswordHasherIterationCount" xml:space="preserve">
+    <value>The iteration count must be a positive integer.</value>
+    <comment>Error when the iteration count is &lt; 1.</comment>
+  </data>
+  <data name="InvalidRoleName" xml:space="preserve">
+    <value>Role name '{0}' is invalid.</value>
+    <comment>Error for invalid role names</comment>
+  </data>
+  <data name="InvalidToken" xml:space="preserve">
+    <value>Invalid token.</value>
+    <comment>Error when a token is not recognized</comment>
+  </data>
+  <data name="InvalidUserName" xml:space="preserve">
+    <value>User name '{0}' is invalid, can only contain letters or digits.</value>
+    <comment>User names can only contain letters or digits</comment>
+  </data>
+  <data name="LoginAlreadyAssociated" xml:space="preserve">
+    <value>A user with this login already exists.</value>
+    <comment>Error when a login already linked</comment>
+  </data>
+  <data name="PasswordMismatch" xml:space="preserve">
+    <value>Incorrect password.</value>
+    <comment>Error when a password doesn't match</comment>
+  </data>
+  <data name="PasswordRequiresDigit" xml:space="preserve">
+    <value>Passwords must have at least one digit ('0'-'9').</value>
+    <comment>Error when passwords do not have a digit</comment>
+  </data>
+  <data name="PasswordRequiresLower" xml:space="preserve">
+    <value>Passwords must have at least one lowercase ('a'-'z').</value>
+    <comment>Error when passwords do not have a lowercase letter</comment>
+  </data>
+  <data name="PasswordRequiresNonAlphanumeric" xml:space="preserve">
+    <value>Passwords must have at least one non alphanumeric character.</value>
+    <comment>Error when password does not have enough non alphanumeric characters</comment>
+  </data>
+  <data name="PasswordRequiresUpper" xml:space="preserve">
+    <value>Passwords must have at least one uppercase ('A'-'Z').</value>
+    <comment>Error when passwords do not have an uppercase letter</comment>
+  </data>
+  <data name="PasswordTooShort" xml:space="preserve">
+    <value>Passwords must be at least {0} characters.</value>
+    <comment>Error message for passwords that are too short</comment>
+  </data>
+  <data name="RoleNotFound" xml:space="preserve">
+    <value>Role {0} does not exist.</value>
+    <comment>Error when a role does not exist</comment>
+  </data>
+  <data name="RecoveryCodeRedemptionFailed" xml:space="preserve">
+    <value>Recovery code redemption failed.</value>
+    <comment>Error when a recovery code is not redeemed.</comment>
+  </data>
+  <data name="UserAlreadyHasPassword" xml:space="preserve">
+    <value>User already has a password set.</value>
+    <comment>Error when AddPasswordAsync called when a user already has a password</comment>
+  </data>
+  <data name="UserAlreadyInRole" xml:space="preserve">
+    <value>User already in role '{0}'.</value>
+    <comment>Error when a user is already in a role</comment>
+  </data>
+  <data name="UserLockedOut" xml:space="preserve">
+    <value>User is locked out.</value>
+    <comment>Error when a user is locked out</comment>
+  </data>
+  <data name="UserLockoutNotEnabled" xml:space="preserve">
+    <value>Lockout is not enabled for this user.</value>
+    <comment>Error when lockout is not enabled</comment>
+  </data>
+  <data name="UserNameNotFound" xml:space="preserve">
+    <value>User {0} does not exist.</value>
+    <comment>Error when a user does not exist</comment>
+  </data>
+  <data name="UserNotInRole" xml:space="preserve">
+    <value>User is not in role '{0}'.</value>
+    <comment>Error when a user is not in the role</comment>
+  </data>
+  <data name="PasswordRequiresUniqueChars" xml:space="preserve">
+    <value>Passwords must use at least {0} different characters.</value>
+    <comment>Error message for passwords that are based on similar characters</comment>
+  </data>
+</root>

--- a/tests/Skoruba.IdentityServer4.Admin.UnitTests/Helpers/IdentityErrorDescriberTestData.cs
+++ b/tests/Skoruba.IdentityServer4.Admin.UnitTests/Helpers/IdentityErrorDescriberTestData.cs
@@ -1,5 +1,4 @@
 ﻿using Skoruba.IdentityServer4.Admin.Helpers.Identity;
-using System;
 using System.Collections;
 using System.Collections.Generic;
 
@@ -66,13 +65,6 @@ namespace Skoruba.IdentityServer4.Admin.UnitTests.Helpers
                 nameof(IdentityErrorMessages.PasswordRequiresLower),
                 nameof(IdentityErrorMessages.PasswordRequiresLower),
                 "PasswordRequiresLowerTranslated"
-            };
-
-            yield return new object[]
-            {
-                nameof(IdentityErrorMessages.PasswordRequiresNonAlphanumeric),
-                nameof(IdentityErrorMessages.PasswordRequiresNonAlphanumeric),
-                "PasswordRequiresNonAlphanumericTranslated"
             };
 
             yield return new object[]

--- a/tests/Skoruba.IdentityServer4.Admin.UnitTests/Helpers/IdentityErrorDescriberTestData.cs
+++ b/tests/Skoruba.IdentityServer4.Admin.UnitTests/Helpers/IdentityErrorDescriberTestData.cs
@@ -1,0 +1,184 @@
+﻿using Skoruba.IdentityServer4.Admin.Helpers.Identity;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Skoruba.IdentityServer4.Admin.UnitTests.Helpers
+{
+    public class IdentityErrorDescriberTestData : IEnumerable<object[]>
+    {
+        public IEnumerator<object[]> GetEnumerator()
+        {
+            #region Parameterless methods
+
+            yield return new object[]
+            {
+                nameof(IdentityErrorMessages.ConcurrencyFailure),
+                nameof(IdentityErrorMessages.ConcurrencyFailure),
+                "ConcurrencyFailureTranslated"
+            };
+
+            yield return new object[]
+            {
+                nameof(IdentityErrorMessages.DefaultError),
+                nameof(IdentityErrorMessages.DefaultError),
+                "DefaultErrorTranslated"
+                };
+
+            yield return new object[]
+            {
+                nameof(IdentityErrorMessages.PasswordRequiresNonAlphanumeric),
+                nameof(IdentityErrorMessages.PasswordRequiresNonAlphanumeric),
+                "PasswordRequiresNonAlphanumericTranslated"
+                };
+
+            yield return new object[]
+            {
+                nameof(IdentityErrorMessages.LoginAlreadyAssociated),
+                nameof(IdentityErrorMessages.LoginAlreadyAssociated),
+                "LoginAlreadyAssociatedTranslated"
+            };
+
+
+            yield return new object[]
+            {
+                nameof(IdentityErrorMessages.InvalidToken),
+                nameof(IdentityErrorMessages.InvalidToken),
+                "InvalidTokenTranslated",
+            };
+
+            yield return new object[]
+            {
+                nameof(IdentityErrorMessages.PasswordMismatch),
+                nameof(IdentityErrorMessages.PasswordMismatch),
+                "PasswordMismatchTranslated"
+            };
+
+            yield return new object[]
+            {
+                nameof(IdentityErrorMessages.PasswordRequiresDigit),
+                nameof(IdentityErrorMessages.PasswordRequiresDigit),
+                "PasswordRequiresDigitTranslated"
+            };
+
+            yield return new object[]
+            {
+                nameof(IdentityErrorMessages.PasswordRequiresLower),
+                nameof(IdentityErrorMessages.PasswordRequiresLower),
+                "PasswordRequiresLowerTranslated"
+            };
+
+            yield return new object[]
+            {
+                nameof(IdentityErrorMessages.PasswordRequiresNonAlphanumeric),
+                nameof(IdentityErrorMessages.PasswordRequiresNonAlphanumeric),
+                "PasswordRequiresNonAlphanumericTranslated"
+            };
+
+            yield return new object[]
+            {
+                nameof(IdentityErrorMessages.RecoveryCodeRedemptionFailed),
+                nameof(IdentityErrorMessages.RecoveryCodeRedemptionFailed),
+                "RecoveryCodeRedemptionFailedTranslated"
+            };
+
+            yield return new object[]
+            {
+                nameof(IdentityErrorMessages.UserAlreadyHasPassword),
+                nameof(IdentityErrorMessages.UserAlreadyHasPassword),
+                "UserAlreadyHasPasswordTranslated"
+            };
+
+            yield return new object[]
+            {
+                nameof(IdentityErrorMessages.UserLockoutNotEnabled),
+                nameof(IdentityErrorMessages.UserLockoutNotEnabled),
+                "UserLockoutNotEnabledTranslated"
+            };
+
+
+            #endregion
+
+            #region Methods with parameters
+
+            yield return new object[]
+            {
+                nameof(IdentityErrorMessages.InvalidEmail),
+                nameof(IdentityErrorMessages.InvalidEmail),
+                "InvalidEmailTranslated",
+                "TestUsername"
+            };
+
+            yield return new object[]
+            {
+                nameof(IdentityErrorMessages.DuplicateUserName),
+                nameof(IdentityErrorMessages.DuplicateUserName),
+                "DuplicateUserNameTranslated",
+                "TestDuplicatedUsername"
+            };
+
+            yield return new object[]
+            {
+                nameof(IdentityErrorMessages.DuplicateRoleName),
+                nameof(IdentityErrorMessages.DuplicateRoleName),
+                "DuplicateRoleNameTranslated",
+                "TestRoleName"
+            };
+
+            yield return new object[]
+            {
+                nameof(IdentityErrorMessages.InvalidRoleName),
+                nameof(IdentityErrorMessages.InvalidRoleName),
+                "InvalidRoleNameTranslated",
+                "InvalidRoleNameTest"
+            };
+
+            yield return new object[]
+            {
+                nameof(IdentityErrorMessages.PasswordTooShort),
+                nameof(IdentityErrorMessages.PasswordTooShort),
+                "PasswordTooShortTranslated",
+                4
+            };
+
+            yield return new object[]
+            {
+                nameof(IdentityErrorMessages.UserAlreadyInRole),
+                nameof(IdentityErrorMessages.UserAlreadyInRole),
+                "UserAlreadyInRoleTranslated",
+                "TestRole"
+            };
+
+            yield return new object[]
+            {
+                nameof(IdentityErrorMessages.UserNotInRole),
+                nameof(IdentityErrorMessages.UserNotInRole),
+                "UserNotInRoleTranslated",
+                "TestRole"
+            };
+
+            yield return new object[]
+            {
+                nameof(IdentityErrorMessages.InvalidUserName),
+                nameof(IdentityErrorMessages.InvalidUserName),
+                "InvalidUsernameTranslated",
+                "TestUsername"
+            };
+
+            yield return new object[]
+            {
+                nameof(IdentityErrorMessages.PasswordRequiresUniqueChars),
+                nameof(IdentityErrorMessages.PasswordRequiresUniqueChars),
+                "PasswordRequiresUniqueCharsTranslated",
+                5
+            };
+
+            #endregion
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+}

--- a/tests/Skoruba.IdentityServer4.Admin.UnitTests/Helpers/IdentityErrorDescriberTestData.cs
+++ b/tests/Skoruba.IdentityServer4.Admin.UnitTests/Helpers/IdentityErrorDescriberTestData.cs
@@ -22,7 +22,7 @@ namespace Skoruba.IdentityServer4.Admin.UnitTests.Helpers
                 nameof(IdentityErrorMessages.DefaultError),
                 nameof(IdentityErrorMessages.DefaultError),
                 "DefaultErrorTranslated"
-                };
+            };
 
             yield return new object[]
             {
@@ -163,6 +163,14 @@ namespace Skoruba.IdentityServer4.Admin.UnitTests.Helpers
                 nameof(IdentityErrorMessages.PasswordRequiresUniqueChars),
                 "PasswordRequiresUniqueCharsTranslated",
                 5
+            };
+
+            yield return new object[]
+            {
+                nameof(IdentityErrorMessages.DuplicateEmail),
+                nameof(IdentityErrorMessages.DuplicateEmail),
+                "DuplicateEmailTranslated",
+                "testduplicateemail@email.com"
             };
 
             #endregion

--- a/tests/Skoruba.IdentityServer4.Admin.UnitTests/Helpers/IdentityErrorDescriberTests.cs
+++ b/tests/Skoruba.IdentityServer4.Admin.UnitTests/Helpers/IdentityErrorDescriberTests.cs
@@ -2,9 +2,6 @@
 using Microsoft.Extensions.Localization;
 using Moq;
 using Skoruba.IdentityServer4.Admin.Helpers.Identity;
-using System;
-using System.Collections.Generic;
-using System.Text;
 using Xunit;
 
 namespace Skoruba.IdentityServer4.Admin.UnitTests.Helpers

--- a/tests/Skoruba.IdentityServer4.Admin.UnitTests/Helpers/IdentityErrorDescriberTests.cs
+++ b/tests/Skoruba.IdentityServer4.Admin.UnitTests/Helpers/IdentityErrorDescriberTests.cs
@@ -1,0 +1,39 @@
+﻿using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Localization;
+using Moq;
+using Skoruba.IdentityServer4.Admin.Helpers.Identity;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+
+namespace Skoruba.IdentityServer4.Admin.UnitTests.Helpers
+{
+    public class IdentityErrorDescriberTests
+    {
+        [Theory]
+        [ClassData(typeof(IdentityErrorDescriberTestData))]
+        public void TranslationTests(string key, string methodName, string translated, params object[] args)
+        {
+
+            // Arrange
+            var localizer = new Mock<IStringLocalizer<IdentityErrorMessages>>();
+
+            // GetString extension method uses indexer underneath
+            localizer.Setup(x => x[key])
+                .Returns(new LocalizedString(key, translated));
+
+            var describer = new IdentityErrorMessages(localizer.Object);
+
+            // Act
+            var methodInfo = typeof(IdentityErrorMessages).GetMethod(methodName); // get method name dynamically
+            var error = methodInfo.Invoke(describer, args) as IdentityError; // invoke method on our instance
+
+            // Assert
+            Assert.IsType<IdentityError>(error);
+
+            Assert.Equal(translated, error.Description);
+            Assert.Equal(key, error.Code);
+        }
+    }
+}


### PR DESCRIPTION
@skoruba 

A simple implementation of ASP.NET Core Identity translation via inbuilt IStringLocalizer.
I have already used these in several projects.


I can add another layer of abstraction (for example IIdentityLocalizer/IIdentityErrorMessageLocalizer) so consumers can implement it independently, and pull that out into  
_(namespacebefore).AspNetCore.Identity.Localization_

Opens up multiple implementations not coupled to ASP.NET Core localization implementation.
It may be reinventing wheel, though it's quite easy thing to do. 


What's your opinion about this? :)