### PR TITLE
fix defaultscheme in api

### DIFF
--- a/src/Skoruba.IdentityServer4.Admin.Api/Configuration/Test/StartupTest.cs
+++ b/src/Skoruba.IdentityServer4.Admin.Api/Configuration/Test/StartupTest.cs
@@ -29,7 +29,11 @@ namespace Skoruba.IdentityServer4.Admin.Api.Configuration.Test
                 .AddEntityFrameworkStores<AdminIdentityDbContext>()
                 .AddDefaultTokenProviders();
 
-            services.AddAuthentication(IdentityServerAuthenticationDefaults.AuthenticationScheme)
+            services.AddAuthentication(options =>
+            {
+            options.DefaultAuthenticateScheme = IdentityServerAuthenticationDefaults.AuthenticationScheme;
+            options.DefaultChallengeScheme = IdentityServerAuthenticationDefaults.AuthenticationScheme;
+            )
                 .AddCookie(IdentityServerAuthenticationDefaults.AuthenticationScheme);
         }
 

--- a/src/Skoruba.IdentityServer4.Admin.Api/Configuration/Test/StartupTest.cs
+++ b/src/Skoruba.IdentityServer4.Admin.Api/Configuration/Test/StartupTest.cs
@@ -31,8 +31,9 @@ namespace Skoruba.IdentityServer4.Admin.Api.Configuration.Test
 
             services.AddAuthentication(options =>
             {
-            options.DefaultAuthenticateScheme = IdentityServerAuthenticationDefaults.AuthenticationScheme;
-            options.DefaultChallengeScheme = IdentityServerAuthenticationDefaults.AuthenticationScheme;
+                options.DefaultAuthenticateScheme = IdentityServerAuthenticationDefaults.AuthenticationScheme;
+                options.DefaultChallengeScheme = IdentityServerAuthenticationDefaults.AuthenticationScheme;
+            }
             )
                 .AddCookie(IdentityServerAuthenticationDefaults.AuthenticationScheme);
         }

--- a/src/Skoruba.IdentityServer4.Admin.Api/Helpers/StartupHelpers.cs
+++ b/src/Skoruba.IdentityServer4.Admin.Api/Helpers/StartupHelpers.cs
@@ -138,7 +138,7 @@ namespace Skoruba.IdentityServer4.Admin.Api.Helpers
             where TAuditLoggingDbContext : DbContext, IAuditLoggingDbContext<AuditLog>
         {
             var databaseProvider = configuration.GetSection(nameof(DatabaseProviderConfiguration)).Get<DatabaseProviderConfiguration>();
-            
+
             var identityConnectionString = configuration.GetConnectionString(ConfigurationConsts.IdentityDbConnectionStringKey);
             var configurationConnectionString = configuration.GetConnectionString(ConfigurationConsts.ConfigurationDbConnectionStringKey);
             var persistedGrantsConnectionString = configuration.GetConnectionString(ConfigurationConsts.PersistedGrantDbConnectionStringKey);
@@ -175,7 +175,11 @@ namespace Skoruba.IdentityServer4.Admin.Api.Helpers
             where TRole : class
             where TUser : class
         {
-            services.AddAuthentication(IdentityServerAuthenticationDefaults.AuthenticationScheme)
+            services.AddAuthentication(options =>
+            {
+                options.DefaultAuthenticateScheme = IdentityServerAuthenticationDefaults.AuthenticationScheme;
+                options.DefaultChallengeScheme = IdentityServerAuthenticationDefaults.AuthenticationScheme;
+            })
                 .AddIdentityServerAuthentication(options =>
                 {
                     options.Authority = adminApiConfiguration.IdentityServerBaseUrl;

--- a/templates/template-publish/content/src/SkorubaIdentityServer4Admin.Admin.Api/Helpers/StartupHelpers.cs
+++ b/templates/template-publish/content/src/SkorubaIdentityServer4Admin.Admin.Api/Helpers/StartupHelpers.cs
@@ -175,7 +175,11 @@ namespace SkorubaIdentityServer4Admin.Admin.Api.Helpers
             where TRole : class
             where TUser : class
         {
-            services.AddAuthentication(IdentityServerAuthenticationDefaults.AuthenticationScheme)
+            services.AddAuthentication(options =>
+            {
+            options.DefaultAuthenticateScheme = IdentityServerAuthenticationDefaults.AuthenticationScheme;
+            options.DefaultChallengeScheme = IdentityServerAuthenticationDefaults.AuthenticationScheme;
+            )
                 .AddIdentityServerAuthentication(options =>
                 {
                     options.Authority = adminApiConfiguration.IdentityServerBaseUrl;

--- a/templates/template-publish/content/src/SkorubaIdentityServer4Admin.Admin.Api/Helpers/StartupHelpers.cs
+++ b/templates/template-publish/content/src/SkorubaIdentityServer4Admin.Admin.Api/Helpers/StartupHelpers.cs
@@ -138,7 +138,7 @@ namespace SkorubaIdentityServer4Admin.Admin.Api.Helpers
             where TAuditLoggingDbContext : DbContext, IAuditLoggingDbContext<AuditLog>
         {
             var databaseProvider = configuration.GetSection(nameof(DatabaseProviderConfiguration)).Get<DatabaseProviderConfiguration>();
-            
+
             var identityConnectionString = configuration.GetConnectionString(ConfigurationConsts.IdentityDbConnectionStringKey);
             var configurationConnectionString = configuration.GetConnectionString(ConfigurationConsts.ConfigurationDbConnectionStringKey);
             var persistedGrantsConnectionString = configuration.GetConnectionString(ConfigurationConsts.PersistedGrantDbConnectionStringKey);
@@ -177,8 +177,9 @@ namespace SkorubaIdentityServer4Admin.Admin.Api.Helpers
         {
             services.AddAuthentication(options =>
             {
-            options.DefaultAuthenticateScheme = IdentityServerAuthenticationDefaults.AuthenticationScheme;
-            options.DefaultChallengeScheme = IdentityServerAuthenticationDefaults.AuthenticationScheme;
+                options.DefaultAuthenticateScheme = IdentityServerAuthenticationDefaults.AuthenticationScheme;
+                options.DefaultChallengeScheme = IdentityServerAuthenticationDefaults.AuthenticationScheme;
+            }
             )
                 .AddIdentityServerAuthentication(options =>
                 {


### PR DESCRIPTION
closes #455
The problem was in `services.AddAuthentication` and defaultScheme.
Resolved by changing default scheme definition:
``` cs
services.AddAuthentication(options =>
            {
                options.DefaultAuthenticateScheme = IdentityServerAuthenticationDefaults.AuthenticationScheme;
                options.DefaultChallengeScheme = IdentityServerAuthenticationDefaults.AuthenticationScheme;
            }
            
```
