### PR TITLE
WIP: Kubernetes setup on docker-for-desktop

### DIFF
--- a/k8s/identity.admin.yml
+++ b/k8s/identity.admin.yml
@@ -1,0 +1,100 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    system: identityadmin-demo
+    app: identity-admin
+    version: "1.0"
+  name: identity-admin
+  namespace: identityadmin-demo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      system: identityadmin-demo
+      app: identity-admin
+  template:
+    metadata:
+      labels:
+        system: identityadmin-demo
+        app: identity-admin
+        version: "1.0"
+    spec:
+      containers:
+
+      - env:
+        - name: ASPNETCORE_ENVIRONMENT
+          value: Development
+        - name: ConnectionStrings__ConfigurationDbConnection
+          value: Server=sqlserver;Database=IdentityServer4Admin;User Id=sa;Password=Password_123;MultipleActiveResultSets=true
+        - name: ConnectionStrings__PersistedGrantDbConnection
+          value: Server=sqlserver;Database=IdentityServer4Admin;User Id=sa;Password=Password_123;MultipleActiveResultSets=true
+        - name: ConnectionStrings__IdentityDbConnection
+          value: Server=sqlserver;Database=IdentityServer4Admin;User Id=sa;Password=Password_123;MultipleActiveResultSets=true
+        - name: ConnectionStrings__AdminLogDbConnection
+          value: Server=sqlserver;Database=IdentityServer4Admin;User Id=sa;Password=Password_123;MultipleActiveResultSets=true
+        - name: ConnectionStrings__AdminAuditLogDbConnection
+          value: Server=sqlserver;Database=IdentityServer4Admin;User Id=sa;Password=Password_123;MultipleActiveResultSets=true
+        - name: AdminConfiguration__IdentityAdminBaseUrl
+          value: http://identityadmin.k8s.local:9000
+        - name: AdminConfiguration__IdentityAdminRedirectUri
+          value: http://identityadmin.k8s.local:9000/signin-oidc
+        - name: AdminConfiguration__IdentityServerBaseUrl
+          value: http://identityadmin.k8s.local
+        - name: AdminConfiguration__RequireHttpsMetadata
+          value: "false"
+        - name: IdentityServerData__Clients__0__ClientUri
+          value: http://identityadmin.k8s.local:9000
+        - name: IdentityServerData__Clients__0__RedirectUris__0
+          value: http://identityadmin.k8s.local:9000/signin-oidc
+        - name: IdentityServerData__Clients__0__FrontChannelLogoutUri
+          value: http://identityadmin.k8s.local:9000/signin-oidc
+        - name: IdentityServerData__Clients__0__PostLogoutRedirectUris__0
+          value: http://identityadmin.k8s.local:9000/signout-callback-oidc
+        - name: IdentityServerData__Clients__0__AllowedCorsOrigins__0
+          value: http://identityadmin.k8s.local:9000
+        - name: IdentityServerData__Clients__1__RedirectUris__0
+          value: http://identityadmin.k8s.local:5000/swagger/oauth2-redirect.html
+        - name: Serilog__WriteTo__1__Args__connectionString
+          value: Server=sqlserver;Database=IdentityServer4Admin;User Id=sa;Password=Password_123;MultipleActiveResultSets=true
+        - name: Serilog__MinimumLevel__Default
+          value: Information
+        image: skorubaidentityserver4admin:latest
+        command: ["dotnet"]
+        args: ["Skoruba.IdentityServer4.Admin.dll", "/seed"]
+        imagePullPolicy: IfNotPresent
+        name: identity-admin
+        ports:
+        - name: http
+          containerPort: 80
+        resources:
+          requests:
+            memory: "200Mi"
+            cpu: "250m"
+          limits:
+            memory: "250Mi"
+            cpu: "500m"
+      dnsPolicy: ClusterFirstWithHostNet
+      imagePullSecrets:
+      - name: regcred
+      restartPolicy: Always
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    system: identityadmin-demo
+    app: identity-admin
+    version: v1
+  name: identity-admin
+  namespace: identityadmin-demo
+spec:
+  type: LoadBalancer
+  ports:
+  - name: http
+    port: 9000
+    protocol: TCP
+    targetPort: 80
+  selector:
+    app: identity-admin

--- a/k8s/identity.api.yml
+++ b/k8s/identity.api.yml
@@ -1,0 +1,80 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    system: identityadmin-demo
+    app: identity-api
+    version: "1.0"
+  name: identity-api
+  namespace: identityadmin-demo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      system: identityadmin-demo
+      app: identity-api
+  template:
+    metadata:
+      labels:
+        system: identityadmin-demo
+        app: identity-api
+        version: "1.0"
+    spec:
+      containers:
+      - env:
+        - name: ASPNETCORE_ENVIRONMENT
+          value: Development
+        - name: Serilog__MinimumLevel__Default
+          value: Information
+        - name: AdminApiConfiguration__RequireHttpsMetadata
+          value: "false"
+        - name: AdminApiConfiguration__IdentityServerBaseUrl
+          value: http://identityadmin.k8s.local
+        - name: AdminApiConfiguration__ApiBaseUrl
+          value: http://identityadmin.k8s.local:5000
+        - name: ConnectionStrings__ConfigurationDbConnection
+          value: Server=db;Database=IdentityServer4Admin;User Id=sa;Password=Password_123;MultipleActiveResultSets=true
+        - name: ConnectionStrings__PersistedGrantDbConnection
+          value: Server=db;Database=IdentityServer4Admin;User Id=sa;Password=Password_123;MultipleActiveResultSets=true
+        - name: ConnectionStrings__IdentityDbConnection
+          value: Server=db;Database=IdentityServer4Admin;User Id=sa;Password=Password_123;MultipleActiveResultSets=true
+        - name: ConnectionStrings__AdminLogDbConnection
+          value: Server=db;Database=IdentityServer4Admin;User Id=sa;Password=Password_123;MultipleActiveResultSets=true
+        - name: ConnectionStrings__AdminAuditLogDbConnection
+          value: Server=db;Database=IdentityServer4Admin;User Id=sa;Password=Password_123;MultipleActiveResultSets=true
+        image: skorubaidentityserver4adminapi:latest
+        imagePullPolicy: IfNotPresent
+        name: identity-api
+        ports:
+        - name: http
+          containerPort: 80
+        resources:
+          requests:
+            memory: "200Mi"
+            cpu: "250m"
+          limits:
+            memory: "250Mi"
+            cpu: "500m"
+      imagePullSecrets:
+      - name: regcred
+      restartPolicy: Always
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    system: identityadmin-demo
+    app: identity-api
+    version: v1
+  name: identity-api
+  namespace: identityadmin-demo
+spec:
+  type: LoadBalancer
+  ports:
+  - name: http
+    port: 5000
+    protocol: TCP
+    targetPort: 80
+  selector:
+    app: identity-api

--- a/k8s/identity.sts.yml
+++ b/k8s/identity.sts.yml
@@ -1,0 +1,72 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    system: identityadmin-demo
+    app: identity-sts
+    version: "1.0"
+  name: identity-sts
+  namespace: identityadmin-demo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      system: identityadmin-demo
+      app: identity-sts
+  template:
+    metadata:
+      labels:
+        system: identityadmin-demo
+        app: identity-sts
+        version: "1.0"
+    spec:
+      containers:
+      - env:
+        - name: ASPNETCORE_ENVIRONMENT
+          value: Development
+        - name: ConnectionStrings__ConfigurationDbConnection
+          value: Server=sqlserver;Database=IdentityServer4Admin;User Id=sa;Password=Password_123;MultipleActiveResultSets=true
+        - name: ConnectionStrings__PersistedGrantDbConnection
+          value: Server=sqlserver;Database=IdentityServer4Admin;User Id=sa;Password=Password_123;MultipleActiveResultSets=true
+        - name: ConnectionStrings__IdentityDbConnection
+          value: Server=sqlserver;Database=IdentityServer4Admin;User Id=sa;Password=Password_123;MultipleActiveResultSets=true
+        - name: AdminConfiguration__IdentityAdminBaseUrl
+          value: http://identityadmin.k8s.local:9000
+        - name: Serilog__MinimumLevel__Default
+          value: Information
+        image: skorubaidentityserver4stsidentity:latest
+        imagePullPolicy: IfNotPresent
+        name: identity-sts
+        ports:
+        - name: http
+          containerPort: 80
+        resources:
+          requests:
+            memory: "200Mi"
+            cpu: "250m"
+          limits:
+            memory: "250Mi"
+            cpu: "500m"
+      imagePullSecrets:
+      - name: regcred
+      restartPolicy: Always
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    system: identityadmin-demo
+    app: identity-sts
+    version: v1
+  name: identity-sts
+  namespace: identityadmin-demo
+spec:
+  type: LoadBalancer
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 80
+  selector:
+    app: identity-sts

--- a/k8s/metallb.yml
+++ b/k8s/metallb.yml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: metallb-system
+  name: config
+data:
+  config: |
+    address-pools:
+    - name: my-ip-space
+      protocol: layer2
+      addresses:
+      - 127.0.0.240/28

--- a/k8s/namespace.yml
+++ b/k8s/namespace.yml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: identityadmin-demo

--- a/k8s/readme.md
+++ b/k8s/readme.md
@@ -1,0 +1,5 @@
+# Install on docker-for-windows
+
+```bash
+kubectl apply -f https://raw.githubusercontent.com/google/metallb/v0.8.3/manifests/metallb.yaml
+```

--- a/k8s/sqlserver.yml
+++ b/k8s/sqlserver.yml
@@ -1,0 +1,68 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    system: identityadmin-demo
+    app: sqlserver
+    version: v1
+  name: sqlserver
+  namespace: identityadmin-demo
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      system: identityadmin-demo
+      app: sqlserver
+  template:
+    metadata:
+      labels:
+        system: identityadmin-demo
+        app: sqlserver
+        version: v1
+    spec:
+      containers:
+      - env:
+        - name: ACCEPT_EULA
+          value: "Y"
+        - name: MSSQL_PID
+          value: Developer
+        - name: SA_PASSWORD
+          value: Password_123
+        image: microsoft/mssql-server-linux:latest
+        imagePullPolicy: IfNotPresent
+        name: sqlserver
+        resources:
+          requests:
+            memory: "500Mi"
+            cpu: "250m"
+          limits:
+            memory: "1Gi"
+            cpu: "500m"
+        ports:
+        - containerPort: 1433
+      restartPolicy: Always
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    system: identityadmin-demo
+    app: sqlserver
+    version: v1
+  name: sqlserver
+  namespace: identityadmin-demo
+spec:
+  type: NodePort
+  ports:
+  - name: "tds"
+    port: 1433
+    targetPort: 1433
+    nodePort: 30000
+  selector:
+    system: identityadmin-demo
+    app: sqlserver
+    version: v1


### PR DESCRIPTION
While still a work in progress, the current yml files will allow running the docker images on the single-node cluster on docker-for-desktop on Windows. It hasn't been tested on MacOS 
You will need to edit your hosts file adding `identityadmin.k8s.local` to point to the IP of the machine running the cluster. The shortcut we took in `docker-compose` will not work on k8s as DNS resolving needs to happen at a different level. 
I also added metallb to allow k8s to pass out external IP addresses all pointing at localhost. This should allow load balancing in future scenarios (by adding extra replicas).

This configuration is for dev usage only. Do NOT use it on production!! 
Missing features are: 
1. TLS support
2. Volume claims (to persist the data of sql server between reboots)
3. Configure the different services with config maps instead env variables
4. Store the database credentials in a k8s Secret. 

We need to package the docker images and store them in a packages registry. Github offers this already, but we're not using that yet, so you will need to build the docker images manually. You can use `docker-compose build` to do so.

Prerequisites:
1. install Docker-for-desktop on windows
2. Enable Kubernetes in Docker-for-desktop in the settings
3. Have `kubectl` installed, ready from the command line.
4. Make sure you kubectl context is pointing to your local kubernetes environment. If you have no other k8s clusters, that should already be the case. 

How to run:
1. Edit your host file as mentioned above. Add the following line in your `C:\Windows\System32\drivers\etc\hosts` file: `<Your IP Address> identityadmin.k8s.local`
2. Run the following commands
```
cd k8s
kubectl apply -f ./namespace.yml
kubectl apply -f https://raw.githubusercontent.com/google/metallb/v0.8.3/manifests/metallb.yaml
kubectl apply -f ./metallb.yml
kubectl apply -f ./sqlserver.yml
kubectl apply -f ./identity.admin.yml
kubectl apply -f ./identity.sts.yml
kubectl apply -f ./identity.api.yml
```    

I might have missed a couple of things, so if someone could test this out on their machine, that'd be great.