### PR TITLE
Admin configuration builder

### DIFF
--- a/src/Skoruba.IdentityServer4.Admin.Api/Configuration/ApplicationParts/GenericTypeControllerFeatureProvider.cs
+++ b/src/Skoruba.IdentityServer4.Admin.Api/Configuration/ApplicationParts/GenericTypeControllerFeatureProvider.cs
@@ -10,7 +10,7 @@ using Skoruba.IdentityServer4.Admin.BusinessLogic.Identity.Dtos.Identity;
 
 namespace Skoruba.IdentityServer4.Admin.Api.Configuration.ApplicationParts
 {
-    public class GenericTypeControllerFeatureProvider<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUserKey, TRoleKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
+    public class GenericTypeControllerFeatureProvider<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
         TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
         TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto> : IApplicationFeatureProvider<ControllerFeature>
         where TUserDto : UserDto<TUserDtoKey>, new()
@@ -36,7 +36,7 @@ namespace Skoruba.IdentityServer4.Admin.Api.Configuration.ApplicationParts
     {
         public void PopulateFeature(IEnumerable<ApplicationPart> parts, ControllerFeature feature)
         {
-            var currentAssembly = typeof(GenericTypeControllerFeatureProvider<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUserKey, TRoleKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
+            var currentAssembly = typeof(GenericTypeControllerFeatureProvider<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
                 TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
                 TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto>).Assembly;
             var controllerTypes = currentAssembly.GetExportedTypes()

--- a/src/Skoruba.IdentityServer4.Admin.Api/Configuration/ApplicationParts/GenericTypeControllerFeatureProvider.cs
+++ b/src/Skoruba.IdentityServer4.Admin.Api/Configuration/ApplicationParts/GenericTypeControllerFeatureProvider.cs
@@ -10,11 +10,11 @@ using Skoruba.IdentityServer4.Admin.BusinessLogic.Identity.Dtos.Identity;
 
 namespace Skoruba.IdentityServer4.Admin.Api.Configuration.ApplicationParts
 {
-    public class GenericTypeControllerFeatureProvider<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
+    public class GenericTypeControllerFeatureProvider<TUserDto, TRoleDto, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
         TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
         TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto> : IApplicationFeatureProvider<ControllerFeature>
-        where TUserDto : UserDto<TUserDtoKey>, new()
-        where TRoleDto : RoleDto<TRoleDtoKey>, new()
+        where TUserDto : UserDto<TKey>, new()
+        where TRoleDto : RoleDto<TKey>, new()
         where TUser : IdentityUser<TKey>
         where TRole : IdentityRole<TKey>
         where TKey : IEquatable<TKey>
@@ -23,20 +23,20 @@ namespace Skoruba.IdentityServer4.Admin.Api.Configuration.ApplicationParts
         where TUserLogin : IdentityUserLogin<TKey>
         where TRoleClaim : IdentityRoleClaim<TKey>
         where TUserToken : IdentityUserToken<TKey>
-        where TRoleDtoKey : IEquatable<TRoleDtoKey>
-        where TUserDtoKey : IEquatable<TUserDtoKey>
-        where TUsersDto : UsersDto<TUserDto, TUserDtoKey>
-        where TRolesDto : RolesDto<TRoleDto, TRoleDtoKey>
-        where TUserRolesDto : UserRolesDto<TRoleDto, TUserDtoKey, TRoleDtoKey>
-        where TUserClaimsDto : UserClaimsDto<TUserDtoKey>
-        where TUserProviderDto : UserProviderDto<TUserDtoKey>
-        where TUserProvidersDto : UserProvidersDto<TUserDtoKey>
-        where TUserChangePasswordDto : UserChangePasswordDto<TUserDtoKey>
-        where TRoleClaimsDto : RoleClaimsDto<TRoleDtoKey>
+
+
+        where TUsersDto : UsersDto<TUserDto, TKey>
+        where TRolesDto : RolesDto<TRoleDto, TKey>
+        where TUserRolesDto : UserRolesDto<TRoleDto, TKey>
+        where TUserClaimsDto : UserClaimsDto<TKey>
+        where TUserProviderDto : UserProviderDto<TKey>
+        where TUserProvidersDto : UserProvidersDto<TKey>
+        where TUserChangePasswordDto : UserChangePasswordDto<TKey>
+        where TRoleClaimsDto : RoleClaimsDto<TKey>
     {
         public void PopulateFeature(IEnumerable<ApplicationPart> parts, ControllerFeature feature)
         {
-            var currentAssembly = typeof(GenericTypeControllerFeatureProvider<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
+            var currentAssembly = typeof(GenericTypeControllerFeatureProvider<TUserDto, TRoleDto, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
                 TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
                 TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto>).Assembly;
             var controllerTypes = currentAssembly.GetExportedTypes()

--- a/src/Skoruba.IdentityServer4.Admin.Api/Controllers/RolesController.cs
+++ b/src/Skoruba.IdentityServer4.Admin.Api/Controllers/RolesController.cs
@@ -21,7 +21,7 @@ namespace Skoruba.IdentityServer4.Admin.Api.Controllers
     [TypeFilter(typeof(ControllerExceptionFilterAttribute))]
     [Produces("application/json", "application/problem+json")]
     [Authorize(Policy = AuthorizationConsts.AdministrationPolicy)]
-    public class RolesController<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUserKey, TRoleKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
+    public class RolesController<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
             TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
             TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto> : ControllerBase
         where TUserDto : UserDto<TUserDtoKey>, new()
@@ -45,20 +45,20 @@ namespace Skoruba.IdentityServer4.Admin.Api.Controllers
         where TUserChangePasswordDto : UserChangePasswordDto<TUserDtoKey>
         where TRoleClaimsDto : RoleClaimsDto<TRoleDtoKey>, new()
     {
-        private readonly IIdentityService<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUserKey, TRoleKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
+        private readonly IIdentityService<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
             TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
             TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto> _identityService;
-        private readonly IGenericControllerLocalizer<UsersController<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUserKey, TRoleKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
+        private readonly IGenericControllerLocalizer<UsersController<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
             TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
             TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto>> _localizer;
 
         private readonly IMapper _mapper;
         private readonly IApiErrorResources _errorResources;
 
-        public RolesController(IIdentityService<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUserKey, TRoleKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
+        public RolesController(IIdentityService<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
                 TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
                 TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto> identityService,
-            IGenericControllerLocalizer<UsersController<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUserKey, TRoleKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
+            IGenericControllerLocalizer<UsersController<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
                 TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
                 TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto>> localizer, IMapper mapper, IApiErrorResources errorResources)
         {

--- a/src/Skoruba.IdentityServer4.Admin.Api/Controllers/RolesController.cs
+++ b/src/Skoruba.IdentityServer4.Admin.Api/Controllers/RolesController.cs
@@ -21,11 +21,11 @@ namespace Skoruba.IdentityServer4.Admin.Api.Controllers
     [TypeFilter(typeof(ControllerExceptionFilterAttribute))]
     [Produces("application/json", "application/problem+json")]
     [Authorize(Policy = AuthorizationConsts.AdministrationPolicy)]
-    public class RolesController<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
+    public class RolesController<TUserDto, TRoleDto, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
             TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
             TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto> : ControllerBase
-        where TUserDto : UserDto<TUserDtoKey>, new()
-        where TRoleDto : RoleDto<TRoleDtoKey>, new()
+        where TUserDto : UserDto<TKey>, new()
+        where TRoleDto : RoleDto<TKey>, new()
         where TUser : IdentityUser<TKey>
         where TRole : IdentityRole<TKey>
         where TKey : IEquatable<TKey>
@@ -34,31 +34,31 @@ namespace Skoruba.IdentityServer4.Admin.Api.Controllers
         where TUserLogin : IdentityUserLogin<TKey>
         where TRoleClaim : IdentityRoleClaim<TKey>
         where TUserToken : IdentityUserToken<TKey>
-        where TRoleDtoKey : IEquatable<TRoleDtoKey>
-        where TUserDtoKey : IEquatable<TUserDtoKey>
-        where TUsersDto : UsersDto<TUserDto, TUserDtoKey>
-        where TRolesDto : RolesDto<TRoleDto, TRoleDtoKey>
-        where TUserRolesDto : UserRolesDto<TRoleDto, TUserDtoKey, TRoleDtoKey>
-        where TUserClaimsDto : UserClaimsDto<TUserDtoKey>, new()
-        where TUserProviderDto : UserProviderDto<TUserDtoKey>
-        where TUserProvidersDto : UserProvidersDto<TUserDtoKey>
-        where TUserChangePasswordDto : UserChangePasswordDto<TUserDtoKey>
-        where TRoleClaimsDto : RoleClaimsDto<TRoleDtoKey>, new()
+
+
+        where TUsersDto : UsersDto<TUserDto, TKey>
+        where TRolesDto : RolesDto<TRoleDto, TKey>
+        where TUserRolesDto : UserRolesDto<TRoleDto, TKey>
+        where TUserClaimsDto : UserClaimsDto<TKey>, new()
+        where TUserProviderDto : UserProviderDto<TKey>
+        where TUserProvidersDto : UserProvidersDto<TKey>
+        where TUserChangePasswordDto : UserChangePasswordDto<TKey>
+        where TRoleClaimsDto : RoleClaimsDto<TKey>, new()
     {
-        private readonly IIdentityService<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
+        private readonly IIdentityService<TUserDto, TRoleDto, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
             TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
             TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto> _identityService;
-        private readonly IGenericControllerLocalizer<UsersController<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
+        private readonly IGenericControllerLocalizer<UsersController<TUserDto, TRoleDto, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
             TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
             TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto>> _localizer;
 
         private readonly IMapper _mapper;
         private readonly IApiErrorResources _errorResources;
 
-        public RolesController(IIdentityService<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
+        public RolesController(IIdentityService<TUserDto, TRoleDto, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
                 TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
                 TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto> identityService,
-            IGenericControllerLocalizer<UsersController<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
+            IGenericControllerLocalizer<UsersController<TUserDto, TRoleDto, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
                 TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
                 TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto>> localizer, IMapper mapper, IApiErrorResources errorResources)
         {
@@ -69,7 +69,7 @@ namespace Skoruba.IdentityServer4.Admin.Api.Controllers
         }
 
         [HttpGet("{id}")]
-        public async Task<ActionResult<TRoleDto>> Get(TUserDtoKey id)
+        public async Task<ActionResult<TRoleDto>> Get(TKey id)
         {
             var role = await _identityService.GetRoleAsync(id.ToString());
 
@@ -89,7 +89,7 @@ namespace Skoruba.IdentityServer4.Admin.Api.Controllers
         [ProducesResponseType(400)]
         public async Task<ActionResult<TRoleDto>> Post([FromBody]TRoleDto role)
         {
-            if (!EqualityComparer<TRoleDtoKey>.Default.Equals(role.Id, default))
+            if (!EqualityComparer<TKey>.Default.Equals(role.Id, default))
             {
                 return BadRequest(_errorResources.CannotSetId());
             }
@@ -110,7 +110,7 @@ namespace Skoruba.IdentityServer4.Admin.Api.Controllers
         }
 
         [HttpDelete("{id}")]
-        public async Task<IActionResult> Delete(TRoleDtoKey id)
+        public async Task<IActionResult> Delete(TKey id)
         {
             var roleDto = new TRoleDto { Id = id };
 
@@ -129,16 +129,16 @@ namespace Skoruba.IdentityServer4.Admin.Api.Controllers
         }
 
         [HttpGet("{id}/Claims")]
-        public async Task<ActionResult<RoleClaimsApiDto<TRoleDtoKey>>> GetRoleClaims(string id, int page = 1, int pageSize = 10)
+        public async Task<ActionResult<RoleClaimsApiDto<TKey>>> GetRoleClaims(string id, int page = 1, int pageSize = 10)
         {
             var roleClaimsDto = await _identityService.GetRoleClaimsAsync(id, page, pageSize);
-            var roleClaimsApiDto = _mapper.Map<RoleClaimsApiDto<TRoleDtoKey>>(roleClaimsDto);
+            var roleClaimsApiDto = _mapper.Map<RoleClaimsApiDto<TKey>>(roleClaimsDto);
 
             return Ok(roleClaimsApiDto);
         }
 
         [HttpPost("Claims")]
-        public async Task<IActionResult> PostRoleClaims([FromBody]RoleClaimApiDto<TRoleDtoKey> roleClaims)
+        public async Task<IActionResult> PostRoleClaims([FromBody]RoleClaimApiDto<TKey> roleClaims)
         {
             var roleClaimsDto = _mapper.Map<TRoleClaimsDto>(roleClaims);
 
@@ -153,7 +153,7 @@ namespace Skoruba.IdentityServer4.Admin.Api.Controllers
         }
 
         [HttpDelete("{id}/Claims")]
-        public async Task<IActionResult> DeleteRoleClaims(TRoleDtoKey id, int claimId)
+        public async Task<IActionResult> DeleteRoleClaims(TKey id, int claimId)
         {
             var roleDto = new TRoleClaimsDto { ClaimId = claimId, RoleId = id };
 

--- a/src/Skoruba.IdentityServer4.Admin.Api/Controllers/UsersController.cs
+++ b/src/Skoruba.IdentityServer4.Admin.Api/Controllers/UsersController.cs
@@ -23,11 +23,11 @@ namespace Skoruba.IdentityServer4.Admin.Api.Controllers
     [TypeFilter(typeof(ControllerExceptionFilterAttribute))]
     [Produces("application/json", "application/problem+json")]
     [Authorize(Policy = AuthorizationConsts.AdministrationPolicy)]
-    public class UsersController<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
+    public class UsersController<TUserDto, TRoleDto, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
             TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
             TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto> : ControllerBase
-        where TUserDto : UserDto<TUserDtoKey>, new()
-        where TRoleDto : RoleDto<TRoleDtoKey>, new()
+        where TUserDto : UserDto<TKey>, new()
+        where TRoleDto : RoleDto<TKey>, new()
         where TUser : IdentityUser<TKey>
         where TRole : IdentityRole<TKey>
         where TKey : IEquatable<TKey>
@@ -36,31 +36,29 @@ namespace Skoruba.IdentityServer4.Admin.Api.Controllers
         where TUserLogin : IdentityUserLogin<TKey>
         where TRoleClaim : IdentityRoleClaim<TKey>
         where TUserToken : IdentityUserToken<TKey>
-        where TRoleDtoKey : IEquatable<TRoleDtoKey>
-        where TUserDtoKey : IEquatable<TUserDtoKey>
-        where TUsersDto : UsersDto<TUserDto, TUserDtoKey>
-        where TRolesDto : RolesDto<TRoleDto, TRoleDtoKey>
-        where TUserRolesDto : UserRolesDto<TRoleDto, TUserDtoKey, TRoleDtoKey>
-        where TUserClaimsDto : UserClaimsDto<TUserDtoKey>, new()
-        where TUserProviderDto : UserProviderDto<TUserDtoKey>
-        where TUserProvidersDto : UserProvidersDto<TUserDtoKey>
-        where TUserChangePasswordDto : UserChangePasswordDto<TUserDtoKey>
-        where TRoleClaimsDto : RoleClaimsDto<TRoleDtoKey>
+        where TUsersDto : UsersDto<TUserDto, TKey>
+        where TRolesDto : RolesDto<TRoleDto, TKey>
+        where TUserRolesDto : UserRolesDto<TRoleDto, TKey>
+        where TUserClaimsDto : UserClaimsDto<TKey>, new()
+        where TUserProviderDto : UserProviderDto<TKey>
+        where TUserProvidersDto : UserProvidersDto<TKey>
+        where TUserChangePasswordDto : UserChangePasswordDto<TKey>
+        where TRoleClaimsDto : RoleClaimsDto<TKey>
     {
-        private readonly IIdentityService<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
+        private readonly IIdentityService<TUserDto, TRoleDto, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
             TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
             TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto> _identityService;
-        private readonly IGenericControllerLocalizer<UsersController<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
+        private readonly IGenericControllerLocalizer<UsersController<TUserDto, TRoleDto, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
             TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
             TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto>> _localizer;
 
         private readonly IMapper _mapper;
         private readonly IApiErrorResources _errorResources;
 
-        public UsersController(IIdentityService<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
+        public UsersController(IIdentityService<TUserDto, TRoleDto, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
                 TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
                 TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto> identityService,
-            IGenericControllerLocalizer<UsersController<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
+            IGenericControllerLocalizer<UsersController<TUserDto, TRoleDto, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
                 TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
                 TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto>> localizer, IMapper mapper, IApiErrorResources errorResources)
         {
@@ -71,7 +69,7 @@ namespace Skoruba.IdentityServer4.Admin.Api.Controllers
         }
 
         [HttpGet("{id}")]
-        public async Task<ActionResult<TUserDto>> Get(TUserDtoKey id)
+        public async Task<ActionResult<TUserDto>> Get(TKey id)
         {
             var user = await _identityService.GetUserAsync(id.ToString());
 
@@ -91,7 +89,7 @@ namespace Skoruba.IdentityServer4.Admin.Api.Controllers
         [ProducesResponseType(400)]
         public async Task<ActionResult<TUserDto>> Post([FromBody]TUserDto user)
         {
-            if (!EqualityComparer<TUserDtoKey>.Default.Equals(user.Id, default))
+            if (!EqualityComparer<TKey>.Default.Equals(user.Id, default))
             {
                 return BadRequest(_errorResources.CannotSetId());
             }
@@ -112,7 +110,7 @@ namespace Skoruba.IdentityServer4.Admin.Api.Controllers
         }
 
         [HttpDelete("{id}")]
-        public async Task<IActionResult> Delete(TUserDtoKey id)
+        public async Task<IActionResult> Delete(TKey id)
         {
             var currentUserId = User.GetSubjectId();
             if (id.ToString() == currentUserId)
@@ -127,7 +125,7 @@ namespace Skoruba.IdentityServer4.Admin.Api.Controllers
         }
 
         [HttpGet("{id}/Roles")]
-        public async Task<ActionResult<UserRolesApiDto<TRoleDto>>> GetUserRoles(TRoleDtoKey id, int page = 1, int pageSize = 10)
+        public async Task<ActionResult<UserRolesApiDto<TRoleDto>>> GetUserRoles(TKey id, int page = 1, int pageSize = 10)
         {
             var userRoles = await _identityService.GetUserRolesAsync(id.ToString(), page, pageSize);
             var userRolesApiDto = _mapper.Map<UserRolesApiDto<TRoleDto>>(userRoles);
@@ -136,7 +134,7 @@ namespace Skoruba.IdentityServer4.Admin.Api.Controllers
         }
 
         [HttpPost("Roles")]
-        public async Task<IActionResult> PostUserRoles([FromBody]UserRoleApiDto<TUserDtoKey, TRoleDtoKey> role)
+        public async Task<IActionResult> PostUserRoles([FromBody]UserRoleApiDto<TKey> role)
         {
             var userRolesDto = _mapper.Map<TUserRolesDto>(role);
 
@@ -146,7 +144,7 @@ namespace Skoruba.IdentityServer4.Admin.Api.Controllers
         }
 
         [HttpDelete("Roles")]
-        public async Task<IActionResult> DeleteUserRoles([FromBody]UserRoleApiDto<TUserDtoKey, TRoleDtoKey> role)
+        public async Task<IActionResult> DeleteUserRoles([FromBody]UserRoleApiDto<TKey> role)
         {
             var userRolesDto = _mapper.Map<TUserRolesDto>(role);
 
@@ -159,17 +157,17 @@ namespace Skoruba.IdentityServer4.Admin.Api.Controllers
         }
 
         [HttpGet("{id}/Claims")]
-        public async Task<ActionResult<UserClaimsApiDto<TUserDtoKey>>> GetUserClaims(TUserDtoKey id, int page = 1, int pageSize = 10)
+        public async Task<ActionResult<UserClaimsApiDto<TKey>>> GetUserClaims(TKey id, int page = 1, int pageSize = 10)
         {
             var claims = await _identityService.GetUserClaimsAsync(id.ToString(), page, pageSize);
 
-            var userClaimsApiDto = _mapper.Map<UserClaimsApiDto<TUserDtoKey>>(claims);
+            var userClaimsApiDto = _mapper.Map<UserClaimsApiDto<TKey>>(claims);
 
             return Ok(userClaimsApiDto);
         }
 
         [HttpPost("Claims")]
-        public async Task<IActionResult> PostUserClaims([FromBody]UserClaimApiDto<TUserDtoKey> claim)
+        public async Task<IActionResult> PostUserClaims([FromBody]UserClaimApiDto<TKey> claim)
         {
             var userClaimDto = _mapper.Map<TUserClaimsDto>(claim);
 
@@ -184,7 +182,7 @@ namespace Skoruba.IdentityServer4.Admin.Api.Controllers
         }
 
         [HttpDelete("{id}/Claims")]
-        public async Task<IActionResult> DeleteUserClaims([FromRoute]TUserDtoKey id, int claimId)
+        public async Task<IActionResult> DeleteUserClaims([FromRoute]TKey id, int claimId)
         {
             var userClaimsDto = new TUserClaimsDto
             {
@@ -199,16 +197,16 @@ namespace Skoruba.IdentityServer4.Admin.Api.Controllers
         }
 
         [HttpGet("{id}/Providers")]
-        public async Task<ActionResult<UserProvidersApiDto<TUserDtoKey>>> GetUserProviders(TUserDtoKey id)
+        public async Task<ActionResult<UserProvidersApiDto<TKey>>> GetUserProviders(TKey id)
         {
             var userProvidersDto = await _identityService.GetUserProvidersAsync(id.ToString());
-            var userProvidersApiDto = _mapper.Map<UserProvidersApiDto<TUserDtoKey>>(userProvidersDto);
+            var userProvidersApiDto = _mapper.Map<UserProvidersApiDto<TKey>>(userProvidersDto);
 
             return Ok(userProvidersApiDto);
         }
 
         [HttpDelete("Providers")]
-        public async Task<IActionResult> DeleteUserProviders([FromBody]UserProviderDeleteApiDto<TUserDtoKey> provider)
+        public async Task<IActionResult> DeleteUserProviders([FromBody]UserProviderDeleteApiDto<TKey> provider)
         {
             var providerDto = _mapper.Map<TUserProviderDto>(provider);
 
@@ -219,7 +217,7 @@ namespace Skoruba.IdentityServer4.Admin.Api.Controllers
         }
 
         [HttpPost("ChangePassword")]
-        public async Task<IActionResult> PostChangePassword([FromBody]UserChangePasswordApiDto<TUserDtoKey> password)
+        public async Task<IActionResult> PostChangePassword([FromBody]UserChangePasswordApiDto<TKey> password)
         {
             var userChangePasswordDto = _mapper.Map<TUserChangePasswordDto>(password);
 
@@ -229,10 +227,10 @@ namespace Skoruba.IdentityServer4.Admin.Api.Controllers
         }
 
 		[HttpGet("{id}/RoleClaims")]
-		public async Task<ActionResult<RoleClaimsApiDto<TRoleDtoKey>>> GetRoleClaims(TUserDtoKey id, string claimSearchText, int page = 1, int pageSize = 10)
+		public async Task<ActionResult<RoleClaimsApiDto<TKey>>> GetRoleClaims(TKey id, string claimSearchText, int page = 1, int pageSize = 10)
 		{
 			var roleClaimsDto = await _identityService.GetUserRoleClaimsAsync(id.ToString(), claimSearchText, page, pageSize);
-			var roleClaimsApiDto = _mapper.Map<RoleClaimsApiDto<TRoleDtoKey>>(roleClaimsDto);
+			var roleClaimsApiDto = _mapper.Map<RoleClaimsApiDto<TKey>>(roleClaimsDto);
 
 			return Ok(roleClaimsApiDto);
 		}

--- a/src/Skoruba.IdentityServer4.Admin.Api/Controllers/UsersController.cs
+++ b/src/Skoruba.IdentityServer4.Admin.Api/Controllers/UsersController.cs
@@ -23,7 +23,7 @@ namespace Skoruba.IdentityServer4.Admin.Api.Controllers
     [TypeFilter(typeof(ControllerExceptionFilterAttribute))]
     [Produces("application/json", "application/problem+json")]
     [Authorize(Policy = AuthorizationConsts.AdministrationPolicy)]
-    public class UsersController<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUserKey, TRoleKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
+    public class UsersController<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
             TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
             TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto> : ControllerBase
         where TUserDto : UserDto<TUserDtoKey>, new()
@@ -47,20 +47,20 @@ namespace Skoruba.IdentityServer4.Admin.Api.Controllers
         where TUserChangePasswordDto : UserChangePasswordDto<TUserDtoKey>
         where TRoleClaimsDto : RoleClaimsDto<TRoleDtoKey>
     {
-        private readonly IIdentityService<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUserKey, TRoleKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
+        private readonly IIdentityService<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
             TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
             TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto> _identityService;
-        private readonly IGenericControllerLocalizer<UsersController<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUserKey, TRoleKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
+        private readonly IGenericControllerLocalizer<UsersController<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
             TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
             TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto>> _localizer;
 
         private readonly IMapper _mapper;
         private readonly IApiErrorResources _errorResources;
 
-        public UsersController(IIdentityService<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUserKey, TRoleKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
+        public UsersController(IIdentityService<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
                 TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
                 TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto> identityService,
-            IGenericControllerLocalizer<UsersController<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUserKey, TRoleKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
+            IGenericControllerLocalizer<UsersController<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
                 TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
                 TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto>> localizer, IMapper mapper, IApiErrorResources errorResources)
         {

--- a/src/Skoruba.IdentityServer4.Admin.Api/Dtos/Roles/RoleClaimApiDto.cs
+++ b/src/Skoruba.IdentityServer4.Admin.Api/Dtos/Roles/RoleClaimApiDto.cs
@@ -2,11 +2,11 @@
 
 namespace Skoruba.IdentityServer4.Admin.Api.Dtos.Roles
 {
-    public class RoleClaimApiDto<TRoleDtoKey>
+    public class RoleClaimApiDto<TKey>
     {
         public int ClaimId { get; set; }
 
-        public TRoleDtoKey RoleId { get; set; }
+        public TKey RoleId { get; set; }
 
         [Required]
         public string ClaimType { get; set; }

--- a/src/Skoruba.IdentityServer4.Admin.Api/Dtos/Roles/RoleClaimsApiDto.cs
+++ b/src/Skoruba.IdentityServer4.Admin.Api/Dtos/Roles/RoleClaimsApiDto.cs
@@ -2,14 +2,14 @@
 
 namespace Skoruba.IdentityServer4.Admin.Api.Dtos.Roles
 {
-    public class RoleClaimsApiDto<TRoleDtoKey>
+    public class RoleClaimsApiDto<TKey>
     {
         public RoleClaimsApiDto()
         {
-            Claims = new List<RoleClaimApiDto<TRoleDtoKey>>();
+            Claims = new List<RoleClaimApiDto<TKey>>();
         }
 
-        public List<RoleClaimApiDto<TRoleDtoKey>> Claims { get; set; }
+        public List<RoleClaimApiDto<TKey>> Claims { get; set; }
 
         public int TotalCount { get; set; }
 

--- a/src/Skoruba.IdentityServer4.Admin.Api/Dtos/Users/UserChangePasswordApiDto.cs
+++ b/src/Skoruba.IdentityServer4.Admin.Api/Dtos/Users/UserChangePasswordApiDto.cs
@@ -2,9 +2,9 @@
 
 namespace Skoruba.IdentityServer4.Admin.Api.Dtos.Users
 {
-    public class UserChangePasswordApiDto<TUserDtoKey>
+    public class UserChangePasswordApiDto<TKey>
     {
-        public TUserDtoKey UserId { get; set; }
+        public TKey UserId { get; set; }
 
         [Required]
         public string Password { get; set; }

--- a/src/Skoruba.IdentityServer4.Admin.Api/Dtos/Users/UserClaimApiDto.cs
+++ b/src/Skoruba.IdentityServer4.Admin.Api/Dtos/Users/UserClaimApiDto.cs
@@ -2,11 +2,11 @@
 
 namespace Skoruba.IdentityServer4.Admin.Api.Dtos.Users
 {
-    public class UserClaimApiDto<TUserDtoKey>
+    public class UserClaimApiDto<TKey>
     {
         public int ClaimId { get; set; }
 
-        public TUserDtoKey UserId { get; set; }
+        public TKey UserId { get; set; }
 
         [Required]
         public string ClaimType { get; set; }

--- a/src/Skoruba.IdentityServer4.Admin.Api/Dtos/Users/UserClaimsApiDto.cs
+++ b/src/Skoruba.IdentityServer4.Admin.Api/Dtos/Users/UserClaimsApiDto.cs
@@ -2,14 +2,14 @@
 
 namespace Skoruba.IdentityServer4.Admin.Api.Dtos.Users
 {
-    public class UserClaimsApiDto<TUserDtoKey>
+    public class UserClaimsApiDto<TKey>
     {
         public UserClaimsApiDto()
         {
-            Claims = new List<UserClaimApiDto<TUserDtoKey>>();
+            Claims = new List<UserClaimApiDto<TKey>>();
         }
 
-        public List<UserClaimApiDto<TUserDtoKey>> Claims { get; set; }
+        public List<UserClaimApiDto<TKey>> Claims { get; set; }
 
         public int TotalCount { get; set; }
 

--- a/src/Skoruba.IdentityServer4.Admin.Api/Dtos/Users/UserProviderApiDto.cs
+++ b/src/Skoruba.IdentityServer4.Admin.Api/Dtos/Users/UserProviderApiDto.cs
@@ -1,8 +1,8 @@
 ﻿namespace Skoruba.IdentityServer4.Admin.Api.Dtos.Users
 {
-    public class UserProviderApiDto<TUserDtoKey>
+    public class UserProviderApiDto<TKey>
     {
-        public TUserDtoKey UserId { get; set; }
+        public TKey UserId { get; set; }
 
         public string UserName { get; set; }
 

--- a/src/Skoruba.IdentityServer4.Admin.Api/Dtos/Users/UserProviderDeleteApiDto.cs
+++ b/src/Skoruba.IdentityServer4.Admin.Api/Dtos/Users/UserProviderDeleteApiDto.cs
@@ -1,8 +1,8 @@
 ﻿namespace Skoruba.IdentityServer4.Admin.Api.Dtos.Users
 {
-    public class UserProviderDeleteApiDto<TUserDtoKey>
+    public class UserProviderDeleteApiDto<TKey>
     {
-        public TUserDtoKey UserId { get; set; }
+        public TKey UserId { get; set; }
 
         public string ProviderKey { get; set; }
 

--- a/src/Skoruba.IdentityServer4.Admin.Api/Dtos/Users/UserProvidersApiDto.cs
+++ b/src/Skoruba.IdentityServer4.Admin.Api/Dtos/Users/UserProvidersApiDto.cs
@@ -2,13 +2,13 @@
 
 namespace Skoruba.IdentityServer4.Admin.Api.Dtos.Users
 {
-    public class UserProvidersApiDto<TUserDtoKey>
+    public class UserProvidersApiDto<TKey>
     {
         public UserProvidersApiDto()
         {
-            Providers = new List<UserProviderApiDto<TUserDtoKey>>();
+            Providers = new List<UserProviderApiDto<TKey>>();
         }
 
-        public List<UserProviderApiDto<TUserDtoKey>> Providers { get; set; }
+        public List<UserProviderApiDto<TKey>> Providers { get; set; }
     }
 }

--- a/src/Skoruba.IdentityServer4.Admin.Api/Dtos/Users/UserRoleApiDto.cs
+++ b/src/Skoruba.IdentityServer4.Admin.Api/Dtos/Users/UserRoleApiDto.cs
@@ -1,9 +1,9 @@
 ﻿namespace Skoruba.IdentityServer4.Admin.Api.Dtos.Users
 {
-    public class UserRoleApiDto<TUserDtoKey, TRoleDtoKey>
+    public class UserRoleApiDto<TKey>
     {
-        public TUserDtoKey UserId { get; set; }
+        public TKey UserId { get; set; }
 
-        public TRoleDtoKey RoleId { get; set; }
+        public TKey RoleId { get; set; }
     }
 }

--- a/src/Skoruba.IdentityServer4.Admin.Api/Helpers/StartupHelpers.cs
+++ b/src/Skoruba.IdentityServer4.Admin.Api/Helpers/StartupHelpers.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using IdentityModel;
 using IdentityServer4.AccessTokenValidation;
 using IdentityServer4.EntityFramework.Options;
@@ -24,6 +25,8 @@ using Skoruba.IdentityServer4.Admin.EntityFramework.Interfaces;
 using Skoruba.IdentityServer4.Admin.EntityFramework.MySql.Extensions;
 using Skoruba.IdentityServer4.Admin.EntityFramework.PostgreSQL.Extensions;
 using Skoruba.IdentityServer4.Admin.EntityFramework.Shared.Configuration;
+using Skoruba.IdentityServer4.Admin.EntityFramework.Shared.DbContexts;
+using Skoruba.IdentityServer4.Admin.EntityFramework.Shared.Entities.Identity;
 using Skoruba.IdentityServer4.Admin.EntityFramework.SqlServer.Extensions;
 
 namespace Skoruba.IdentityServer4.Admin.Api.Helpers
@@ -321,6 +324,31 @@ namespace Skoruba.IdentityServer4.Admin.Api.Helpers
                         throw new NotImplementedException($"Health checks not defined for database provider {databaseProvider.ProviderType}");
                 }
             }
+        }
+
+        public static void AddAdminAspNetIdentityServices(this IServiceCollection services, HashSet<Type> profileTypes = null)
+        {
+            services.AddAdminAspNetIdentityServices(adminBuilder => adminBuilder.UseUser<UserIdentity>()
+                    .UseRole<UserIdentityRole>()
+                    .UseUserClaim<UserIdentityUserClaim>()
+                    .UseUserRole<UserIdentityUserRole>()
+                    .UseUserLogin<UserIdentityUserLogin>()
+                    .UseRoleClaim<UserIdentityRoleClaim>()
+                    .UseUserToken<UserIdentityUserToken>()
+                    .UseIdentityDbContext<AdminIdentityDbContext>()
+                    .UsePersistedGrantDbContext<IdentityServerPersistedGrantDbContext>()
+                    .UseDto(dtoBuilder => dtoBuilder.UseRole<RoleDto<string>, RolesDto<RoleDto<string>, string>, UserRolesDto<RoleDto<string>, string>>()
+                        .UseRoleClaim<RoleClaimDto<string>>()
+                        .UseRoleClaims<RoleClaimsDto<string>>()
+                        .UseUser<UserDto<string>, UsersDto<UserDto<string>, string>>()
+                        .UseUserClaim<UserClaimDto<string>>()
+                        .UseUserClaims<UserClaimsDto<string>>()
+                        .UseUserProvider<UserProviderDto<string>>()
+                        .UseUserProviders<UserProvidersDto<string>>()
+                        .UseUserChangePassword<UserChangePasswordDto<string>>()
+                    ),
+                    profileTypes
+            );
         }
     }
 }

--- a/src/Skoruba.IdentityServer4.Admin.Api/Helpers/StartupHelpers.cs
+++ b/src/Skoruba.IdentityServer4.Admin.Api/Helpers/StartupHelpers.cs
@@ -78,7 +78,7 @@ namespace Skoruba.IdentityServer4.Admin.Api.Helpers
         /// Register services for MVC
         /// </summary>
         /// <param name="services"></param>
-        public static void AddMvcServices<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUserKey, TRoleKey,
+        public static void AddMvcServices<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey,
             TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
             TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
             TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto>(
@@ -111,8 +111,8 @@ namespace Skoruba.IdentityServer4.Admin.Api.Helpers
                 .ConfigureApplicationPartManager(m =>
                 {
                     m.FeatureProviders.Add(
-                        new GenericTypeControllerFeatureProvider<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUserKey,
-                            TRoleKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
+                        new GenericTypeControllerFeatureProvider<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey,
+                            TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
                             TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
                             TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto>());
                 });

--- a/src/Skoruba.IdentityServer4.Admin.Api/Helpers/StartupHelpers.cs
+++ b/src/Skoruba.IdentityServer4.Admin.Api/Helpers/StartupHelpers.cs
@@ -78,13 +78,13 @@ namespace Skoruba.IdentityServer4.Admin.Api.Helpers
         /// Register services for MVC
         /// </summary>
         /// <param name="services"></param>
-        public static void AddMvcServices<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey,
+        public static void AddMvcServices<TUserDto, TRoleDto,
             TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
             TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
             TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto>(
             this IServiceCollection services)
-            where TUserDto : UserDto<TUserDtoKey>, new()
-            where TRoleDto : RoleDto<TRoleDtoKey>, new()
+            where TUserDto : UserDto<TKey>, new()
+            where TRoleDto : RoleDto<TKey>, new()
             where TUser : IdentityUser<TKey>
             where TRole : IdentityRole<TKey>
             where TKey : IEquatable<TKey>
@@ -93,16 +93,16 @@ namespace Skoruba.IdentityServer4.Admin.Api.Helpers
             where TUserLogin : IdentityUserLogin<TKey>
             where TRoleClaim : IdentityRoleClaim<TKey>
             where TUserToken : IdentityUserToken<TKey>
-            where TRoleDtoKey : IEquatable<TRoleDtoKey>
-            where TUserDtoKey : IEquatable<TUserDtoKey>
-            where TUsersDto : UsersDto<TUserDto, TUserDtoKey>
-            where TRolesDto : RolesDto<TRoleDto, TRoleDtoKey>
-            where TUserRolesDto : UserRolesDto<TRoleDto, TUserDtoKey, TRoleDtoKey>
-            where TUserClaimsDto : UserClaimsDto<TUserDtoKey>
-            where TUserProviderDto : UserProviderDto<TUserDtoKey>
-            where TUserProvidersDto : UserProvidersDto<TUserDtoKey>
-            where TUserChangePasswordDto : UserChangePasswordDto<TUserDtoKey>
-            where TRoleClaimsDto : RoleClaimsDto<TRoleDtoKey>
+
+
+            where TUsersDto : UsersDto<TUserDto, TKey>
+            where TRolesDto : RolesDto<TRoleDto, TKey>
+            where TUserRolesDto : UserRolesDto<TRoleDto, TKey>
+            where TUserClaimsDto : UserClaimsDto<TKey>
+            where TUserProviderDto : UserProviderDto<TKey>
+            where TUserProvidersDto : UserProvidersDto<TKey>
+            where TUserChangePasswordDto : UserChangePasswordDto<TKey>
+            where TRoleClaimsDto : RoleClaimsDto<TKey>
         {
             services.TryAddTransient(typeof(IGenericControllerLocalizer<>), typeof(GenericControllerLocalizer<>));
 
@@ -111,7 +111,7 @@ namespace Skoruba.IdentityServer4.Admin.Api.Helpers
                 .ConfigureApplicationPartManager(m =>
                 {
                     m.FeatureProviders.Add(
-                        new GenericTypeControllerFeatureProvider<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey,
+                        new GenericTypeControllerFeatureProvider<TUserDto, TRoleDto,
                             TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
                             TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
                             TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto>());

--- a/src/Skoruba.IdentityServer4.Admin.Api/Mappers/IdentityMapperProfile.cs
+++ b/src/Skoruba.IdentityServer4.Admin.Api/Mappers/IdentityMapperProfile.cs
@@ -5,38 +5,38 @@ using Skoruba.IdentityServer4.Admin.BusinessLogic.Identity.Dtos.Identity;
 
 namespace Skoruba.IdentityServer4.Admin.Api.Mappers
 {
-    public class IdentityMapperProfile<TRoleDto, TRoleDtoKey, TUserRolesDto, TUserDtoKey, TUserClaimsDto, TUserClaimDto, TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimDto, TRoleClaimsDto> : Profile
-        where TUserClaimsDto : UserClaimsDto<TUserDtoKey>
-        where TUserClaimDto : UserClaimDto<TUserDtoKey>
-        where TRoleDto : RoleDto<TRoleDtoKey>
-        where TUserRolesDto : UserRolesDto<TRoleDto, TUserDtoKey, TRoleDtoKey>
-        where TUserProviderDto : UserProviderDto<TUserDtoKey>
-        where TUserProvidersDto : UserProvidersDto<TUserDtoKey>
-        where TUserChangePasswordDto : UserChangePasswordDto<TUserDtoKey>
-        where TRoleClaimsDto : RoleClaimsDto<TRoleDtoKey>
-        where TRoleClaimDto : RoleClaimDto<TRoleDtoKey>
+    public class IdentityMapperProfile<TRoleDto, TUserRolesDto, TKey, TUserClaimsDto, TUserClaimDto, TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimDto, TRoleClaimsDto> : Profile
+        where TUserClaimsDto : UserClaimsDto<TKey>
+        where TUserClaimDto : UserClaimDto<TKey>
+        where TRoleDto : RoleDto<TKey>
+        where TUserRolesDto : UserRolesDto<TRoleDto, TKey>
+        where TUserProviderDto : UserProviderDto<TKey>
+        where TUserProvidersDto : UserProvidersDto<TKey>
+        where TUserChangePasswordDto : UserChangePasswordDto<TKey>
+        where TRoleClaimsDto : RoleClaimsDto<TKey>
+        where TRoleClaimDto : RoleClaimDto<TKey>
     {
         public IdentityMapperProfile()
         {
             // entity to model
-            CreateMap<TUserClaimsDto, UserClaimsApiDto<TUserDtoKey>>(MemberList.Destination);
-            CreateMap<TUserClaimsDto, UserClaimApiDto<TUserDtoKey>>(MemberList.Destination);
+            CreateMap<TUserClaimsDto, UserClaimsApiDto<TKey>>(MemberList.Destination);
+            CreateMap<TUserClaimsDto, UserClaimApiDto<TKey>>(MemberList.Destination);
 
-            CreateMap<UserClaimApiDto<TUserDtoKey>, TUserClaimsDto>(MemberList.Source);
-            CreateMap<TUserClaimDto, UserClaimApiDto<TUserDtoKey>>(MemberList.Destination);
+            CreateMap<UserClaimApiDto<TKey>, TUserClaimsDto>(MemberList.Source);
+            CreateMap<TUserClaimDto, UserClaimApiDto<TKey>>(MemberList.Destination);
 
             CreateMap<TUserRolesDto, UserRolesApiDto<TRoleDto>>(MemberList.Destination);
-            CreateMap<UserRoleApiDto<TUserDtoKey, TRoleDtoKey>, TUserRolesDto>(MemberList.Destination);
+            CreateMap<UserRoleApiDto<TKey>, TUserRolesDto>(MemberList.Destination);
 
-            CreateMap<TUserProviderDto, UserProviderApiDto<TUserDtoKey>>(MemberList.Destination);
-            CreateMap<TUserProvidersDto, UserProvidersApiDto<TUserDtoKey>>(MemberList.Destination);
-            CreateMap<UserProviderDeleteApiDto<TUserDtoKey>, TUserProviderDto>(MemberList.Source);
+            CreateMap<TUserProviderDto, UserProviderApiDto<TKey>>(MemberList.Destination);
+            CreateMap<TUserProvidersDto, UserProvidersApiDto<TKey>>(MemberList.Destination);
+            CreateMap<UserProviderDeleteApiDto<TKey>, TUserProviderDto>(MemberList.Source);
 
-            CreateMap<UserChangePasswordApiDto<TUserDtoKey>, TUserChangePasswordDto>(MemberList.Destination);
+            CreateMap<UserChangePasswordApiDto<TKey>, TUserChangePasswordDto>(MemberList.Destination);
 
-            CreateMap<RoleClaimsApiDto<TRoleDtoKey>, TRoleClaimsDto>(MemberList.Source);
-            CreateMap<RoleClaimApiDto<TRoleDtoKey>, TRoleClaimDto>(MemberList.Destination);
-            CreateMap<RoleClaimApiDto<TRoleDtoKey>, TRoleClaimsDto>(MemberList.Destination);
+            CreateMap<RoleClaimsApiDto<TKey>, TRoleClaimsDto>(MemberList.Source);
+            CreateMap<RoleClaimApiDto<TKey>, TRoleClaimDto>(MemberList.Destination);
+            CreateMap<RoleClaimApiDto<TKey>, TRoleClaimsDto>(MemberList.Destination);
         }
     }
 }

--- a/src/Skoruba.IdentityServer4.Admin.Api/Startup.cs
+++ b/src/Skoruba.IdentityServer4.Admin.Api/Startup.cs
@@ -55,12 +55,29 @@ namespace Skoruba.IdentityServer4.Admin.Api
                 typeof(IdentityMapperProfile<RoleDto<string>, UserRolesDto<RoleDto<string>, string>, string, UserClaimsDto<string>, UserClaimDto<string>, UserProviderDto<string>, UserProvidersDto<string>, UserChangePasswordDto<string>,RoleClaimDto<string>, RoleClaimsDto<string>>)
             };
 
-            services.AddAdminAspNetIdentityServices<AdminIdentityDbContext, IdentityServerPersistedGrantDbContext, UserDto<string>, RoleDto<string>,
-                UserIdentity, UserIdentityRole, string, UserIdentityUserClaim, UserIdentityUserRole,
-                UserIdentityUserLogin, UserIdentityRoleClaim, UserIdentityUserToken,
-                UsersDto<UserDto<string>, string>, RolesDto<RoleDto<string>, string>, UserRolesDto<RoleDto<string>, string>,
-                UserClaimsDto<string>, UserProviderDto<string>, UserProvidersDto<string>, UserChangePasswordDto<string>,
-                RoleClaimsDto<string>, UserClaimDto<string>, RoleClaimDto<string>>(profileTypes);
+            // Default configuration which we can not use for now cause we have no default IdentityDbContext and IdentityServerPersistedGrantDbContext in Skoruba.IdentityServer4.Admin.BusinessLogic.Identity
+            //services.AddAdminAspNetIdentityServices(profileTypes);
+            // Custom configuration
+            services.AddAdminAspNetIdentityServices<string>(adminBuilder => adminBuilder.UseUser<UserIdentity>()
+                    .UseRole<UserIdentityRole>()
+                    .UseUserClaim<UserIdentityUserClaim>()
+                    .UseUserRole<UserIdentityUserRole>()
+                    .UseUserLogin<UserIdentityUserLogin>()
+                    .UseRoleClaim<UserIdentityRoleClaim>()
+                    .UseUserToken<UserIdentityUserToken>()
+                    .UseIdentityDbContext<AdminIdentityDbContext>()
+                    .UsePersistedGrantDbContext<IdentityServerPersistedGrantDbContext>()
+                    .UseDto(dtoBuilder => dtoBuilder.UseRole<RoleDto<string>, RolesDto<RoleDto<string>, string>, UserRolesDto<RoleDto<string>, string>>()
+                        .UseRoleClaim<RoleClaimDto<string>>()
+                        .UseRoleClaims<RoleClaimsDto<string>>()
+                        .UseUser<UserDto<string>, UsersDto<UserDto<string>, string>>()
+                        .UseUserClaim<UserClaimDto<string>>()
+                        .UseUserClaims<UserClaimsDto<string>>()
+                        .UseUserProvider<UserProviderDto<string>>()
+                        .UseUserProviders<UserProvidersDto<string>>()
+                        .UseUserChangePassword<UserChangePasswordDto<string>>()),
+                    profileTypes
+            );
 
             services.AddAdminServices<IdentityServerConfigurationDbContext, IdentityServerPersistedGrantDbContext, AdminLogDbContext>();
 

--- a/src/Skoruba.IdentityServer4.Admin.Api/Startup.cs
+++ b/src/Skoruba.IdentityServer4.Admin.Api/Startup.cs
@@ -55,7 +55,7 @@ namespace Skoruba.IdentityServer4.Admin.Api
                 typeof(IdentityMapperProfile<RoleDto<string>, string, UserRolesDto<RoleDto<string>, string, string>, string, UserClaimsDto<string>, UserClaimDto<string>, UserProviderDto<string>, UserProvidersDto<string>, UserChangePasswordDto<string>,RoleClaimDto<string>, RoleClaimsDto<string>>)
             };
 
-            services.AddAdminAspNetIdentityServices<AdminIdentityDbContext, IdentityServerPersistedGrantDbContext, UserDto<string>, string, RoleDto<string>, string, string, string,
+            services.AddAdminAspNetIdentityServices<AdminIdentityDbContext, IdentityServerPersistedGrantDbContext, UserDto<string>, string, RoleDto<string>, string,
                 UserIdentity, UserIdentityRole, string, UserIdentityUserClaim, UserIdentityUserRole,
                 UserIdentityUserLogin, UserIdentityRoleClaim, UserIdentityUserToken,
                 UsersDto<UserDto<string>, string>, RolesDto<RoleDto<string>, string>, UserRolesDto<RoleDto<string>, string, string>,
@@ -66,7 +66,7 @@ namespace Skoruba.IdentityServer4.Admin.Api
 
             services.AddAdminApiCors(adminApiConfiguration);
 
-            services.AddMvcServices<UserDto<string>, string, RoleDto<string>, string, string, string,
+            services.AddMvcServices<UserDto<string>, string, RoleDto<string>, string,
                 UserIdentity, UserIdentityRole, string, UserIdentityUserClaim, UserIdentityUserRole,
                 UserIdentityUserLogin, UserIdentityRoleClaim, UserIdentityUserToken,
                 UsersDto<UserDto<string>, string>, RolesDto<RoleDto<string>, string>, UserRolesDto<RoleDto<string>, string, string>,

--- a/src/Skoruba.IdentityServer4.Admin.Api/Startup.cs
+++ b/src/Skoruba.IdentityServer4.Admin.Api/Startup.cs
@@ -55,29 +55,7 @@ namespace Skoruba.IdentityServer4.Admin.Api
                 typeof(IdentityMapperProfile<RoleDto<string>, UserRolesDto<RoleDto<string>, string>, string, UserClaimsDto<string>, UserClaimDto<string>, UserProviderDto<string>, UserProvidersDto<string>, UserChangePasswordDto<string>,RoleClaimDto<string>, RoleClaimsDto<string>>)
             };
 
-            // Default configuration which we can not use for now cause we have no default IdentityDbContext and IdentityServerPersistedGrantDbContext in Skoruba.IdentityServer4.Admin.BusinessLogic.Identity
-            //services.AddAdminAspNetIdentityServices(profileTypes);
-            // Custom configuration
-            services.AddAdminAspNetIdentityServices<string>(adminBuilder => adminBuilder.UseUser<UserIdentity>()
-                    .UseRole<UserIdentityRole>()
-                    .UseUserClaim<UserIdentityUserClaim>()
-                    .UseUserRole<UserIdentityUserRole>()
-                    .UseUserLogin<UserIdentityUserLogin>()
-                    .UseRoleClaim<UserIdentityRoleClaim>()
-                    .UseUserToken<UserIdentityUserToken>()
-                    .UseIdentityDbContext<AdminIdentityDbContext>()
-                    .UsePersistedGrantDbContext<IdentityServerPersistedGrantDbContext>()
-                    .UseDto(dtoBuilder => dtoBuilder.UseRole<RoleDto<string>, RolesDto<RoleDto<string>, string>, UserRolesDto<RoleDto<string>, string>>()
-                        .UseRoleClaim<RoleClaimDto<string>>()
-                        .UseRoleClaims<RoleClaimsDto<string>>()
-                        .UseUser<UserDto<string>, UsersDto<UserDto<string>, string>>()
-                        .UseUserClaim<UserClaimDto<string>>()
-                        .UseUserClaims<UserClaimsDto<string>>()
-                        .UseUserProvider<UserProviderDto<string>>()
-                        .UseUserProviders<UserProvidersDto<string>>()
-                        .UseUserChangePassword<UserChangePasswordDto<string>>()),
-                    profileTypes
-            );
+            services.AddAdminAspNetIdentityServices(profileTypes);
 
             services.AddAdminServices<IdentityServerConfigurationDbContext, IdentityServerPersistedGrantDbContext, AdminLogDbContext>();
 

--- a/src/Skoruba.IdentityServer4.Admin.Api/Startup.cs
+++ b/src/Skoruba.IdentityServer4.Admin.Api/Startup.cs
@@ -52,13 +52,13 @@ namespace Skoruba.IdentityServer4.Admin.Api
 
             var profileTypes = new HashSet<Type>
             {
-                typeof(IdentityMapperProfile<RoleDto<string>, string, UserRolesDto<RoleDto<string>, string, string>, string, UserClaimsDto<string>, UserClaimDto<string>, UserProviderDto<string>, UserProvidersDto<string>, UserChangePasswordDto<string>,RoleClaimDto<string>, RoleClaimsDto<string>>)
+                typeof(IdentityMapperProfile<RoleDto<string>, UserRolesDto<RoleDto<string>, string>, string, UserClaimsDto<string>, UserClaimDto<string>, UserProviderDto<string>, UserProvidersDto<string>, UserChangePasswordDto<string>,RoleClaimDto<string>, RoleClaimsDto<string>>)
             };
 
-            services.AddAdminAspNetIdentityServices<AdminIdentityDbContext, IdentityServerPersistedGrantDbContext, UserDto<string>, string, RoleDto<string>, string,
+            services.AddAdminAspNetIdentityServices<AdminIdentityDbContext, IdentityServerPersistedGrantDbContext, UserDto<string>, RoleDto<string>,
                 UserIdentity, UserIdentityRole, string, UserIdentityUserClaim, UserIdentityUserRole,
                 UserIdentityUserLogin, UserIdentityRoleClaim, UserIdentityUserToken,
-                UsersDto<UserDto<string>, string>, RolesDto<RoleDto<string>, string>, UserRolesDto<RoleDto<string>, string, string>,
+                UsersDto<UserDto<string>, string>, RolesDto<RoleDto<string>, string>, UserRolesDto<RoleDto<string>, string>,
                 UserClaimsDto<string>, UserProviderDto<string>, UserProvidersDto<string>, UserChangePasswordDto<string>,
                 RoleClaimsDto<string>, UserClaimDto<string>, RoleClaimDto<string>>(profileTypes);
 
@@ -66,10 +66,10 @@ namespace Skoruba.IdentityServer4.Admin.Api
 
             services.AddAdminApiCors(adminApiConfiguration);
 
-            services.AddMvcServices<UserDto<string>, string, RoleDto<string>, string,
+            services.AddMvcServices<UserDto<string>, RoleDto<string>,
                 UserIdentity, UserIdentityRole, string, UserIdentityUserClaim, UserIdentityUserRole,
                 UserIdentityUserLogin, UserIdentityRoleClaim, UserIdentityUserToken,
-                UsersDto<UserDto<string>, string>, RolesDto<RoleDto<string>, string>, UserRolesDto<RoleDto<string>, string, string>,
+                UsersDto<UserDto<string>, string>, RolesDto<RoleDto<string>, string>, UserRolesDto<RoleDto<string>, string>,
                 UserClaimsDto<string>, UserProviderDto<string>, UserProvidersDto<string>, UserChangePasswordDto<string>,
                 RoleClaimsDto<string>>();
 

--- a/src/Skoruba.IdentityServer4.Admin.BusinessLogic.Identity/Builders/AdminAspNetIdentityConfiguration.cs
+++ b/src/Skoruba.IdentityServer4.Admin.BusinessLogic.Identity/Builders/AdminAspNetIdentityConfiguration.cs
@@ -1,0 +1,34 @@
+using System;
+
+namespace Skoruba.IdentityServer4.Admin.BusinessLogic.Identity.Builders
+{
+    public struct AdminAspNetIdentityConfiguration<TKey> where TKey : IEquatable<TKey>
+    {
+        public struct Dto
+        {
+            public Type Role { get; internal set; }
+            public Type Roles { get; internal set; }
+            public Type RoleClaim { get; internal set; }
+            public Type RoleClaims { get; internal set; }
+            public Type UserRoles { get; internal set; }
+            public Type User { get; internal set; }
+            public Type Users { get; internal set; }
+            public Type UserClaim { get; internal set; }
+            public Type UserClaims { get; internal set; }
+            public Type UserProvider { get; internal set; }
+            public Type UserProviders { get; internal set; }
+            public Type UserChangePassword { get; internal set; }
+        }
+
+        public Type UserType { get; internal set; }
+        public Type UserClaimType { get; internal set; }
+        public Type UserLoginType { get; internal set; }
+        public Type UserTokenType { get; internal set; }
+        public Type RoleType { get; internal set; }
+        public Type RoleClaimType { get; internal set; }
+        public Type UserRoleType { get; internal set; }
+        public Type IdentityDbContextType { get; internal set; }
+        public Type PersistedGrantDbContextType { get; internal set; }
+        public Dto DtoTypes { get; internal set; }
+    }
+}

--- a/src/Skoruba.IdentityServer4.Admin.BusinessLogic.Identity/Builders/AdminAspNetIdentityConfigurationBuilder.cs
+++ b/src/Skoruba.IdentityServer4.Admin.BusinessLogic.Identity/Builders/AdminAspNetIdentityConfigurationBuilder.cs
@@ -1,0 +1,232 @@
+using System;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore;
+using Skoruba.IdentityServer4.Admin.BusinessLogic.Identity.Builders.Interfaces;
+using Skoruba.IdentityServer4.Admin.BusinessLogic.Identity.Dtos.Identity;
+using Skoruba.IdentityServer4.Admin.EntityFramework.Interfaces;
+
+namespace Skoruba.IdentityServer4.Admin.BusinessLogic.Identity.Builders
+{
+    internal class AdminAspNetIdentityConfigurationBuilder<TKey> : AdminAspNetIdentityConfigurationBuilder<TKey, IdentityUser<TKey>, IdentityUserClaim<TKey>, IdentityUserLogin<TKey>, IdentityUserToken<TKey>, IdentityRole<TKey>, IdentityRoleClaim<TKey>, IdentityUserRole<TKey>>, IAdminAspNetIdentityConfigurationBuilder<TKey>
+        where TKey : IEquatable<TKey>
+    {
+        private static readonly AdminAspNetIdentityConfiguration<TKey>.Dto DefaultDto = new AdminAspNetIdentityConfiguration<TKey>.Dto
+        {
+            Role = typeof(RoleDto<TKey>),
+            Roles = typeof(RolesDto<RoleDto<TKey>, TKey>),
+            RoleClaim = typeof(RoleClaimDto<TKey>),
+            RoleClaims = typeof(RoleClaimsDto<TKey>),
+            UserRoles = typeof(UserRolesDto<RoleDto<TKey>, TKey>),
+            User = typeof(UserDto<TKey>),
+            Users = typeof(UsersDto<UserDto<TKey>, TKey>),
+            UserClaim = typeof(UserClaimDto<TKey>),
+            UserClaims = typeof(UserClaimsDto<TKey>),
+            UserProvider = typeof(UserProviderDto<TKey>),
+            UserProviders = typeof(UserProvidersDto<TKey>),
+            UserChangePassword = typeof(UserChangePasswordDto<TKey>)
+        };
+
+        public AdminAspNetIdentityConfigurationBuilder() : base(DefaultDto)
+        {
+        }
+    }
+
+    internal class AdminAspNetIdentityConfigurationBuilder<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole>
+        : IAdminAspNetIdentityConfigurationBuilder<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole>,
+          IAdminAspNetIdentityConfigurationBuilderWithDto<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole>
+        where TKey : IEquatable<TKey>
+        where TUser : IdentityUser<TKey>
+        where TUserClaim : IdentityUserClaim<TKey>
+        where TUserLogin : IdentityUserLogin<TKey>
+        where TUserToken : IdentityUserToken<TKey>
+        where TRole : IdentityRole<TKey>
+        where TRoleClaim : IdentityRoleClaim<TKey>
+        where TUserRole : IdentityUserRole<TKey>
+    {
+        protected AdminAspNetIdentityConfiguration<TKey>.Dto dto;
+
+        public AdminAspNetIdentityConfigurationBuilder(AdminAspNetIdentityConfiguration<TKey>.Dto dto) => this.dto = dto;
+
+        protected AdminAspNetIdentityConfigurationBuilder<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole> updateDto(Action<IAdminAspNetIdentityDtoConfigurationBuilder<TKey>> configure = null)
+        {
+            var dtoBuilder = new AdminAspNetIdentityDtoConfigurationBuilder<TKey>();
+            configure?.Invoke(dtoBuilder);
+            dto = dtoBuilder.Build();
+            return this;
+        }
+
+        IAdminAspNetIdentityConfigurationBuilderWithDto<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole> IAdminAspNetIdentityConfigurationBuilder<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole>.UseDto(Action<IAdminAspNetIdentityDtoConfigurationBuilder<TKey>> configure) => updateDto(configure);
+
+        IAdminAspNetIdentityConfigurationBuilderWithDto<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole> IAdminAspNetIdentityConfigurationBuilderWithDto<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole>.UseDto(Action<IAdminAspNetIdentityDtoConfigurationBuilder<TKey>> configure) => updateDto(configure);
+
+        IAdminAspNetIdentityConfigurationBuilderWithIdentityDbContext<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole, TIdentityDbContext> IAdminAspNetIdentityConfigurationBuilder<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole>.UseIdentityDbContext<TIdentityDbContext>() =>
+            new AdminAspNetIdentityConfigurationBuilderWithIdentityDbContext<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole, TIdentityDbContext>(dto);
+
+        IAdminAspNetIdentityConfigurationBuilderWithDtoAndIdentityDbContext<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole, TIdentityDbContext> IAdminAspNetIdentityConfigurationBuilderWithDto<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole>.UseIdentityDbContext<TIdentityDbContext>() =>
+            new AdminAspNetIdentityConfigurationBuilderWithIdentityDbContext<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole, TIdentityDbContext>(dto);
+
+        IAdminAspNetIdentityConfigurationBuilderWithPersistedGrantDbContext<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole, TPersistedGrantDbContext> IAdminAspNetIdentityConfigurationBuilder<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole>.UsePersistedGrantDbContext<TPersistedGrantDbContext>() =>
+            new AdminAspNetIdentityConfigurationBuilderWithPersistedGrantDbContext<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole, TPersistedGrantDbContext>(dto);
+
+        IAdminAspNetIdentityConfigurationBuilderWithDtoAndPersistedGrantDbContext<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole, TPersistedGrantDbContext> IAdminAspNetIdentityConfigurationBuilderWithDto<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole>.UsePersistedGrantDbContext<TPersistedGrantDbContext>() =>
+            new AdminAspNetIdentityConfigurationBuilderWithPersistedGrantDbContext<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole, TPersistedGrantDbContext>(dto);
+
+        IAdminAspNetIdentityConfigurationBuilder<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TNewRole, TRoleClaim, TUserRole> IAdminAspNetIdentityConfigurationBuilder<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole>.UseRole<TNewRole>() =>
+            new AdminAspNetIdentityConfigurationBuilder<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TNewRole, TRoleClaim, TUserRole>(dto);
+
+        IAdminAspNetIdentityConfigurationBuilder<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TNewRoleClaim, TUserRole> IAdminAspNetIdentityConfigurationBuilder<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole>.UseRoleClaim<TNewRoleClaim>() =>
+            new AdminAspNetIdentityConfigurationBuilder<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TNewRoleClaim, TUserRole>(dto);
+
+        IAdminAspNetIdentityConfigurationBuilder<TKey, TNewUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole> IAdminAspNetIdentityConfigurationBuilder<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole>.UseUser<TNewUser>() =>
+            new AdminAspNetIdentityConfigurationBuilder<TKey, TNewUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole>(dto);
+
+        IAdminAspNetIdentityConfigurationBuilder<TKey, TUser, TNewUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole> IAdminAspNetIdentityConfigurationBuilder<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole>.UseUserClaim<TNewUserClaim>() =>
+            new AdminAspNetIdentityConfigurationBuilder<TKey, TUser, TNewUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole>(dto);
+
+        IAdminAspNetIdentityConfigurationBuilder<TKey, TUser, TUserClaim, TNewUserLogin, TUserToken, TRole, TRoleClaim, TUserRole> IAdminAspNetIdentityConfigurationBuilder<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole>.UseUserLogin<TNewUserLogin>() =>
+            new AdminAspNetIdentityConfigurationBuilder<TKey, TUser, TUserClaim, TNewUserLogin, TUserToken, TRole, TRoleClaim, TUserRole>(dto);
+
+        IAdminAspNetIdentityConfigurationBuilder<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TNewUserRole> IAdminAspNetIdentityConfigurationBuilder<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole>.UseUserRole<TNewUserRole>() =>
+            new AdminAspNetIdentityConfigurationBuilder<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TNewUserRole>(dto);
+
+        IAdminAspNetIdentityConfigurationBuilder<TKey, TUser, TUserClaim, TUserLogin, TNewUserToken, TRole, TRoleClaim, TUserRole> IAdminAspNetIdentityConfigurationBuilder<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole>.UseUserToken<TNewUserToken>() =>
+            new AdminAspNetIdentityConfigurationBuilder<TKey, TUser, TUserClaim, TUserLogin, TNewUserToken, TRole, TRoleClaim, TUserRole>(dto);
+    }
+
+    internal class AdminAspNetIdentityConfigurationBuilderWithIdentityDbContext<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole, TIdentityDbContext>
+        : AdminAspNetIdentityConfigurationBuilder<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole>,
+          IAdminAspNetIdentityConfigurationBuilder<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole>,
+          IAdminAspNetIdentityConfigurationBuilderWithIdentityDbContext<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole, TIdentityDbContext>,
+          IAdminAspNetIdentityConfigurationBuilderWithDto<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole>,
+          IAdminAspNetIdentityConfigurationBuilderWithDtoAndIdentityDbContext<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole, TIdentityDbContext>
+        where TKey : IEquatable<TKey>
+        where TUser : IdentityUser<TKey>
+        where TUserClaim : IdentityUserClaim<TKey>
+        where TUserLogin : IdentityUserLogin<TKey>
+        where TUserToken : IdentityUserToken<TKey>
+        where TRole : IdentityRole<TKey>
+        where TRoleClaim : IdentityRoleClaim<TKey>
+        where TUserRole : IdentityUserRole<TKey>
+        where TIdentityDbContext : IdentityDbContext<TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken>
+    {
+        public AdminAspNetIdentityConfigurationBuilderWithIdentityDbContext(AdminAspNetIdentityConfiguration<TKey>.Dto dto) : base(dto)
+        {
+        }
+
+        private new AdminAspNetIdentityConfigurationBuilderWithIdentityDbContext<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole, TIdentityDbContext> updateDto(Action<IAdminAspNetIdentityDtoConfigurationBuilder<TKey>> configure = null)
+        {
+            base.updateDto();
+            return this;
+        }
+
+        IAdminAspNetIdentityConfigurationBuilderWithDtoAndIdentityDbContext<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole, TIdentityDbContext> IAdminAspNetIdentityConfigurationBuilderWithIdentityDbContext<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole, TIdentityDbContext>.UseDto(Action<IAdminAspNetIdentityDtoConfigurationBuilder<TKey>> configure) => updateDto(configure);
+
+        IAdminAspNetIdentityConfigurationBuilderWithDtoAndIdentityDbContext<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole, TIdentityDbContext> IAdminAspNetIdentityConfigurationBuilderWithDtoAndIdentityDbContext<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole, TIdentityDbContext>.UseDto(Action<IAdminAspNetIdentityDtoConfigurationBuilder<TKey>> configure) => updateDto(configure);
+
+        IAdminAspNetIdentityConfigurationBuilderWithIdentityDbContext<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole, TNewIdentityDbContext> IAdminAspNetIdentityConfigurationBuilderWithIdentityDbContext<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole, TIdentityDbContext>.UseIdentityDbContext<TNewIdentityDbContext>() =>
+            new AdminAspNetIdentityConfigurationBuilderWithIdentityDbContext<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole, TNewIdentityDbContext>(dto);
+
+        IAdminAspNetIdentityConfigurationBuilderWithDtoAndIdentityDbContext<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole, TNewIdentityDbContext> IAdminAspNetIdentityConfigurationBuilderWithDtoAndIdentityDbContext<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole, TIdentityDbContext>.UseIdentityDbContext<TNewIdentityDbContext>() =>
+            new AdminAspNetIdentityConfigurationBuilderWithIdentityDbContext<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole, TNewIdentityDbContext>(dto);
+
+        IAdminAspNetIdentityConfigurationBuilder<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole, TIdentityDbContext, TPersistedGrantDbContext> IAdminAspNetIdentityConfigurationBuilderWithIdentityDbContext<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole, TIdentityDbContext>.UsePersistedGrantDbContext<TPersistedGrantDbContext>() =>
+            new AdminAspNetIdentityConfigurationBuilder<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole, TIdentityDbContext, TPersistedGrantDbContext>(dto);
+
+        IConfiguredAdminAspNetIdentityConfigurationBuilder<TKey> IAdminAspNetIdentityConfigurationBuilderWithDtoAndIdentityDbContext<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole, TIdentityDbContext>.UsePersistedGrantDbContext<TPersistedGrantDbContext>() =>
+            new AdminAspNetIdentityConfigurationBuilder<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole, TIdentityDbContext, TPersistedGrantDbContext>(dto);
+    }
+
+    internal class AdminAspNetIdentityConfigurationBuilderWithPersistedGrantDbContext<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole, TPersistedGrantDbContext>
+        : AdminAspNetIdentityConfigurationBuilder<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole>,
+          IAdminAspNetIdentityConfigurationBuilder<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole>,
+          IAdminAspNetIdentityConfigurationBuilderWithPersistedGrantDbContext<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole, TPersistedGrantDbContext>,
+          IAdminAspNetIdentityConfigurationBuilderWithDto<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole>,
+          IAdminAspNetIdentityConfigurationBuilderWithDtoAndPersistedGrantDbContext<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole, TPersistedGrantDbContext>
+        where TKey : IEquatable<TKey>
+        where TUser : IdentityUser<TKey>
+        where TUserClaim : IdentityUserClaim<TKey>
+        where TUserLogin : IdentityUserLogin<TKey>
+        where TUserToken : IdentityUserToken<TKey>
+        where TRole : IdentityRole<TKey>
+        where TRoleClaim : IdentityRoleClaim<TKey>
+        where TUserRole : IdentityUserRole<TKey>
+        where TPersistedGrantDbContext : DbContext, IAdminPersistedGrantDbContext
+    {
+        public AdminAspNetIdentityConfigurationBuilderWithPersistedGrantDbContext(AdminAspNetIdentityConfiguration<TKey>.Dto dto) : base(dto)
+        {
+        }
+
+        private new AdminAspNetIdentityConfigurationBuilderWithPersistedGrantDbContext<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole, TPersistedGrantDbContext> updateDto(Action<IAdminAspNetIdentityDtoConfigurationBuilder<TKey>> configure = null)
+        {
+            base.updateDto();
+            return this;
+        }
+
+        IAdminAspNetIdentityConfigurationBuilderWithDtoAndPersistedGrantDbContext<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole, TPersistedGrantDbContext> IAdminAspNetIdentityConfigurationBuilderWithPersistedGrantDbContext<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole, TPersistedGrantDbContext>.UseDto(Action<IAdminAspNetIdentityDtoConfigurationBuilder<TKey>> configure) => updateDto(configure);
+
+        IAdminAspNetIdentityConfigurationBuilderWithDtoAndPersistedGrantDbContext<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole, TPersistedGrantDbContext> IAdminAspNetIdentityConfigurationBuilderWithDtoAndPersistedGrantDbContext<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole, TPersistedGrantDbContext>.UseDto(Action<IAdminAspNetIdentityDtoConfigurationBuilder<TKey>> configure) => updateDto(configure);
+
+        IAdminAspNetIdentityConfigurationBuilder<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole, TIdentityDbContext, TPersistedGrantDbContext> IAdminAspNetIdentityConfigurationBuilderWithPersistedGrantDbContext<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole, TPersistedGrantDbContext>.UseIdentityDbContext<TIdentityDbContext>() =>
+            new AdminAspNetIdentityConfigurationBuilder<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole, TIdentityDbContext, TPersistedGrantDbContext>(dto);
+
+        IConfiguredAdminAspNetIdentityConfigurationBuilder<TKey> IAdminAspNetIdentityConfigurationBuilderWithDtoAndPersistedGrantDbContext<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole, TPersistedGrantDbContext>.UseIdentityDbContext<TIdentityDbContext>() =>
+            new AdminAspNetIdentityConfigurationBuilder<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole, TIdentityDbContext, TPersistedGrantDbContext>(dto);
+
+        IAdminAspNetIdentityConfigurationBuilderWithPersistedGrantDbContext<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole, TNewPersistedGrantDbContext> IAdminAspNetIdentityConfigurationBuilderWithPersistedGrantDbContext<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole, TPersistedGrantDbContext>.UsePersistedGrantDbContext<TNewPersistedGrantDbContext>() =>
+            new AdminAspNetIdentityConfigurationBuilderWithPersistedGrantDbContext<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole, TNewPersistedGrantDbContext>(dto);
+
+        IAdminAspNetIdentityConfigurationBuilderWithDtoAndPersistedGrantDbContext<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole, TNewPersistedGrantDbContext> IAdminAspNetIdentityConfigurationBuilderWithDtoAndPersistedGrantDbContext<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole, TPersistedGrantDbContext>.UsePersistedGrantDbContext<TNewPersistedGrantDbContext>() =>
+            new AdminAspNetIdentityConfigurationBuilderWithPersistedGrantDbContext<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole, TNewPersistedGrantDbContext>(dto);
+    }
+
+    internal class AdminAspNetIdentityConfigurationBuilder<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole, TIdentityDbContext, TPersistedGrantDbContext>
+        : AdminAspNetIdentityConfigurationBuilder<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole>,
+          IAdminAspNetIdentityConfigurationBuilder<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole>,
+          IAdminAspNetIdentityConfigurationBuilder<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole, TIdentityDbContext, TPersistedGrantDbContext>,
+          IAdminAspNetIdentityConfigurationBuilderWithDto<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole>,
+          IConfiguredAdminAspNetIdentityConfigurationBuilder<TKey>
+        where TKey : IEquatable<TKey>
+        where TUser : IdentityUser<TKey>
+        where TUserClaim : IdentityUserClaim<TKey>
+        where TUserLogin : IdentityUserLogin<TKey>
+        where TUserToken : IdentityUserToken<TKey>
+        where TRole : IdentityRole<TKey>
+        where TRoleClaim : IdentityRoleClaim<TKey>
+        where TUserRole : IdentityUserRole<TKey>
+        where TIdentityDbContext : IdentityDbContext<TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken>
+        where TPersistedGrantDbContext : DbContext, IAdminPersistedGrantDbContext
+    {
+        public AdminAspNetIdentityConfigurationBuilder(AdminAspNetIdentityConfiguration<TKey>.Dto dto) : base(dto)
+        {
+        }
+
+        private new AdminAspNetIdentityConfigurationBuilder<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole, TIdentityDbContext, TPersistedGrantDbContext> updateDto(Action<IAdminAspNetIdentityDtoConfigurationBuilder<TKey>> configure = null)
+        {
+            base.updateDto();
+            return this;
+        }
+
+        AdminAspNetIdentityConfiguration<TKey> IConfiguredAdminAspNetIdentityConfigurationBuilder<TKey>.Build() => new AdminAspNetIdentityConfiguration<TKey>
+        {
+            UserType = typeof(TUser),
+            UserClaimType = typeof(TUserClaim),
+            UserLoginType = typeof(TUserLogin),
+            UserTokenType = typeof(TUserToken),
+            RoleType = typeof(TRole),
+            RoleClaimType = typeof(TRoleClaim),
+            UserRoleType = typeof(TUserRole),
+            IdentityDbContextType = typeof(TIdentityDbContext),
+            PersistedGrantDbContextType = typeof(TPersistedGrantDbContext),
+            DtoTypes = dto
+        };
+
+        IConfiguredAdminAspNetIdentityConfigurationBuilder<TKey> IAdminAspNetIdentityConfigurationBuilder<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole, TIdentityDbContext, TPersistedGrantDbContext>.UseDto(Action<IAdminAspNetIdentityDtoConfigurationBuilder<TKey>> configure) => updateDto(configure);
+
+        IAdminAspNetIdentityConfigurationBuilder<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole, TNewIdentityDbContext, TPersistedGrantDbContext> IAdminAspNetIdentityConfigurationBuilder<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole, TIdentityDbContext, TPersistedGrantDbContext>.UseIdentityDbContext<TNewIdentityDbContext>() =>
+            new AdminAspNetIdentityConfigurationBuilder<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole, TNewIdentityDbContext, TPersistedGrantDbContext>(dto);
+
+        IAdminAspNetIdentityConfigurationBuilder<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole, TIdentityDbContext, TNewPersistedGrantDbContext> IAdminAspNetIdentityConfigurationBuilder<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole, TIdentityDbContext, TPersistedGrantDbContext>.UsePersistedGrantDbContext<TNewPersistedGrantDbContext>() =>
+            new AdminAspNetIdentityConfigurationBuilder<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole, TIdentityDbContext, TNewPersistedGrantDbContext>(dto);
+    }
+}

--- a/src/Skoruba.IdentityServer4.Admin.BusinessLogic.Identity/Builders/AdminAspNetIdentityDtoConfigurationBuilder.cs
+++ b/src/Skoruba.IdentityServer4.Admin.BusinessLogic.Identity/Builders/AdminAspNetIdentityDtoConfigurationBuilder.cs
@@ -1,0 +1,75 @@
+using System;
+using Skoruba.IdentityServer4.Admin.BusinessLogic.Identity.Builders.Interfaces;
+using Skoruba.IdentityServer4.Admin.BusinessLogic.Identity.Dtos.Identity;
+
+namespace Skoruba.IdentityServer4.Admin.BusinessLogic.Identity.Builders
+{
+    internal class AdminAspNetIdentityDtoConfigurationBuilder<TKey> : AdminAspNetIdentityDtoConfigurationBuilder<TKey, UserDto<TKey>, RoleDto<TKey>, UserClaimsDto<TKey>, UserProviderDto<TKey>, UserProvidersDto<TKey>, UserChangePasswordDto<TKey>, RoleClaimsDto<TKey>, UserClaimDto<TKey>, RoleClaimDto<TKey>, UsersDto<UserDto<TKey>, TKey>, RolesDto<RoleDto<TKey>, TKey>, UserRolesDto<RoleDto<TKey>, TKey>>, IAdminAspNetIdentityDtoConfigurationBuilder<TKey>
+        where TKey : IEquatable<TKey>
+    {
+    }
+
+    internal class AdminAspNetIdentityDtoConfigurationBuilder<TKey, TUserDto, TRoleDto, TUserClaimsDto, TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto, TUserClaimDto, TRoleClaimDto, TUsersDto, TRolesDto, TUserRolesDto> : IAdminAspNetIdentityDtoConfigurationBuilder<TKey, TUserDto, TRoleDto, TUserClaimsDto, TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto, TUserClaimDto, TRoleClaimDto, TUsersDto, TRolesDto, TUserRolesDto>
+        where TKey : IEquatable<TKey>
+        where TUserDto : UserDto<TKey>
+        where TRoleDto : RoleDto<TKey>
+        where TUserClaimsDto : UserClaimsDto<TKey>
+        where TUserProviderDto : UserProviderDto<TKey>
+        where TUserProvidersDto : UserProvidersDto<TKey>
+        where TUserChangePasswordDto : UserChangePasswordDto<TKey>
+        where TRoleClaimsDto : RoleClaimsDto<TKey>
+        where TUserClaimDto : UserClaimDto<TKey>
+        where TRoleClaimDto : RoleClaimDto<TKey>
+        where TUsersDto : UsersDto<TUserDto, TKey>
+        where TRolesDto : RolesDto<TRoleDto, TKey>
+        where TUserRolesDto : UserRolesDto<TRoleDto, TKey>
+    {
+        public AdminAspNetIdentityConfiguration<TKey>.Dto Build() => new AdminAspNetIdentityConfiguration<TKey>.Dto
+        {
+            User = typeof(TUserDto),
+            Role = typeof(TRoleDto),
+            UserClaims = typeof(TUserClaimsDto),
+            UserProvider = typeof(TUserProviderDto),
+            UserProviders = typeof(TUserProvidersDto),
+            UserChangePassword = typeof(TUserChangePasswordDto),
+            RoleClaims = typeof(TRoleClaimsDto),
+            UserClaim = typeof(TUserClaimDto),
+            RoleClaim = typeof(TRoleClaimDto),
+            Users = typeof(TUsersDto),
+            Roles = typeof(TRolesDto),
+            UserRoles = typeof(TUserRolesDto)
+        };
+
+        public IAdminAspNetIdentityDtoConfigurationBuilder<TKey, TUserDto, TNewRoleDto, TUserClaimsDto, TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto, TUserClaimDto, TRoleClaimDto, TUsersDto, TNewRolesDto, TNewUserRolesDto> UseRole<TNewRoleDto, TNewRolesDto, TNewUserRolesDto>()
+            where TNewRoleDto : RoleDto<TKey>
+            where TNewRolesDto : RolesDto<TNewRoleDto, TKey>
+            where TNewUserRolesDto : UserRolesDto<TNewRoleDto, TKey> =>
+            new AdminAspNetIdentityDtoConfigurationBuilder<TKey, TUserDto, TNewRoleDto, TUserClaimsDto, TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto, TUserClaimDto, TRoleClaimDto, TUsersDto, TNewRolesDto, TNewUserRolesDto>();
+
+        public IAdminAspNetIdentityDtoConfigurationBuilder<TKey, TUserDto, TRoleDto, TUserClaimsDto, TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto, TUserClaimDto, TNewRoleClaimDto, TUsersDto, TRolesDto, TUserRolesDto> UseRoleClaim<TNewRoleClaimDto>() where TNewRoleClaimDto : RoleClaimDto<TKey> =>
+            new AdminAspNetIdentityDtoConfigurationBuilder<TKey, TUserDto, TRoleDto, TUserClaimsDto, TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto, TUserClaimDto, TNewRoleClaimDto, TUsersDto, TRolesDto, TUserRolesDto>();
+
+        public IAdminAspNetIdentityDtoConfigurationBuilder<TKey, TUserDto, TRoleDto, TUserClaimsDto, TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TNewRoleClaimsDto, TUserClaimDto, TRoleClaimDto, TUsersDto, TRolesDto, TUserRolesDto> UseRoleClaims<TNewRoleClaimsDto>() where TNewRoleClaimsDto : RoleClaimsDto<TKey> =>
+            new AdminAspNetIdentityDtoConfigurationBuilder<TKey, TUserDto, TRoleDto, TUserClaimsDto, TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TNewRoleClaimsDto, TUserClaimDto, TRoleClaimDto, TUsersDto, TRolesDto, TUserRolesDto>();
+
+        public IAdminAspNetIdentityDtoConfigurationBuilder<TKey, TNewUserDto, TRoleDto, TUserClaimsDto, TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto, TUserClaimDto, TRoleClaimDto, TNewUsersDto, TRolesDto, TUserRolesDto> UseUser<TNewUserDto, TNewUsersDto>()
+            where TNewUserDto : UserDto<TKey>
+            where TNewUsersDto : UsersDto<TNewUserDto, TKey> =>
+                new AdminAspNetIdentityDtoConfigurationBuilder<TKey, TNewUserDto, TRoleDto, TUserClaimsDto, TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto, TUserClaimDto, TRoleClaimDto, TNewUsersDto, TRolesDto, TUserRolesDto>();
+
+        public IAdminAspNetIdentityDtoConfigurationBuilder<TKey, TUserDto, TRoleDto, TUserClaimsDto, TUserProviderDto, TUserProvidersDto, TNewUserChangePasswordDto, TRoleClaimsDto, TUserClaimDto, TRoleClaimDto, TUsersDto, TRolesDto, TUserRolesDto> UseUserChangePassword<TNewUserChangePasswordDto>() where TNewUserChangePasswordDto : UserChangePasswordDto<TKey> =>
+            new AdminAspNetIdentityDtoConfigurationBuilder<TKey, TUserDto, TRoleDto, TUserClaimsDto, TUserProviderDto, TUserProvidersDto, TNewUserChangePasswordDto, TRoleClaimsDto, TUserClaimDto, TRoleClaimDto, TUsersDto, TRolesDto, TUserRolesDto>();
+
+        public IAdminAspNetIdentityDtoConfigurationBuilder<TKey, TUserDto, TRoleDto, TUserClaimsDto, TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto, TNewUserClaimDto, TRoleClaimDto, TUsersDto, TRolesDto, TUserRolesDto> UseUserClaim<TNewUserClaimDto>() where TNewUserClaimDto : UserClaimDto<TKey> =>
+            new AdminAspNetIdentityDtoConfigurationBuilder<TKey, TUserDto, TRoleDto, TUserClaimsDto, TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto, TNewUserClaimDto, TRoleClaimDto, TUsersDto, TRolesDto, TUserRolesDto>();
+
+        public IAdminAspNetIdentityDtoConfigurationBuilder<TKey, TUserDto, TRoleDto, TNewUserClaimsDto, TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto, TUserClaimDto, TRoleClaimDto, TUsersDto, TRolesDto, TUserRolesDto> UseUserClaims<TNewUserClaimsDto>() where TNewUserClaimsDto : UserClaimsDto<TKey> =>
+            new AdminAspNetIdentityDtoConfigurationBuilder<TKey, TUserDto, TRoleDto, TNewUserClaimsDto, TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto, TUserClaimDto, TRoleClaimDto, TUsersDto, TRolesDto, TUserRolesDto>();
+
+        public IAdminAspNetIdentityDtoConfigurationBuilder<TKey, TUserDto, TRoleDto, TUserClaimsDto, TNewUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto, TUserClaimDto, TRoleClaimDto, TUsersDto, TRolesDto, TUserRolesDto> UseUserProvider<TNewUserProviderDto>() where TNewUserProviderDto : UserProviderDto<TKey> =>
+            new AdminAspNetIdentityDtoConfigurationBuilder<TKey, TUserDto, TRoleDto, TUserClaimsDto, TNewUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto, TUserClaimDto, TRoleClaimDto, TUsersDto, TRolesDto, TUserRolesDto>();
+
+        public IAdminAspNetIdentityDtoConfigurationBuilder<TKey, TUserDto, TRoleDto, TUserClaimsDto, TUserProviderDto, TNewUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto, TUserClaimDto, TRoleClaimDto, TUsersDto, TRolesDto, TUserRolesDto> UseUserProviders<TNewUserProvidersDto>() where TNewUserProvidersDto : UserProvidersDto<TKey> =>
+            new AdminAspNetIdentityDtoConfigurationBuilder<TKey, TUserDto, TRoleDto, TUserClaimsDto, TUserProviderDto, TNewUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto, TUserClaimDto, TRoleClaimDto, TUsersDto, TRolesDto, TUserRolesDto>();
+    }
+}

--- a/src/Skoruba.IdentityServer4.Admin.BusinessLogic.Identity/Builders/Interfaces/IAdminAspNetIdentityConfigurationBuilder.cs
+++ b/src/Skoruba.IdentityServer4.Admin.BusinessLogic.Identity/Builders/Interfaces/IAdminAspNetIdentityConfigurationBuilder.cs
@@ -1,0 +1,87 @@
+using System;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore;
+using Skoruba.IdentityServer4.Admin.EntityFramework.Interfaces;
+
+namespace Skoruba.IdentityServer4.Admin.BusinessLogic.Identity.Builders.Interfaces
+{
+    public interface IAdminAspNetIdentityConfigurationBuilder<TKey> : IAdminAspNetIdentityConfigurationBuilder<TKey, IdentityUser<TKey>, IdentityUserClaim<TKey>, IdentityUserLogin<TKey>, IdentityUserToken<TKey>, IdentityRole<TKey>, IdentityRoleClaim<TKey>, IdentityUserRole<TKey>>
+        where TKey : IEquatable<TKey>
+    {
+    }
+
+    public interface IAdminAspNetIdentityConfigurationBuilder<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole>
+        where TKey : IEquatable<TKey>
+        where TUser : IdentityUser<TKey>
+        where TUserClaim : IdentityUserClaim<TKey>
+        where TUserLogin : IdentityUserLogin<TKey>
+        where TUserToken : IdentityUserToken<TKey>
+        where TRole : IdentityRole<TKey>
+        where TRoleClaim : IdentityRoleClaim<TKey>
+        where TUserRole : IdentityUserRole<TKey>
+    {
+        IAdminAspNetIdentityConfigurationBuilder<TKey, TNewUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole> UseUser<TNewUser>() where TNewUser : IdentityUser<TKey>;
+        IAdminAspNetIdentityConfigurationBuilder<TKey, TUser, TNewUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole> UseUserClaim<TNewUserClaim>() where TNewUserClaim : IdentityUserClaim<TKey>;
+        IAdminAspNetIdentityConfigurationBuilder<TKey, TUser, TUserClaim, TNewUserLogin, TUserToken, TRole, TRoleClaim, TUserRole> UseUserLogin<TNewUserLogin>() where TNewUserLogin : IdentityUserLogin<TKey>;
+        IAdminAspNetIdentityConfigurationBuilder<TKey, TUser, TUserClaim, TUserLogin, TNewUserToken, TRole, TRoleClaim, TUserRole> UseUserToken<TNewUserToken>() where TNewUserToken : IdentityUserToken<TKey>;
+        IAdminAspNetIdentityConfigurationBuilder<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TNewRole, TRoleClaim, TUserRole> UseRole<TNewRole>() where TNewRole : IdentityRole<TKey>;
+        IAdminAspNetIdentityConfigurationBuilder<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TNewRoleClaim, TUserRole> UseRoleClaim<TNewRoleClaim>() where TNewRoleClaim : IdentityRoleClaim<TKey>;
+        IAdminAspNetIdentityConfigurationBuilder<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TNewUserRole> UseUserRole<TNewUserRole>() where TNewUserRole : IdentityUserRole<TKey>;
+        IAdminAspNetIdentityConfigurationBuilderWithIdentityDbContext<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole, TIdentityDbContext> UseIdentityDbContext<TIdentityDbContext>() where TIdentityDbContext : IdentityDbContext<TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken>;
+        IAdminAspNetIdentityConfigurationBuilderWithPersistedGrantDbContext<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole, TPersistedGrantDbContext> UsePersistedGrantDbContext<TPersistedGrantDbContext>() where TPersistedGrantDbContext : DbContext, IAdminPersistedGrantDbContext;
+        IAdminAspNetIdentityConfigurationBuilderWithDto<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole> UseDto(Action<IAdminAspNetIdentityDtoConfigurationBuilder<TKey>> configure);
+    }
+
+    public interface IAdminAspNetIdentityConfigurationBuilder<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole, TIdentityDbContext, TPersistedGrantDbContext>
+        : IAdminAspNetIdentityConfigurationBuilder<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole>
+        where TKey : IEquatable<TKey>
+        where TUser : IdentityUser<TKey>
+        where TUserClaim : IdentityUserClaim<TKey>
+        where TUserLogin : IdentityUserLogin<TKey>
+        where TUserToken : IdentityUserToken<TKey>
+        where TRole : IdentityRole<TKey>
+        where TRoleClaim : IdentityRoleClaim<TKey>
+        where TUserRole : IdentityUserRole<TKey>
+        where TIdentityDbContext : IdentityDbContext<TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken>
+        where TPersistedGrantDbContext : DbContext, IAdminPersistedGrantDbContext
+    {
+        new IAdminAspNetIdentityConfigurationBuilder<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole, TNewIdentityDbContext, TPersistedGrantDbContext> UseIdentityDbContext<TNewIdentityDbContext>() where TNewIdentityDbContext : IdentityDbContext<TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken>;
+        new IAdminAspNetIdentityConfigurationBuilder<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole, TIdentityDbContext, TNewPersistedGrantDbContext> UsePersistedGrantDbContext<TNewPersistedGrantDbContext>() where TNewPersistedGrantDbContext : DbContext, IAdminPersistedGrantDbContext;
+        new IConfiguredAdminAspNetIdentityConfigurationBuilder<TKey> UseDto(Action<IAdminAspNetIdentityDtoConfigurationBuilder<TKey>> configure);
+    }
+
+    public interface IAdminAspNetIdentityConfigurationBuilderWithIdentityDbContext<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole, TIdentityDbContext>
+        : IAdminAspNetIdentityConfigurationBuilder<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole>
+        where TKey : IEquatable<TKey>
+        where TUser : IdentityUser<TKey>
+        where TUserClaim : IdentityUserClaim<TKey>
+        where TUserLogin : IdentityUserLogin<TKey>
+        where TUserToken : IdentityUserToken<TKey>
+        where TRole : IdentityRole<TKey>
+        where TRoleClaim : IdentityRoleClaim<TKey>
+        where TUserRole : IdentityUserRole<TKey>
+        where TIdentityDbContext : IdentityDbContext<TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken>
+    {
+        new IAdminAspNetIdentityConfigurationBuilderWithIdentityDbContext<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole, TNewIdentityDbContext> UseIdentityDbContext<TNewIdentityDbContext>() where TNewIdentityDbContext : IdentityDbContext<TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken>;
+        new IAdminAspNetIdentityConfigurationBuilder<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole, TIdentityDbContext, TPersistedGrantDbContext> UsePersistedGrantDbContext<TPersistedGrantDbContext>() where TPersistedGrantDbContext : DbContext, IAdminPersistedGrantDbContext;
+        new IAdminAspNetIdentityConfigurationBuilderWithDtoAndIdentityDbContext<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole, TIdentityDbContext> UseDto(Action<IAdminAspNetIdentityDtoConfigurationBuilder<TKey>> configure);
+    }
+
+    public interface IAdminAspNetIdentityConfigurationBuilderWithPersistedGrantDbContext<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole, TPersistedGrantDbContext>
+        : IAdminAspNetIdentityConfigurationBuilder<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole>
+        where TKey : IEquatable<TKey>
+        where TUser : IdentityUser<TKey>
+        where TUserClaim : IdentityUserClaim<TKey>
+        where TUserLogin : IdentityUserLogin<TKey>
+        where TUserToken : IdentityUserToken<TKey>
+        where TRole : IdentityRole<TKey>
+        where TRoleClaim : IdentityRoleClaim<TKey>
+        where TUserRole : IdentityUserRole<TKey>
+        where TPersistedGrantDbContext : DbContext, IAdminPersistedGrantDbContext
+    {
+        new IAdminAspNetIdentityConfigurationBuilderWithPersistedGrantDbContext<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole, TNewPersistedGrantDbContext> UsePersistedGrantDbContext<TNewPersistedGrantDbContext>() where TNewPersistedGrantDbContext : DbContext, IAdminPersistedGrantDbContext;
+        new IAdminAspNetIdentityConfigurationBuilder<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole, TIdentityDbContext, TPersistedGrantDbContext> UseIdentityDbContext<TIdentityDbContext>() where TIdentityDbContext : IdentityDbContext<TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken>;
+        new IAdminAspNetIdentityConfigurationBuilderWithDtoAndPersistedGrantDbContext<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole, TPersistedGrantDbContext> UseDto(Action<IAdminAspNetIdentityDtoConfigurationBuilder<TKey>> configure);
+    }
+}

--- a/src/Skoruba.IdentityServer4.Admin.BusinessLogic.Identity/Builders/Interfaces/IAdminAspNetIdentityConfigurationBuilderWithDto.cs
+++ b/src/Skoruba.IdentityServer4.Admin.BusinessLogic.Identity/Builders/Interfaces/IAdminAspNetIdentityConfigurationBuilderWithDto.cs
@@ -1,0 +1,58 @@
+using System;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore;
+using Skoruba.IdentityServer4.Admin.EntityFramework.Interfaces;
+
+namespace Skoruba.IdentityServer4.Admin.BusinessLogic.Identity.Builders.Interfaces
+{
+    public interface IAdminAspNetIdentityConfigurationBuilderWithDto<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole>
+        : IAdminAspNetIdentityConfigurationBuilder<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole>
+        where TKey : IEquatable<TKey>
+        where TUser : IdentityUser<TKey>
+        where TUserClaim : IdentityUserClaim<TKey>
+        where TUserLogin : IdentityUserLogin<TKey>
+        where TUserToken : IdentityUserToken<TKey>
+        where TRole : IdentityRole<TKey>
+        where TRoleClaim : IdentityRoleClaim<TKey>
+        where TUserRole : IdentityUserRole<TKey>
+    {
+        new IAdminAspNetIdentityConfigurationBuilderWithDto<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole> UseDto(Action<IAdminAspNetIdentityDtoConfigurationBuilder<TKey>> configure);
+        new IAdminAspNetIdentityConfigurationBuilderWithDtoAndIdentityDbContext<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole, TIdentityDbContext> UseIdentityDbContext<TIdentityDbContext>() where TIdentityDbContext : IdentityDbContext<TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken>;
+        new IAdminAspNetIdentityConfigurationBuilderWithDtoAndPersistedGrantDbContext<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole, TPersistedGrantDbContext> UsePersistedGrantDbContext<TPersistedGrantDbContext>() where TPersistedGrantDbContext : DbContext, IAdminPersistedGrantDbContext;
+    }
+
+    public interface IAdminAspNetIdentityConfigurationBuilderWithDtoAndIdentityDbContext<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole, TIdentityDbContext>
+        : IAdminAspNetIdentityConfigurationBuilderWithDto<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole>
+        where TKey : IEquatable<TKey>
+        where TUser : IdentityUser<TKey>
+        where TUserClaim : IdentityUserClaim<TKey>
+        where TUserLogin : IdentityUserLogin<TKey>
+        where TUserToken : IdentityUserToken<TKey>
+        where TRole : IdentityRole<TKey>
+        where TRoleClaim : IdentityRoleClaim<TKey>
+        where TUserRole : IdentityUserRole<TKey>
+        where TIdentityDbContext : IdentityDbContext<TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken>
+    {
+        new IAdminAspNetIdentityConfigurationBuilderWithDtoAndIdentityDbContext<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole, TIdentityDbContext> UseDto(Action<IAdminAspNetIdentityDtoConfigurationBuilder<TKey>> configure);
+        new IAdminAspNetIdentityConfigurationBuilderWithDtoAndIdentityDbContext<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole, TNewIdentityDbContext> UseIdentityDbContext<TNewIdentityDbContext>() where TNewIdentityDbContext : IdentityDbContext<TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken>;
+        new IConfiguredAdminAspNetIdentityConfigurationBuilder<TKey> UsePersistedGrantDbContext<TPersistedGrantDbContext>() where TPersistedGrantDbContext : DbContext, IAdminPersistedGrantDbContext;
+    }
+
+    public interface IAdminAspNetIdentityConfigurationBuilderWithDtoAndPersistedGrantDbContext<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole, TPersistedGrantDbContext>
+        : IAdminAspNetIdentityConfigurationBuilderWithDto<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole>
+        where TKey : IEquatable<TKey>
+        where TUser : IdentityUser<TKey>
+        where TUserClaim : IdentityUserClaim<TKey>
+        where TUserLogin : IdentityUserLogin<TKey>
+        where TUserToken : IdentityUserToken<TKey>
+        where TRole : IdentityRole<TKey>
+        where TRoleClaim : IdentityRoleClaim<TKey>
+        where TUserRole : IdentityUserRole<TKey>
+        where TPersistedGrantDbContext : DbContext, IAdminPersistedGrantDbContext
+    {
+        new IAdminAspNetIdentityConfigurationBuilderWithDtoAndPersistedGrantDbContext<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole, TPersistedGrantDbContext> UseDto(Action<IAdminAspNetIdentityDtoConfigurationBuilder<TKey>> configure);
+        new IAdminAspNetIdentityConfigurationBuilderWithDtoAndPersistedGrantDbContext<TKey, TUser, TUserClaim, TUserLogin, TUserToken, TRole, TRoleClaim, TUserRole, TNewPersistedGrantDbContext> UsePersistedGrantDbContext<TNewPersistedGrantDbContext>() where TNewPersistedGrantDbContext : DbContext, IAdminPersistedGrantDbContext;
+        new IConfiguredAdminAspNetIdentityConfigurationBuilder<TKey> UseIdentityDbContext<TIdentityDbContext>() where TIdentityDbContext : IdentityDbContext<TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken>;
+    }
+}

--- a/src/Skoruba.IdentityServer4.Admin.BusinessLogic.Identity/Builders/Interfaces/IAdminAspNetIdentityDtoConfigurationBuilder.cs
+++ b/src/Skoruba.IdentityServer4.Admin.BusinessLogic.Identity/Builders/Interfaces/IAdminAspNetIdentityDtoConfigurationBuilder.cs
@@ -1,0 +1,37 @@
+using System;
+using Skoruba.IdentityServer4.Admin.BusinessLogic.Identity.Dtos.Identity;
+
+namespace Skoruba.IdentityServer4.Admin.BusinessLogic.Identity.Builders.Interfaces
+{
+    public interface IAdminAspNetIdentityDtoConfigurationBuilder<TKey>
+        : IAdminAspNetIdentityDtoConfigurationBuilder<TKey, UserDto<TKey>, RoleDto<TKey>, UserClaimsDto<TKey>, UserProviderDto<TKey>, UserProvidersDto<TKey>, UserChangePasswordDto<TKey>, RoleClaimsDto<TKey>, UserClaimDto<TKey>, RoleClaimDto<TKey>, UsersDto<UserDto<TKey>, TKey>, RolesDto<RoleDto<TKey>, TKey>, UserRolesDto<RoleDto<TKey>, TKey>>
+        where TKey : IEquatable<TKey>
+    {
+    }
+
+    public interface IAdminAspNetIdentityDtoConfigurationBuilder<TKey, TUserDto, TRoleDto, TUserClaimsDto, TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto, TUserClaimDto, TRoleClaimDto, TUsersDto, TRolesDto, TUserRolesDto>
+        where TKey : IEquatable<TKey>
+        where TUserDto : UserDto<TKey>
+        where TRoleDto : RoleDto<TKey>
+        where TUserClaimsDto : UserClaimsDto<TKey>
+        where TUserProviderDto : UserProviderDto<TKey>
+        where TUserProvidersDto : UserProvidersDto<TKey>
+        where TUserChangePasswordDto : UserChangePasswordDto<TKey>
+        where TRoleClaimsDto : RoleClaimsDto<TKey>
+        where TUserClaimDto : UserClaimDto<TKey>
+        where TRoleClaimDto : RoleClaimDto<TKey>
+        where TUsersDto : UsersDto<TUserDto, TKey>
+        where TRolesDto : RolesDto<TRoleDto, TKey>
+        where TUserRolesDto : UserRolesDto<TRoleDto, TKey>
+    {
+        IAdminAspNetIdentityDtoConfigurationBuilder<TKey, TUserDto, TNewRoleDto, TUserClaimsDto, TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto, TUserClaimDto, TRoleClaimDto, TUsersDto, TNewRolesDto, TNewUserRolesDto> UseRole<TNewRoleDto, TNewRolesDto, TNewUserRolesDto>() where TNewRoleDto : RoleDto<TKey> where TNewRolesDto : RolesDto<TNewRoleDto, TKey> where TNewUserRolesDto : UserRolesDto<TNewRoleDto, TKey>;
+        IAdminAspNetIdentityDtoConfigurationBuilder<TKey, TUserDto, TRoleDto, TUserClaimsDto, TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto, TUserClaimDto, TNewRoleClaimDto, TUsersDto, TRolesDto, TUserRolesDto> UseRoleClaim<TNewRoleClaimDto>() where TNewRoleClaimDto : RoleClaimDto<TKey>;
+        IAdminAspNetIdentityDtoConfigurationBuilder<TKey, TUserDto, TRoleDto, TUserClaimsDto, TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TNewRoleClaimsDto, TUserClaimDto, TRoleClaimDto, TUsersDto, TRolesDto, TUserRolesDto> UseRoleClaims<TNewRoleClaimsDto>() where TNewRoleClaimsDto : RoleClaimsDto<TKey>;
+        IAdminAspNetIdentityDtoConfigurationBuilder<TKey, TNewUserDto, TRoleDto, TUserClaimsDto, TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto, TUserClaimDto, TRoleClaimDto, TNewUsersDto, TRolesDto, TUserRolesDto> UseUser<TNewUserDto, TNewUsersDto>() where TNewUserDto : UserDto<TKey> where TNewUsersDto : UsersDto<TNewUserDto, TKey>;
+        IAdminAspNetIdentityDtoConfigurationBuilder<TKey, TUserDto, TRoleDto, TUserClaimsDto, TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto, TNewUserClaimDto, TRoleClaimDto, TUsersDto, TRolesDto, TUserRolesDto> UseUserClaim<TNewUserClaimDto>() where TNewUserClaimDto : UserClaimDto<TKey>;
+        IAdminAspNetIdentityDtoConfigurationBuilder<TKey, TUserDto, TRoleDto, TNewUserClaimsDto, TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto, TUserClaimDto, TRoleClaimDto, TUsersDto, TRolesDto, TUserRolesDto> UseUserClaims<TNewUserClaimsDto>() where TNewUserClaimsDto : UserClaimsDto<TKey>;
+        IAdminAspNetIdentityDtoConfigurationBuilder<TKey, TUserDto, TRoleDto, TUserClaimsDto, TNewUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto, TUserClaimDto, TRoleClaimDto, TUsersDto, TRolesDto, TUserRolesDto> UseUserProvider<TNewUserProviderDto>() where TNewUserProviderDto : UserProviderDto<TKey>;
+        IAdminAspNetIdentityDtoConfigurationBuilder<TKey, TUserDto, TRoleDto, TUserClaimsDto, TUserProviderDto, TNewUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto, TUserClaimDto, TRoleClaimDto, TUsersDto, TRolesDto, TUserRolesDto> UseUserProviders<TNewUserProvidersDto>() where TNewUserProvidersDto : UserProvidersDto<TKey>;
+        IAdminAspNetIdentityDtoConfigurationBuilder<TKey, TUserDto, TRoleDto, TUserClaimsDto, TUserProviderDto, TUserProvidersDto, TNewUserChangePasswordDto, TRoleClaimsDto, TUserClaimDto, TRoleClaimDto, TUsersDto, TRolesDto, TUserRolesDto> UseUserChangePassword<TNewUserChangePasswordDto>() where TNewUserChangePasswordDto : UserChangePasswordDto<TKey>;
+    }
+}

--- a/src/Skoruba.IdentityServer4.Admin.BusinessLogic.Identity/Builders/Interfaces/IConfiguredAdminAspNetIdentityConfigurationBuilder.cs
+++ b/src/Skoruba.IdentityServer4.Admin.BusinessLogic.Identity/Builders/Interfaces/IConfiguredAdminAspNetIdentityConfigurationBuilder.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace Skoruba.IdentityServer4.Admin.BusinessLogic.Identity.Builders.Interfaces
+{
+    public interface IConfiguredAdminAspNetIdentityConfigurationBuilder<TKey>
+        where TKey : IEquatable<TKey>
+    {
+        AdminAspNetIdentityConfiguration<TKey> Build();
+    }
+}

--- a/src/Skoruba.IdentityServer4.Admin.BusinessLogic.Identity/Dtos/Identity/Base/BaseUserRolesDto.cs
+++ b/src/Skoruba.IdentityServer4.Admin.BusinessLogic.Identity/Dtos/Identity/Base/BaseUserRolesDto.cs
@@ -2,11 +2,11 @@
 
 namespace Skoruba.IdentityServer4.Admin.BusinessLogic.Identity.Dtos.Identity.Base
 {
-    public class BaseUserRolesDto<TUserDtoKey, TRoleDtoKey> : IBaseUserRolesDto
+    public class BaseUserRolesDto<TKey> : IBaseUserRolesDto
     {
-        public TUserDtoKey UserId { get; set; }
+        public TKey UserId { get; set; }
 
-        public TRoleDtoKey RoleId { get; set; }
+        public TKey RoleId { get; set; }
 
         object IBaseUserRolesDto.UserId => UserId;
 

--- a/src/Skoruba.IdentityServer4.Admin.BusinessLogic.Identity/Dtos/Identity/RoleClaimDto.cs
+++ b/src/Skoruba.IdentityServer4.Admin.BusinessLogic.Identity/Dtos/Identity/RoleClaimDto.cs
@@ -4,7 +4,7 @@ using Skoruba.IdentityServer4.Admin.BusinessLogic.Identity.Dtos.Identity.Interfa
 
 namespace Skoruba.IdentityServer4.Admin.BusinessLogic.Identity.Dtos.Identity
 {
-    public class RoleClaimDto<TRoleDtoKey> : BaseRoleClaimDto<TRoleDtoKey>, IRoleClaimDto
+    public class RoleClaimDto<TKey> : BaseRoleClaimDto<TKey>, IRoleClaimDto
     {
         [Required]
         public string ClaimType { get; set; }

--- a/src/Skoruba.IdentityServer4.Admin.BusinessLogic.Identity/Dtos/Identity/RoleClaimsDto.cs
+++ b/src/Skoruba.IdentityServer4.Admin.BusinessLogic.Identity/Dtos/Identity/RoleClaimsDto.cs
@@ -4,16 +4,16 @@ using System.Linq;
 
 namespace Skoruba.IdentityServer4.Admin.BusinessLogic.Identity.Dtos.Identity
 {
-    public class RoleClaimsDto<TRoleDtoKey> : RoleClaimDto<TRoleDtoKey>, IRoleClaimsDto
+    public class RoleClaimsDto<TKey> : RoleClaimDto<TKey>, IRoleClaimsDto
     {
         public RoleClaimsDto()
         {
-            Claims = new List<RoleClaimDto<TRoleDtoKey>>();
+            Claims = new List<RoleClaimDto<TKey>>();
         }
 
         public string RoleName { get; set; }
 
-        public List<RoleClaimDto<TRoleDtoKey>> Claims { get; set; }
+        public List<RoleClaimDto<TKey>> Claims { get; set; }
 
         public int TotalCount { get; set; }
 

--- a/src/Skoruba.IdentityServer4.Admin.BusinessLogic.Identity/Dtos/Identity/RolesDto.cs
+++ b/src/Skoruba.IdentityServer4.Admin.BusinessLogic.Identity/Dtos/Identity/RolesDto.cs
@@ -4,7 +4,7 @@ using System.Linq;
 
 namespace Skoruba.IdentityServer4.Admin.BusinessLogic.Identity.Dtos.Identity
 {
-    public class RolesDto<TRoleDto, TRoleDtoKey>: IRolesDto where TRoleDto : RoleDto<TRoleDtoKey>
+    public class RolesDto<TRoleDto, TKey>: IRolesDto where TRoleDto : RoleDto<TKey>
     {
         public RolesDto()
         {

--- a/src/Skoruba.IdentityServer4.Admin.BusinessLogic.Identity/Dtos/Identity/UserChangePasswordDto.cs
+++ b/src/Skoruba.IdentityServer4.Admin.BusinessLogic.Identity/Dtos/Identity/UserChangePasswordDto.cs
@@ -4,7 +4,7 @@ using Skoruba.IdentityServer4.Admin.BusinessLogic.Identity.Dtos.Identity.Interfa
 
 namespace Skoruba.IdentityServer4.Admin.BusinessLogic.Identity.Dtos.Identity
 {
-    public class UserChangePasswordDto<TUserDtoKey> : BaseUserChangePasswordDto<TUserDtoKey>, IUserChangePasswordDto
+    public class UserChangePasswordDto<TKey> : BaseUserChangePasswordDto<TKey>, IUserChangePasswordDto
     {
         public string UserName { get; set; }
 

--- a/src/Skoruba.IdentityServer4.Admin.BusinessLogic.Identity/Dtos/Identity/UserClaimDto.cs
+++ b/src/Skoruba.IdentityServer4.Admin.BusinessLogic.Identity/Dtos/Identity/UserClaimDto.cs
@@ -4,7 +4,7 @@ using Skoruba.IdentityServer4.Admin.BusinessLogic.Identity.Dtos.Identity.Interfa
 
 namespace Skoruba.IdentityServer4.Admin.BusinessLogic.Identity.Dtos.Identity
 {
-    public class UserClaimDto<TUserDtoKey> : BaseUserClaimDto<TUserDtoKey>, IUserClaimDto
+    public class UserClaimDto<TKey> : BaseUserClaimDto<TKey>, IUserClaimDto
     {
         [Required]
         public string ClaimType { get; set; }

--- a/src/Skoruba.IdentityServer4.Admin.BusinessLogic.Identity/Dtos/Identity/UserClaimsDto.cs
+++ b/src/Skoruba.IdentityServer4.Admin.BusinessLogic.Identity/Dtos/Identity/UserClaimsDto.cs
@@ -4,16 +4,16 @@ using System.Linq;
 
 namespace Skoruba.IdentityServer4.Admin.BusinessLogic.Identity.Dtos.Identity
 {
-    public class UserClaimsDto<TUserDtoKey> : UserClaimDto<TUserDtoKey>, IUserClaimsDto
+    public class UserClaimsDto<TKey> : UserClaimDto<TKey>, IUserClaimsDto
     {
         public UserClaimsDto()
         {
-            Claims = new List<UserClaimDto<TUserDtoKey>>();
+            Claims = new List<UserClaimDto<TKey>>();
         }
 
         public string UserName { get; set; }
 
-        public List<UserClaimDto<TUserDtoKey>> Claims { get; set; }
+        public List<UserClaimDto<TKey>> Claims { get; set; }
 
         public int TotalCount { get; set; }
 

--- a/src/Skoruba.IdentityServer4.Admin.BusinessLogic.Identity/Dtos/Identity/UserProviderDto.cs
+++ b/src/Skoruba.IdentityServer4.Admin.BusinessLogic.Identity/Dtos/Identity/UserProviderDto.cs
@@ -3,7 +3,7 @@ using Skoruba.IdentityServer4.Admin.BusinessLogic.Identity.Dtos.Identity.Interfa
 
 namespace Skoruba.IdentityServer4.Admin.BusinessLogic.Identity.Dtos.Identity
 {
-    public class UserProviderDto<TUserDtoKey> : BaseUserProviderDto<TUserDtoKey>, IUserProviderDto
+    public class UserProviderDto<TKey> : BaseUserProviderDto<TKey>, IUserProviderDto
     {
         public string UserName { get; set; }
 

--- a/src/Skoruba.IdentityServer4.Admin.BusinessLogic.Identity/Dtos/Identity/UserProvidersDto.cs
+++ b/src/Skoruba.IdentityServer4.Admin.BusinessLogic.Identity/Dtos/Identity/UserProvidersDto.cs
@@ -4,14 +4,14 @@ using System.Linq;
 
 namespace Skoruba.IdentityServer4.Admin.BusinessLogic.Identity.Dtos.Identity
 {
-    public class UserProvidersDto<TUserDtoKey> : UserProviderDto<TUserDtoKey>, IUserProvidersDto
+    public class UserProvidersDto<TKey> : UserProviderDto<TKey>, IUserProvidersDto
     {
         public UserProvidersDto()
         {
-            Providers = new List<UserProviderDto<TUserDtoKey>>();
+            Providers = new List<UserProviderDto<TKey>>();
         }
 
-        public List<UserProviderDto<TUserDtoKey>> Providers { get; set; }
+        public List<UserProviderDto<TKey>> Providers { get; set; }
 
         List<IUserProviderDto> IUserProvidersDto.Providers => Providers.Cast<IUserProviderDto>().ToList();
     }

--- a/src/Skoruba.IdentityServer4.Admin.BusinessLogic.Identity/Dtos/Identity/UserRolesDto.cs
+++ b/src/Skoruba.IdentityServer4.Admin.BusinessLogic.Identity/Dtos/Identity/UserRolesDto.cs
@@ -6,8 +6,8 @@ using Skoruba.IdentityServer4.Admin.BusinessLogic.Shared.Dtos.Common;
 
 namespace Skoruba.IdentityServer4.Admin.BusinessLogic.Identity.Dtos.Identity
 {
-    public class UserRolesDto<TRoleDto, TUserDtoKey, TRoleDtoKey> : BaseUserRolesDto<TUserDtoKey, TRoleDtoKey>, IUserRolesDto
-        where TRoleDto : RoleDto<TRoleDtoKey>
+    public class UserRolesDto<TRoleDto, TKey> : BaseUserRolesDto<TKey>, IUserRolesDto
+        where TRoleDto : RoleDto<TKey>
     {
         public UserRolesDto()
         {

--- a/src/Skoruba.IdentityServer4.Admin.BusinessLogic.Identity/Dtos/Identity/UsersDto.cs
+++ b/src/Skoruba.IdentityServer4.Admin.BusinessLogic.Identity/Dtos/Identity/UsersDto.cs
@@ -4,7 +4,7 @@ using System.Linq;
 
 namespace Skoruba.IdentityServer4.Admin.BusinessLogic.Identity.Dtos.Identity
 {
-    public class UsersDto<TUserDto, TUserDtoKey> : IUsersDto where TUserDto : UserDto<TUserDtoKey>
+    public class UsersDto<TUserDto, TKey> : IUsersDto where TUserDto : UserDto<TKey>
     {
         public UsersDto()
         {

--- a/src/Skoruba.IdentityServer4.Admin.BusinessLogic.Identity/Extensions/AdminServicesExtensions.cs
+++ b/src/Skoruba.IdentityServer4.Admin.BusinessLogic.Identity/Extensions/AdminServicesExtensions.cs
@@ -38,15 +38,15 @@ namespace Microsoft.Extensions.DependencyInjection
             where TPersistedGrantDbContext : DbContext, IAdminPersistedGrantDbContext
             where TUser : IdentityUser
         {
-            return services.AddAdminAspNetIdentityServices<TIdentityDbContext, TPersistedGrantDbContext, UserDto<string>, string, RoleDto<string>, string, string,
-                string, TUser, IdentityRole, string, IdentityUserClaim<string>, IdentityUserRole<string>, IdentityUserLogin<string>, IdentityRoleClaim<string>, IdentityUserToken<string>,
+            return services.AddAdminAspNetIdentityServices<TIdentityDbContext, TPersistedGrantDbContext, UserDto<string>, string, RoleDto<string>, string,
+                TUser, IdentityRole, string, IdentityUserClaim<string>, IdentityUserRole<string>, IdentityUserLogin<string>, IdentityRoleClaim<string>, IdentityUserToken<string>,
                 UsersDto<UserDto<string>, string>, RolesDto<RoleDto<string>, string>, UserRolesDto<RoleDto<string>, string, string>,
                 UserClaimsDto<string>, UserProviderDto<string>, UserProvidersDto<string>, UserChangePasswordDto<string>,
                 RoleClaimsDto<string>, UserClaimDto<string>, RoleClaimDto<string>>();
         }
 
-        public static IServiceCollection AddAdminAspNetIdentityServices<TAdminDbContext, TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUserKey,
-            TRoleKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
+        public static IServiceCollection AddAdminAspNetIdentityServices<TAdminDbContext, TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey,
+            TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
             TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
             TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto,
             TUserClaimDto, TRoleClaimDto>(
@@ -76,13 +76,13 @@ namespace Microsoft.Extensions.DependencyInjection
             where TRoleClaimDto : RoleClaimDto<TRoleDtoKey>
         {
 
-            return services.AddAdminAspNetIdentityServices<TAdminDbContext, TAdminDbContext, TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUserKey,
-                TRoleKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
+            return services.AddAdminAspNetIdentityServices<TAdminDbContext, TAdminDbContext, TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey,
+                TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
                 TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
                 TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto, TUserClaimDto, TRoleClaimDto>();
         }
 
-        public static IServiceCollection AddAdminAspNetIdentityServices<TIdentityDbContext, TPersistedGrantDbContext, TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUserKey, TRoleKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
+        public static IServiceCollection AddAdminAspNetIdentityServices<TIdentityDbContext, TPersistedGrantDbContext, TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
                     TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
                     TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto, TUserClaimDto, TRoleClaimDto>(
                         this IServiceCollection services)
@@ -110,14 +110,14 @@ namespace Microsoft.Extensions.DependencyInjection
             where TRoleClaimDto : RoleClaimDto<TRoleDtoKey>
         {
             return AddAdminAspNetIdentityServices<TIdentityDbContext, TPersistedGrantDbContext, TUserDto, TUserDtoKey,
-                TRoleDto, TRoleDtoKey, TUserKey, TRoleKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin,
+                TRoleDto, TRoleDtoKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin,
                 TRoleClaim, TUserToken,
                 TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
                 TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto, TUserClaimDto,
                 TRoleClaimDto>(services, null);
         }
 
-        public static IServiceCollection AddAdminAspNetIdentityServices<TIdentityDbContext, TPersistedGrantDbContext, TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUserKey, TRoleKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
+        public static IServiceCollection AddAdminAspNetIdentityServices<TIdentityDbContext, TPersistedGrantDbContext, TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
                     TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
                     TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto, TUserClaimDto, TRoleClaimDto>(
                         this IServiceCollection services, HashSet<Type> profileTypes)
@@ -145,14 +145,14 @@ namespace Microsoft.Extensions.DependencyInjection
             where TRoleClaimDto : RoleClaimDto<TRoleDtoKey>
         {
             //Repositories
-            services.AddTransient<IIdentityRepository<TUserKey, TRoleKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken>, IdentityRepository<TIdentityDbContext, TUserKey, TRoleKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken>>();
+            services.AddTransient<IIdentityRepository<TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken>, IdentityRepository<TIdentityDbContext, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken>>();
             services.AddTransient<IPersistedGrantAspNetIdentityRepository, PersistedGrantAspNetIdentityRepository<TIdentityDbContext, TPersistedGrantDbContext, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken>>();
           
             //Services
-            services.AddTransient<IIdentityService<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUserKey, TRoleKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
+            services.AddTransient<IIdentityService<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
                 TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
                 TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto>, 
-                IdentityService<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUserKey, TRoleKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
+                IdentityService<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
                     TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
                     TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto>>();
             services.AddTransient<IPersistedGrantAspNetIdentityService, PersistedGrantAspNetIdentityService>();

--- a/src/Skoruba.IdentityServer4.Admin.BusinessLogic.Identity/Extensions/AdminServicesExtensions.cs
+++ b/src/Skoruba.IdentityServer4.Admin.BusinessLogic.Identity/Extensions/AdminServicesExtensions.cs
@@ -38,9 +38,9 @@ namespace Microsoft.Extensions.DependencyInjection
             where TPersistedGrantDbContext : DbContext, IAdminPersistedGrantDbContext
             where TUser : IdentityUser
         {
-            return services.AddAdminAspNetIdentityServices<TIdentityDbContext, TPersistedGrantDbContext, UserDto<string>, string, RoleDto<string>, string,
+            return services.AddAdminAspNetIdentityServices<TIdentityDbContext, TPersistedGrantDbContext, UserDto<string>, RoleDto<string>,
                 TUser, IdentityRole, string, IdentityUserClaim<string>, IdentityUserRole<string>, IdentityUserLogin<string>, IdentityRoleClaim<string>, IdentityUserToken<string>,
-                UsersDto<UserDto<string>, string>, RolesDto<RoleDto<string>, string>, UserRolesDto<RoleDto<string>, string, string>,
+                UsersDto<UserDto<string>, string>, RolesDto<RoleDto<string>, string>, UserRolesDto<RoleDto<string>, string>,
                 UserClaimsDto<string>, UserProviderDto<string>, UserProvidersDto<string>, UserChangePasswordDto<string>,
                 RoleClaimsDto<string>, UserClaimDto<string>, RoleClaimDto<string>>();
         }
@@ -54,7 +54,7 @@ namespace Microsoft.Extensions.DependencyInjection
             where TAdminDbContext :
             IdentityDbContext<TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken>,
             IAdminPersistedGrantDbContext
-            where TUserDto : UserDto<TUserDtoKey>
+            where TUserDto : UserDto<TKey>
             where TUser : IdentityUser<TKey>
             where TRole : IdentityRole<TKey>
             where TKey : IEquatable<TKey>
@@ -63,32 +63,32 @@ namespace Microsoft.Extensions.DependencyInjection
             where TUserLogin : IdentityUserLogin<TKey>
             where TRoleClaim : IdentityRoleClaim<TKey>
             where TUserToken : IdentityUserToken<TKey>
-            where TRoleDto : RoleDto<TRoleDtoKey>
-            where TUsersDto : UsersDto<TUserDto, TUserDtoKey>
-            where TRolesDto : RolesDto<TRoleDto, TRoleDtoKey>
-            where TUserRolesDto : UserRolesDto<TRoleDto, TUserDtoKey, TRoleDtoKey>
-            where TUserClaimsDto : UserClaimsDto<TUserDtoKey>
-            where TUserProviderDto : UserProviderDto<TUserDtoKey>
-            where TUserProvidersDto : UserProvidersDto<TUserDtoKey>
-            where TUserChangePasswordDto : UserChangePasswordDto<TUserDtoKey>
-            where TRoleClaimsDto : RoleClaimsDto<TRoleDtoKey>
-            where TUserClaimDto : UserClaimDto<TUserDtoKey>
-            where TRoleClaimDto : RoleClaimDto<TRoleDtoKey>
+            where TRoleDto : RoleDto<TKey>
+            where TUsersDto : UsersDto<TUserDto, TKey>
+            where TRolesDto : RolesDto<TRoleDto, TKey>
+            where TUserRolesDto : UserRolesDto<TRoleDto, TKey>
+            where TUserClaimsDto : UserClaimsDto<TKey>
+            where TUserProviderDto : UserProviderDto<TKey>
+            where TUserProvidersDto : UserProvidersDto<TKey>
+            where TUserChangePasswordDto : UserChangePasswordDto<TKey>
+            where TRoleClaimsDto : RoleClaimsDto<TKey>
+            where TUserClaimDto : UserClaimDto<TKey>
+            where TRoleClaimDto : RoleClaimDto<TKey>
         {
 
-            return services.AddAdminAspNetIdentityServices<TAdminDbContext, TAdminDbContext, TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey,
+            return services.AddAdminAspNetIdentityServices<TAdminDbContext, TAdminDbContext, TUserDto, TRoleDto,
                 TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
                 TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
                 TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto, TUserClaimDto, TRoleClaimDto>();
         }
 
-        public static IServiceCollection AddAdminAspNetIdentityServices<TIdentityDbContext, TPersistedGrantDbContext, TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
+        public static IServiceCollection AddAdminAspNetIdentityServices<TIdentityDbContext, TPersistedGrantDbContext, TUserDto, TRoleDto, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
                     TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
                     TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto, TUserClaimDto, TRoleClaimDto>(
                         this IServiceCollection services)
             where TPersistedGrantDbContext : DbContext, IAdminPersistedGrantDbContext
             where TIdentityDbContext : IdentityDbContext<TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken>
-            where TUserDto : UserDto<TUserDtoKey>
+            where TUserDto : UserDto<TKey>
             where TUser : IdentityUser<TKey>
             where TRole : IdentityRole<TKey>
             where TKey : IEquatable<TKey>
@@ -97,33 +97,33 @@ namespace Microsoft.Extensions.DependencyInjection
             where TUserLogin : IdentityUserLogin<TKey>
             where TRoleClaim : IdentityRoleClaim<TKey>
             where TUserToken : IdentityUserToken<TKey>
-            where TRoleDto : RoleDto<TRoleDtoKey>
-            where TUsersDto : UsersDto<TUserDto, TUserDtoKey>
-            where TRolesDto : RolesDto<TRoleDto, TRoleDtoKey>
-            where TUserRolesDto : UserRolesDto<TRoleDto, TUserDtoKey, TRoleDtoKey>
-            where TUserClaimsDto : UserClaimsDto<TUserDtoKey>
-            where TUserProviderDto : UserProviderDto<TUserDtoKey>
-            where TUserProvidersDto : UserProvidersDto<TUserDtoKey>
-            where TUserChangePasswordDto : UserChangePasswordDto<TUserDtoKey>
-            where TRoleClaimsDto : RoleClaimsDto<TRoleDtoKey>
-            where TUserClaimDto : UserClaimDto<TUserDtoKey>
-            where TRoleClaimDto : RoleClaimDto<TRoleDtoKey>
+            where TRoleDto : RoleDto<TKey>
+            where TUsersDto : UsersDto<TUserDto, TKey>
+            where TRolesDto : RolesDto<TRoleDto, TKey>
+            where TUserRolesDto : UserRolesDto<TRoleDto, TKey>
+            where TUserClaimsDto : UserClaimsDto<TKey>
+            where TUserProviderDto : UserProviderDto<TKey>
+            where TUserProvidersDto : UserProvidersDto<TKey>
+            where TUserChangePasswordDto : UserChangePasswordDto<TKey>
+            where TRoleClaimsDto : RoleClaimsDto<TKey>
+            where TUserClaimDto : UserClaimDto<TKey>
+            where TRoleClaimDto : RoleClaimDto<TKey>
         {
-            return AddAdminAspNetIdentityServices<TIdentityDbContext, TPersistedGrantDbContext, TUserDto, TUserDtoKey,
-                TRoleDto, TRoleDtoKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin,
+            return AddAdminAspNetIdentityServices<TIdentityDbContext, TPersistedGrantDbContext, TUserDto,
+                TRoleDto, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin,
                 TRoleClaim, TUserToken,
                 TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
                 TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto, TUserClaimDto,
                 TRoleClaimDto>(services, null);
         }
 
-        public static IServiceCollection AddAdminAspNetIdentityServices<TIdentityDbContext, TPersistedGrantDbContext, TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
+        public static IServiceCollection AddAdminAspNetIdentityServices<TIdentityDbContext, TPersistedGrantDbContext, TUserDto, TRoleDto, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
                     TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
                     TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto, TUserClaimDto, TRoleClaimDto>(
                         this IServiceCollection services, HashSet<Type> profileTypes)
             where TPersistedGrantDbContext : DbContext, IAdminPersistedGrantDbContext
             where TIdentityDbContext : IdentityDbContext<TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken>
-            where TUserDto : UserDto<TUserDtoKey>
+            where TUserDto : UserDto<TKey>
             where TUser : IdentityUser<TKey>
             where TRole : IdentityRole<TKey>
             where TKey : IEquatable<TKey>
@@ -132,27 +132,27 @@ namespace Microsoft.Extensions.DependencyInjection
             where TUserLogin : IdentityUserLogin<TKey>
             where TRoleClaim : IdentityRoleClaim<TKey>
             where TUserToken : IdentityUserToken<TKey>
-            where TRoleDto : RoleDto<TRoleDtoKey>
-            where TUsersDto : UsersDto<TUserDto, TUserDtoKey>
-            where TRolesDto : RolesDto<TRoleDto, TRoleDtoKey>
-            where TUserRolesDto : UserRolesDto<TRoleDto, TUserDtoKey, TRoleDtoKey>
-            where TUserClaimsDto : UserClaimsDto<TUserDtoKey>
-            where TUserProviderDto : UserProviderDto<TUserDtoKey>
-            where TUserProvidersDto : UserProvidersDto<TUserDtoKey>
-            where TUserChangePasswordDto : UserChangePasswordDto<TUserDtoKey>
-            where TRoleClaimsDto : RoleClaimsDto<TRoleDtoKey>
-            where TUserClaimDto : UserClaimDto<TUserDtoKey>
-            where TRoleClaimDto : RoleClaimDto<TRoleDtoKey>
+            where TRoleDto : RoleDto<TKey>
+            where TUsersDto : UsersDto<TUserDto, TKey>
+            where TRolesDto : RolesDto<TRoleDto, TKey>
+            where TUserRolesDto : UserRolesDto<TRoleDto, TKey>
+            where TUserClaimsDto : UserClaimsDto<TKey>
+            where TUserProviderDto : UserProviderDto<TKey>
+            where TUserProvidersDto : UserProvidersDto<TKey>
+            where TUserChangePasswordDto : UserChangePasswordDto<TKey>
+            where TRoleClaimsDto : RoleClaimsDto<TKey>
+            where TUserClaimDto : UserClaimDto<TKey>
+            where TRoleClaimDto : RoleClaimDto<TKey>
         {
             //Repositories
             services.AddTransient<IIdentityRepository<TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken>, IdentityRepository<TIdentityDbContext, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken>>();
             services.AddTransient<IPersistedGrantAspNetIdentityRepository, PersistedGrantAspNetIdentityRepository<TIdentityDbContext, TPersistedGrantDbContext, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken>>();
           
             //Services
-            services.AddTransient<IIdentityService<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
+            services.AddTransient<IIdentityService<TUserDto, TRoleDto, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
                 TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
                 TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto>, 
-                IdentityService<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
+                IdentityService<TUserDto, TRoleDto, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
                     TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
                     TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto>>();
             services.AddTransient<IPersistedGrantAspNetIdentityService, PersistedGrantAspNetIdentityService>();
@@ -163,7 +163,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
             //Register mapping
             services.AddAdminAspNetIdentityMapping()
-                .UseIdentityMappingProfile<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUser, TRole, TKey, TUserClaim,
+                .UseIdentityMappingProfile<TUserDto, TRoleDto, TUser, TRole, TKey, TUserClaim,
                     TUserRole, TUserLogin, TRoleClaim, TUserToken,
                     TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
                     TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto, TUserClaimDto,

--- a/src/Skoruba.IdentityServer4.Admin.BusinessLogic.Identity/Extensions/AdminServicesExtensions.cs
+++ b/src/Skoruba.IdentityServer4.Admin.BusinessLogic.Identity/Extensions/AdminServicesExtensions.cs
@@ -1,176 +1,211 @@
 ﻿using System;
 using System.Collections.Generic;
 using AutoMapper;
-using Microsoft.AspNetCore.Identity;
-using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore;
-using Skoruba.IdentityServer4.Admin.BusinessLogic.Identity.Dtos.Identity;
+using Skoruba.IdentityServer4.Admin.BusinessLogic.Identity.Builders;
+using Skoruba.IdentityServer4.Admin.BusinessLogic.Identity.Builders.Interfaces;
 using Skoruba.IdentityServer4.Admin.BusinessLogic.Identity.Mappers.Configuration;
 using Skoruba.IdentityServer4.Admin.BusinessLogic.Identity.Resources;
 using Skoruba.IdentityServer4.Admin.BusinessLogic.Identity.Services;
 using Skoruba.IdentityServer4.Admin.BusinessLogic.Identity.Services.Interfaces;
 using Skoruba.IdentityServer4.Admin.EntityFramework.Identity.Repositories;
 using Skoruba.IdentityServer4.Admin.EntityFramework.Identity.Repositories.Interfaces;
-using Skoruba.IdentityServer4.Admin.EntityFramework.Interfaces;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
     public static class AdminServicesExtensions
     {
-        public static IMapperConfigurationBuilder AddAdminAspNetIdentityMapping(this IServiceCollection services)
-        {
-            var builder = new MapperConfigurationBuilder();
+        public static IServiceCollection AddAdminAspNetIdentityServices(this IServiceCollection services) =>
+            AddAdminAspNetIdentityServices<string>(services, null, null);
 
-            services.AddSingleton<IConfigurationProvider>(sp => new MapperConfiguration(cfg =>
-            {
-                foreach (var profileType in builder.ProfileTypes)
-                    cfg.AddProfile(profileType);
-            }));
+        public static IServiceCollection AddAdminAspNetIdentityServices(this IServiceCollection services, HashSet<Type> profileTypes) =>
+            AddAdminAspNetIdentityServices<string>(services, null, profileTypes);
 
-            services.AddScoped<IMapper>(sp => new Mapper(sp.GetRequiredService<IConfigurationProvider>(), sp.GetService));
+        public static IServiceCollection AddAdminAspNetIdentityServices(this IServiceCollection services, Func<IAdminAspNetIdentityConfigurationBuilder<string>, IConfiguredAdminAspNetIdentityConfigurationBuilder<string>> configure) =>
+            AddAdminAspNetIdentityServices<string>(services, configure, null);
 
-            return builder;
-        }
-
-        public static IServiceCollection AddAdminAspNetIdentityServices<TIdentityDbContext, TPersistedGrantDbContext, TUser>(
-            this IServiceCollection services)
-            where TIdentityDbContext : IdentityDbContext<TUser, IdentityRole, string, IdentityUserClaim<string>, IdentityUserRole<string>, IdentityUserLogin<string>, IdentityRoleClaim<string>, IdentityUserToken<string>>
-            where TPersistedGrantDbContext : DbContext, IAdminPersistedGrantDbContext
-            where TUser : IdentityUser
-        {
-            return services.AddAdminAspNetIdentityServices<TIdentityDbContext, TPersistedGrantDbContext, UserDto<string>, RoleDto<string>,
-                TUser, IdentityRole, string, IdentityUserClaim<string>, IdentityUserRole<string>, IdentityUserLogin<string>, IdentityRoleClaim<string>, IdentityUserToken<string>,
-                UsersDto<UserDto<string>, string>, RolesDto<RoleDto<string>, string>, UserRolesDto<RoleDto<string>, string>,
-                UserClaimsDto<string>, UserProviderDto<string>, UserProvidersDto<string>, UserChangePasswordDto<string>,
-                RoleClaimsDto<string>, UserClaimDto<string>, RoleClaimDto<string>>();
-        }
-
-        public static IServiceCollection AddAdminAspNetIdentityServices<TAdminDbContext, TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey,
-            TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
-            TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
-            TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto,
-            TUserClaimDto, TRoleClaimDto>(
-                this IServiceCollection services)
-            where TAdminDbContext :
-            IdentityDbContext<TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken>,
-            IAdminPersistedGrantDbContext
-            where TUserDto : UserDto<TKey>
-            where TUser : IdentityUser<TKey>
-            where TRole : IdentityRole<TKey>
+        public static IServiceCollection AddAdminAspNetIdentityServices<TKey>(this IServiceCollection services, Func<IAdminAspNetIdentityConfigurationBuilder<TKey>, IConfiguredAdminAspNetIdentityConfigurationBuilder<TKey>> configure = null, HashSet<Type> profileTypes = null)
             where TKey : IEquatable<TKey>
-            where TUserClaim : IdentityUserClaim<TKey>
-            where TUserRole : IdentityUserRole<TKey>
-            where TUserLogin : IdentityUserLogin<TKey>
-            where TRoleClaim : IdentityRoleClaim<TKey>
-            where TUserToken : IdentityUserToken<TKey>
-            where TRoleDto : RoleDto<TKey>
-            where TUsersDto : UsersDto<TUserDto, TKey>
-            where TRolesDto : RolesDto<TRoleDto, TKey>
-            where TUserRolesDto : UserRolesDto<TRoleDto, TKey>
-            where TUserClaimsDto : UserClaimsDto<TKey>
-            where TUserProviderDto : UserProviderDto<TKey>
-            where TUserProvidersDto : UserProvidersDto<TKey>
-            where TUserChangePasswordDto : UserChangePasswordDto<TKey>
-            where TRoleClaimsDto : RoleClaimsDto<TKey>
-            where TUserClaimDto : UserClaimDto<TKey>
-            where TRoleClaimDto : RoleClaimDto<TKey>
         {
-
-            return services.AddAdminAspNetIdentityServices<TAdminDbContext, TAdminDbContext, TUserDto, TRoleDto,
-                TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
-                TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
-                TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto, TUserClaimDto, TRoleClaimDto>();
-        }
-
-        public static IServiceCollection AddAdminAspNetIdentityServices<TIdentityDbContext, TPersistedGrantDbContext, TUserDto, TRoleDto, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
-                    TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
-                    TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto, TUserClaimDto, TRoleClaimDto>(
-                        this IServiceCollection services)
-            where TPersistedGrantDbContext : DbContext, IAdminPersistedGrantDbContext
-            where TIdentityDbContext : IdentityDbContext<TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken>
-            where TUserDto : UserDto<TKey>
-            where TUser : IdentityUser<TKey>
-            where TRole : IdentityRole<TKey>
-            where TKey : IEquatable<TKey>
-            where TUserClaim : IdentityUserClaim<TKey>
-            where TUserRole : IdentityUserRole<TKey>
-            where TUserLogin : IdentityUserLogin<TKey>
-            where TRoleClaim : IdentityRoleClaim<TKey>
-            where TUserToken : IdentityUserToken<TKey>
-            where TRoleDto : RoleDto<TKey>
-            where TUsersDto : UsersDto<TUserDto, TKey>
-            where TRolesDto : RolesDto<TRoleDto, TKey>
-            where TUserRolesDto : UserRolesDto<TRoleDto, TKey>
-            where TUserClaimsDto : UserClaimsDto<TKey>
-            where TUserProviderDto : UserProviderDto<TKey>
-            where TUserProvidersDto : UserProvidersDto<TKey>
-            where TUserChangePasswordDto : UserChangePasswordDto<TKey>
-            where TRoleClaimsDto : RoleClaimsDto<TKey>
-            where TUserClaimDto : UserClaimDto<TKey>
-            where TRoleClaimDto : RoleClaimDto<TKey>
-        {
-            return AddAdminAspNetIdentityServices<TIdentityDbContext, TPersistedGrantDbContext, TUserDto,
-                TRoleDto, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin,
-                TRoleClaim, TUserToken,
-                TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
-                TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto, TUserClaimDto,
-                TRoleClaimDto>(services, null);
-        }
-
-        public static IServiceCollection AddAdminAspNetIdentityServices<TIdentityDbContext, TPersistedGrantDbContext, TUserDto, TRoleDto, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
-                    TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
-                    TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto, TUserClaimDto, TRoleClaimDto>(
-                        this IServiceCollection services, HashSet<Type> profileTypes)
-            where TPersistedGrantDbContext : DbContext, IAdminPersistedGrantDbContext
-            where TIdentityDbContext : IdentityDbContext<TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken>
-            where TUserDto : UserDto<TKey>
-            where TUser : IdentityUser<TKey>
-            where TRole : IdentityRole<TKey>
-            where TKey : IEquatable<TKey>
-            where TUserClaim : IdentityUserClaim<TKey>
-            where TUserRole : IdentityUserRole<TKey>
-            where TUserLogin : IdentityUserLogin<TKey>
-            where TRoleClaim : IdentityRoleClaim<TKey>
-            where TUserToken : IdentityUserToken<TKey>
-            where TRoleDto : RoleDto<TKey>
-            where TUsersDto : UsersDto<TUserDto, TKey>
-            where TRolesDto : RolesDto<TRoleDto, TKey>
-            where TUserRolesDto : UserRolesDto<TRoleDto, TKey>
-            where TUserClaimsDto : UserClaimsDto<TKey>
-            where TUserProviderDto : UserProviderDto<TKey>
-            where TUserProvidersDto : UserProvidersDto<TKey>
-            where TUserChangePasswordDto : UserChangePasswordDto<TKey>
-            where TRoleClaimsDto : RoleClaimsDto<TKey>
-            where TUserClaimDto : UserClaimDto<TKey>
-            where TRoleClaimDto : RoleClaimDto<TKey>
-        {
-            //Repositories
-            services.AddTransient<IIdentityRepository<TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken>, IdentityRepository<TIdentityDbContext, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken>>();
-            services.AddTransient<IPersistedGrantAspNetIdentityRepository, PersistedGrantAspNetIdentityRepository<TIdentityDbContext, TPersistedGrantDbContext, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken>>();
-          
-            //Services
-            services.AddTransient<IIdentityService<TUserDto, TRoleDto, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
-                TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
-                TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto>, 
-                IdentityService<TUserDto, TRoleDto, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
-                    TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
-                    TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto>>();
-            services.AddTransient<IPersistedGrantAspNetIdentityService, PersistedGrantAspNetIdentityService>();
-            
-            //Resources
-            services.AddScoped<IIdentityServiceResources, IdentityServiceResources>();
-            services.AddScoped<IPersistedGrantAspNetIdentityServiceResources, PersistedGrantAspNetIdentityServiceResources>();
-
-            //Register mapping
-            services.AddAdminAspNetIdentityMapping()
-                .UseIdentityMappingProfile<TUserDto, TRoleDto, TUser, TRole, TKey, TUserClaim,
-                    TUserRole, TUserLogin, TRoleClaim, TUserToken,
-                    TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
-                    TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto, TUserClaimDto,
-                    TRoleClaimDto>()
-                .AddProfilesType(profileTypes);
-
+            if (configure is null)
+                throw new NotImplementedException("We have no default IdentityDbContext and IdentityServerPersistedGrantDbContext in here");
+            var builder = new AdminAspNetIdentityConfigurationBuilder<TKey>();
+            var configuration = configure(builder).Build();
+            services.AddRepositories(configuration);
+            services.AddServices(configuration);
+            AddResources();
+            services.AddMapping(configuration, profileTypes);
             return services;
+
+            void AddResources()
+            {
+                services.AddScoped<IIdentityServiceResources, IdentityServiceResources>();
+                services.AddScoped<IPersistedGrantAspNetIdentityServiceResources, PersistedGrantAspNetIdentityServiceResources>();
+            }
+        }
+
+        private static void AddRepositories<TKey>(this IServiceCollection services, AdminAspNetIdentityConfiguration<TKey> configuration)
+            where TKey : IEquatable<TKey>
+        {
+            AddIdentityRepository();
+            AddPersistedGrantAspNetIdentityRepository();
+
+            void AddIdentityRepository()
+            {
+                var genericInterface = typeof(IIdentityRepository<,,,,,,,>);
+                Type[] interfaceTypes = {
+                    configuration.UserType,
+                    configuration.RoleType,
+                    typeof(TKey),
+                    configuration.UserClaimType,
+                    configuration.UserRoleType,
+                    configuration.UserLoginType,
+                    configuration.RoleClaimType,
+                    configuration.UserTokenType
+                };
+                var constructedInterface = genericInterface.MakeGenericType(interfaceTypes);
+                var genericImplementation = typeof(IdentityRepository<,,,,,,,,>);
+                Type[] implementationTypes = {
+                    configuration.IdentityDbContextType,
+                    configuration.UserType,
+                    configuration.RoleType,
+                    typeof(TKey),
+                    configuration.UserClaimType,
+                    configuration.UserRoleType,
+                    configuration.UserLoginType,
+                    configuration.RoleClaimType,
+                    configuration.UserTokenType
+                };
+                var constructedImplementation = genericImplementation.MakeGenericType(implementationTypes);
+                services.AddTransient(constructedInterface, constructedImplementation);
+            }
+
+            void AddPersistedGrantAspNetIdentityRepository()
+            {
+                var @interface = typeof(IPersistedGrantAspNetIdentityRepository);
+                var genericImplementation = typeof(PersistedGrantAspNetIdentityRepository<,,,,,,,,,>);
+                Type[] implementationTypes = {
+                    configuration.IdentityDbContextType,
+                    configuration.PersistedGrantDbContextType,
+                    configuration.UserType,
+                    configuration.RoleType,
+                    typeof(TKey),
+                    configuration.UserClaimType,
+                    configuration.UserRoleType,
+                    configuration.UserLoginType,
+                    configuration.RoleClaimType,
+                    configuration.UserTokenType
+                };
+                var constructedImplementation = genericImplementation.MakeGenericType(implementationTypes);
+                services.AddTransient(@interface, constructedImplementation);
+            }
+        }
+
+        private static void AddServices<TKey>(this IServiceCollection services, AdminAspNetIdentityConfiguration<TKey> configuration)
+            where TKey : IEquatable<TKey>
+        {
+            AddIdentityService();
+            AddPersistedGrandService();
+
+            void AddIdentityService()
+            {
+                var genericInterface = typeof(IIdentityService<,,,,,,,,,,,,,,,,,>);
+                Type[] interfaceTypes = {
+                    configuration.DtoTypes.User,
+                    configuration.DtoTypes.Role,
+                    configuration.UserType,
+                    configuration.RoleType,
+                    typeof(TKey),
+                    configuration.UserClaimType,
+                    configuration.UserRoleType,
+                    configuration.UserLoginType,
+                    configuration.RoleClaimType,
+                    configuration.UserTokenType,
+                    configuration.DtoTypes.Users,
+                    configuration.DtoTypes.Roles,
+                    configuration.DtoTypes.UserRoles,
+                    configuration.DtoTypes.UserClaims,
+                    configuration.DtoTypes.UserProvider,
+                    configuration.DtoTypes.UserProviders,
+                    configuration.DtoTypes.UserChangePassword,
+                    configuration.DtoTypes.RoleClaims,
+                };
+                var constructedInterface = genericInterface.MakeGenericType(interfaceTypes);
+                var genericImplementation = typeof(IdentityService<,,,,,,,,,,,,,,,,,>);
+                Type[] implementationTypes = {
+                    configuration.DtoTypes.User,
+                    configuration.DtoTypes.Role,
+                    configuration.UserType,
+                    configuration.RoleType,
+                    typeof(TKey),
+                    configuration.UserClaimType,
+                    configuration.UserRoleType,
+                    configuration.UserLoginType,
+                    configuration.RoleClaimType,
+                    configuration.UserTokenType,
+                    configuration.DtoTypes.Users,
+                    configuration.DtoTypes.Roles,
+                    configuration.DtoTypes.UserRoles,
+                    configuration.DtoTypes.UserClaims,
+                    configuration.DtoTypes.UserProvider,
+                    configuration.DtoTypes.UserProviders,
+                    configuration.DtoTypes.UserChangePassword,
+                    configuration.DtoTypes.RoleClaims,
+                };
+                var constructedImplementation = genericImplementation.MakeGenericType(implementationTypes);
+                services.AddTransient(constructedInterface, constructedImplementation);
+            }
+
+            void AddPersistedGrandService()
+            {
+                services.AddTransient<IPersistedGrantAspNetIdentityService, PersistedGrantAspNetIdentityService>();
+            }
+        }
+
+        private static void AddMapping<TKey>(this IServiceCollection services, AdminAspNetIdentityConfiguration<TKey> configuration, HashSet<Type> profileTypes)
+            where TKey : IEquatable<TKey>
+        {
+            var builder = AddAdminAspNetIdentityMapping();
+            var method = builder.GetType().GetMethod(nameof(builder.UseIdentityMappingProfile));
+            Type[] methodTypes = {
+                    configuration.DtoTypes.User,
+                    configuration.DtoTypes.Role,
+                    configuration.UserType,
+                    configuration.RoleType,
+                    typeof(TKey),
+                    configuration.UserClaimType,
+                    configuration.UserRoleType,
+                    configuration.UserLoginType,
+                    configuration.RoleClaimType,
+                    configuration.UserTokenType,
+                    configuration.DtoTypes.Users,
+                    configuration.DtoTypes.Roles,
+                    configuration.DtoTypes.UserRoles,
+                    configuration.DtoTypes.UserClaims,
+                    configuration.DtoTypes.UserProvider,
+                    configuration.DtoTypes.UserProviders,
+                    configuration.DtoTypes.UserChangePassword,
+                    configuration.DtoTypes.RoleClaims,
+                    configuration.DtoTypes.UserClaim,
+                    configuration.DtoTypes.RoleClaim
+                };
+            var genericMethod = method.MakeGenericMethod(methodTypes);
+            genericMethod.Invoke(builder, null);
+            builder.AddProfilesType(profileTypes);
+
+            IMapperConfigurationBuilder AddAdminAspNetIdentityMapping()
+            {
+                var builder = new MapperConfigurationBuilder();
+
+                services.AddSingleton<IConfigurationProvider>(sp => new MapperConfiguration(cfg =>
+                {
+                    foreach (var profileType in builder.ProfileTypes)
+                        cfg.AddProfile(profileType);
+                }));
+
+                services.AddScoped<IMapper>(sp => new Mapper(sp.GetRequiredService<IConfigurationProvider>(), sp.GetService));
+
+                return builder;
+            }
         }
     }
 }

--- a/src/Skoruba.IdentityServer4.Admin.BusinessLogic.Identity/Extensions/AdminServicesExtensions.cs
+++ b/src/Skoruba.IdentityServer4.Admin.BusinessLogic.Identity/Extensions/AdminServicesExtensions.cs
@@ -14,20 +14,15 @@ namespace Microsoft.Extensions.DependencyInjection
 {
     public static class AdminServicesExtensions
     {
-        public static IServiceCollection AddAdminAspNetIdentityServices(this IServiceCollection services) =>
-            AddAdminAspNetIdentityServices<string>(services, null, null);
+        public static IServiceCollection AddAdminAspNetIdentityServices(this IServiceCollection services, Func<IAdminAspNetIdentityConfigurationBuilder<string>, IConfiguredAdminAspNetIdentityConfigurationBuilder<string>> configure, HashSet<Type> profileTypes = null) =>
+            AddAdminAspNetIdentityServices<string>(services, configure, profileTypes);
 
-        public static IServiceCollection AddAdminAspNetIdentityServices(this IServiceCollection services, HashSet<Type> profileTypes) =>
-            AddAdminAspNetIdentityServices<string>(services, null, profileTypes);
-
-        public static IServiceCollection AddAdminAspNetIdentityServices(this IServiceCollection services, Func<IAdminAspNetIdentityConfigurationBuilder<string>, IConfiguredAdminAspNetIdentityConfigurationBuilder<string>> configure) =>
-            AddAdminAspNetIdentityServices<string>(services, configure, null);
-
-        public static IServiceCollection AddAdminAspNetIdentityServices<TKey>(this IServiceCollection services, Func<IAdminAspNetIdentityConfigurationBuilder<TKey>, IConfiguredAdminAspNetIdentityConfigurationBuilder<TKey>> configure = null, HashSet<Type> profileTypes = null)
+        public static IServiceCollection AddAdminAspNetIdentityServices<TKey>(this IServiceCollection services, Func<IAdminAspNetIdentityConfigurationBuilder<TKey>, IConfiguredAdminAspNetIdentityConfigurationBuilder<TKey>> configure, HashSet<Type> profileTypes = null)
             where TKey : IEquatable<TKey>
         {
             if (configure is null)
-                throw new NotImplementedException("We have no default IdentityDbContext and IdentityServerPersistedGrantDbContext in here");
+                throw new ArgumentNullException(nameof(configure));
+
             var builder = new AdminAspNetIdentityConfigurationBuilder<TKey>();
             var configuration = configure(builder).Build();
             services.AddRepositories(configuration);

--- a/src/Skoruba.IdentityServer4.Admin.BusinessLogic.Identity/Mappers/Configuration/IMapperConfigurationBuilder.cs
+++ b/src/Skoruba.IdentityServer4.Admin.BusinessLogic.Identity/Mappers/Configuration/IMapperConfigurationBuilder.cs
@@ -11,13 +11,13 @@ namespace Skoruba.IdentityServer4.Admin.BusinessLogic.Identity.Mappers.Configura
 
         IMapperConfigurationBuilder AddProfilesType(HashSet<Type> profileTypes);
 
-        IMapperConfigurationBuilder UseIdentityMappingProfile<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUser, TRole,
+        IMapperConfigurationBuilder UseIdentityMappingProfile<TUserDto, TRoleDto, TUser, TRole,
             TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
             TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
             TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto,
             TUserClaimDto, TRoleClaimDto>()
-            where TUserDto : UserDto<TUserDtoKey>
-            where TRoleDto : RoleDto<TRoleDtoKey>
+            where TUserDto : UserDto<TKey>
+            where TRoleDto : RoleDto<TKey>
             where TUser : IdentityUser<TKey>
             where TRole : IdentityRole<TKey>
             where TKey : IEquatable<TKey>
@@ -26,15 +26,15 @@ namespace Skoruba.IdentityServer4.Admin.BusinessLogic.Identity.Mappers.Configura
             where TUserLogin : IdentityUserLogin<TKey>
             where TRoleClaim : IdentityRoleClaim<TKey>
             where TUserToken : IdentityUserToken<TKey>
-            where TUsersDto : UsersDto<TUserDto, TUserDtoKey>
-            where TRolesDto : RolesDto<TRoleDto, TRoleDtoKey>
-            where TUserRolesDto : UserRolesDto<TRoleDto, TUserDtoKey, TRoleDtoKey>
-            where TUserClaimsDto : UserClaimsDto<TUserDtoKey>
-            where TUserProviderDto : UserProviderDto<TUserDtoKey>
-            where TUserProvidersDto : UserProvidersDto<TUserDtoKey>
-            where TUserChangePasswordDto : UserChangePasswordDto<TUserDtoKey>
-            where TRoleClaimsDto : RoleClaimsDto<TRoleDtoKey>
-            where TUserClaimDto : UserClaimDto<TUserDtoKey>
-            where TRoleClaimDto : RoleClaimDto<TRoleDtoKey>;
+            where TUsersDto : UsersDto<TUserDto, TKey>
+            where TRolesDto : RolesDto<TRoleDto, TKey>
+            where TUserRolesDto : UserRolesDto<TRoleDto, TKey>
+            where TUserClaimsDto : UserClaimsDto<TKey>
+            where TUserProviderDto : UserProviderDto<TKey>
+            where TUserProvidersDto : UserProvidersDto<TKey>
+            where TUserChangePasswordDto : UserChangePasswordDto<TKey>
+            where TRoleClaimsDto : RoleClaimsDto<TKey>
+            where TUserClaimDto : UserClaimDto<TKey>
+            where TRoleClaimDto : RoleClaimDto<TKey>;
     }
 }

--- a/src/Skoruba.IdentityServer4.Admin.BusinessLogic.Identity/Mappers/Configuration/MapperConfigurationBuilder.cs
+++ b/src/Skoruba.IdentityServer4.Admin.BusinessLogic.Identity/Mappers/Configuration/MapperConfigurationBuilder.cs
@@ -21,13 +21,13 @@ namespace Skoruba.IdentityServer4.Admin.BusinessLogic.Identity.Mappers.Configura
             return this;
         }
 
-        public IMapperConfigurationBuilder UseIdentityMappingProfile<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUser, TRole, TKey,
+        public IMapperConfigurationBuilder UseIdentityMappingProfile<TUserDto, TRoleDto, TUser, TRole, TKey,
             TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
             TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
             TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto,
             TUserClaimDto, TRoleClaimDto>()
-            where TUserDto : UserDto<TUserDtoKey>
-            where TRoleDto : RoleDto<TRoleDtoKey>
+            where TUserDto : UserDto<TKey>
+            where TRoleDto : RoleDto<TKey>
             where TUser : IdentityUser<TKey>
             where TRole : IdentityRole<TKey>
             where TKey : IEquatable<TKey>
@@ -36,18 +36,18 @@ namespace Skoruba.IdentityServer4.Admin.BusinessLogic.Identity.Mappers.Configura
             where TUserLogin : IdentityUserLogin<TKey>
             where TRoleClaim : IdentityRoleClaim<TKey>
             where TUserToken : IdentityUserToken<TKey>
-            where TUsersDto : UsersDto<TUserDto, TUserDtoKey>
-            where TRolesDto : RolesDto<TRoleDto, TRoleDtoKey>
-            where TUserRolesDto : UserRolesDto<TRoleDto, TUserDtoKey, TRoleDtoKey>
-            where TUserClaimsDto : UserClaimsDto<TUserDtoKey>
-            where TUserProviderDto : UserProviderDto<TUserDtoKey>
-            where TUserProvidersDto : UserProvidersDto<TUserDtoKey>
-            where TUserChangePasswordDto : UserChangePasswordDto<TUserDtoKey>
-            where TRoleClaimsDto : RoleClaimsDto<TRoleDtoKey>
-            where TUserClaimDto : UserClaimDto<TUserDtoKey>
-            where TRoleClaimDto : RoleClaimDto<TRoleDtoKey>
+            where TUsersDto : UsersDto<TUserDto, TKey>
+            where TRolesDto : RolesDto<TRoleDto, TKey>
+            where TUserRolesDto : UserRolesDto<TRoleDto, TKey>
+            where TUserClaimsDto : UserClaimsDto<TKey>
+            where TUserProviderDto : UserProviderDto<TKey>
+            where TUserProvidersDto : UserProvidersDto<TKey>
+            where TUserChangePasswordDto : UserChangePasswordDto<TKey>
+            where TRoleClaimsDto : RoleClaimsDto<TKey>
+            where TUserClaimDto : UserClaimDto<TKey>
+            where TRoleClaimDto : RoleClaimDto<TKey>
         {
-            ProfileTypes.Add(typeof(IdentityMapperProfile<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUser, TRole, TKey,
+            ProfileTypes.Add(typeof(IdentityMapperProfile<TUserDto, TRoleDto, TUser, TRole, TKey,
                 TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
                 TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
                 TUserProviderDto, TUserProvidersDto, TRoleClaimsDto, TUserClaimDto, TRoleClaimDto>));

--- a/src/Skoruba.IdentityServer4.Admin.BusinessLogic.Identity/Mappers/IdentityMapperProfile.cs
+++ b/src/Skoruba.IdentityServer4.Admin.BusinessLogic.Identity/Mappers/IdentityMapperProfile.cs
@@ -13,14 +13,14 @@ using Skoruba.IdentityServer4.Admin.EntityFramework.Extensions.Common;
 
 namespace Skoruba.IdentityServer4.Admin.BusinessLogic.Identity.Mappers
 {
-    public class IdentityMapperProfile<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUser, TRole, TKey, TUserClaim, TUserRole,
+    public class IdentityMapperProfile<TUserDto, TRoleDto, TUser, TRole, TKey, TUserClaim, TUserRole,
         TUserLogin, TRoleClaim, TUserToken,
         TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
         TUserProviderDto, TUserProvidersDto, TRoleClaimsDto,
         TUserClaimDto, TRoleClaimDto>
         : Profile
-        where TUserDto : UserDto<TUserDtoKey>
-        where TRoleDto : RoleDto<TRoleDtoKey>
+        where TUserDto : UserDto<TKey>
+        where TRoleDto : RoleDto<TKey>
         where TUser : IdentityUser<TKey>
         where TRole : IdentityRole<TKey>
         where TKey : IEquatable<TKey>
@@ -29,15 +29,15 @@ namespace Skoruba.IdentityServer4.Admin.BusinessLogic.Identity.Mappers
         where TUserLogin : IdentityUserLogin<TKey>
         where TRoleClaim : IdentityRoleClaim<TKey>
         where TUserToken : IdentityUserToken<TKey>
-        where TUsersDto : UsersDto<TUserDto, TUserDtoKey>
-        where TRolesDto : RolesDto<TRoleDto, TRoleDtoKey>
-        where TUserRolesDto : UserRolesDto<TRoleDto, TUserDtoKey, TRoleDtoKey>
-        where TUserClaimsDto : UserClaimsDto<TUserDtoKey>
-        where TUserProviderDto : UserProviderDto<TUserDtoKey>
-        where TUserProvidersDto : UserProvidersDto<TUserDtoKey>
-        where TRoleClaimsDto : RoleClaimsDto<TRoleDtoKey>
-        where TUserClaimDto : UserClaimDto<TUserDtoKey>
-        where TRoleClaimDto : RoleClaimDto<TRoleDtoKey>
+        where TUsersDto : UsersDto<TUserDto, TKey>
+        where TRolesDto : RolesDto<TRoleDto, TKey>
+        where TUserRolesDto : UserRolesDto<TRoleDto, TKey>
+        where TUserClaimsDto : UserClaimsDto<TKey>
+        where TUserProviderDto : UserProviderDto<TKey>
+        where TUserProvidersDto : UserProvidersDto<TKey>
+        where TRoleClaimsDto : RoleClaimsDto<TKey>
+        where TUserClaimDto : UserClaimDto<TKey>
+        where TRoleClaimDto : RoleClaimDto<TKey>
     {
         public IdentityMapperProfile()
         {

--- a/src/Skoruba.IdentityServer4.Admin.BusinessLogic.Identity/Services/IdentityService.cs
+++ b/src/Skoruba.IdentityServer4.Admin.BusinessLogic.Identity/Services/IdentityService.cs
@@ -17,10 +17,10 @@ using Skoruba.IdentityServer4.Admin.EntityFramework.Identity.Repositories.Interf
 
 namespace Skoruba.IdentityServer4.Admin.BusinessLogic.Identity.Services
 {
-    public class IdentityService<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUserKey, TRoleKey, TUser, TRole, TKey, TUserClaim, TUserRole,
+    public class IdentityService<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUser, TRole, TKey, TUserClaim, TUserRole,
         TUserLogin, TRoleClaim, TUserToken,
         TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
-        TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto> : IIdentityService<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUserKey, TRoleKey, TUser, TRole, TKey, TUserClaim, TUserRole,
+        TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto> : IIdentityService<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUser, TRole, TKey, TUserClaim, TUserRole,
         TUserLogin, TRoleClaim, TUserToken,
         TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
         TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto>
@@ -43,12 +43,12 @@ namespace Skoruba.IdentityServer4.Admin.BusinessLogic.Identity.Services
         where TUserChangePasswordDto : UserChangePasswordDto<TUserDtoKey>
         where TRoleClaimsDto : RoleClaimsDto<TRoleDtoKey>
     {
-        protected readonly IIdentityRepository<TUserKey, TRoleKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken> IdentityRepository;
+        protected readonly IIdentityRepository<TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken> IdentityRepository;
         protected readonly IIdentityServiceResources IdentityServiceResources;
         protected readonly IMapper Mapper;
         protected readonly IAuditEventLogger AuditEventLogger;
 
-        public IdentityService(IIdentityRepository<TUserKey, TRoleKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken> identityRepository,
+        public IdentityService(IIdentityRepository<TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken> identityRepository,
             IIdentityServiceResources identityServiceResources,
             IMapper mapper,
             IAuditEventLogger auditEventLogger)

--- a/src/Skoruba.IdentityServer4.Admin.BusinessLogic.Identity/Services/IdentityService.cs
+++ b/src/Skoruba.IdentityServer4.Admin.BusinessLogic.Identity/Services/IdentityService.cs
@@ -17,15 +17,15 @@ using Skoruba.IdentityServer4.Admin.EntityFramework.Identity.Repositories.Interf
 
 namespace Skoruba.IdentityServer4.Admin.BusinessLogic.Identity.Services
 {
-    public class IdentityService<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUser, TRole, TKey, TUserClaim, TUserRole,
+    public class IdentityService<TUserDto, TRoleDto, TUser, TRole, TKey, TUserClaim, TUserRole,
         TUserLogin, TRoleClaim, TUserToken,
         TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
-        TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto> : IIdentityService<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUser, TRole, TKey, TUserClaim, TUserRole,
+        TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto> : IIdentityService<TUserDto, TRoleDto, TUser, TRole, TKey, TUserClaim, TUserRole,
         TUserLogin, TRoleClaim, TUserToken,
         TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
         TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto>
-        where TUserDto : UserDto<TUserDtoKey>
-        where TRoleDto : RoleDto<TRoleDtoKey>
+        where TUserDto : UserDto<TKey>
+        where TRoleDto : RoleDto<TKey>
         where TUser : IdentityUser<TKey>
         where TRole : IdentityRole<TKey>
         where TKey : IEquatable<TKey>
@@ -34,14 +34,14 @@ namespace Skoruba.IdentityServer4.Admin.BusinessLogic.Identity.Services
         where TUserLogin : IdentityUserLogin<TKey>
         where TRoleClaim : IdentityRoleClaim<TKey>
         where TUserToken : IdentityUserToken<TKey>
-        where TUsersDto : UsersDto<TUserDto, TUserDtoKey>
-        where TRolesDto : RolesDto<TRoleDto, TRoleDtoKey>
-        where TUserRolesDto : UserRolesDto<TRoleDto, TUserDtoKey, TRoleDtoKey>
-        where TUserClaimsDto : UserClaimsDto<TUserDtoKey>
-        where TUserProviderDto : UserProviderDto<TUserDtoKey>
-        where TUserProvidersDto : UserProvidersDto<TUserDtoKey>
-        where TUserChangePasswordDto : UserChangePasswordDto<TUserDtoKey>
-        where TRoleClaimsDto : RoleClaimsDto<TRoleDtoKey>
+        where TUsersDto : UsersDto<TUserDto, TKey>
+        where TRolesDto : RolesDto<TRoleDto, TKey>
+        where TUserRolesDto : UserRolesDto<TRoleDto, TKey>
+        where TUserClaimsDto : UserClaimsDto<TKey>
+        where TUserProviderDto : UserProviderDto<TKey>
+        where TUserProvidersDto : UserProvidersDto<TKey>
+        where TUserChangePasswordDto : UserChangePasswordDto<TKey>
+        where TRoleClaimsDto : RoleClaimsDto<TKey>
     {
         protected readonly IIdentityRepository<TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken> IdentityRepository;
         protected readonly IIdentityServiceResources IdentityServiceResources;
@@ -245,7 +245,7 @@ namespace Skoruba.IdentityServer4.Admin.BusinessLogic.Identity.Services
             return HandleIdentityError(identityResult, IdentityServiceResources.UserRoleCreateFailed().Description, IdentityServiceResources.IdentityErrorKey().Description, userRolesDto);
         }
 
-        public virtual async Task<TUserRolesDto> BuildUserRolesViewModel(TUserDtoKey id, int? page)
+        public virtual async Task<TUserRolesDto> BuildUserRolesViewModel(TKey id, int? page)
         {
             var roles = await GetRolesAsync();
             var userRoles = await GetUserRolesAsync(id.ToString(), page ?? 1);
@@ -330,15 +330,6 @@ namespace Skoruba.IdentityServer4.Admin.BusinessLogic.Identity.Services
             return deleted;
         }
 
-        public virtual TUserDtoKey ConvertUserDtoKeyFromString(string id)
-        {
-            if (id == null)
-            {
-                return default(TUserDtoKey);
-            }
-            return (TUserDtoKey)TypeDescriptor.GetConverter(typeof(TUserDtoKey)).ConvertFromInvariantString(id);
-        }
-
         public virtual TKey ConvertToKeyFromString(string id)
         {
             if (id == null)
@@ -355,7 +346,7 @@ namespace Skoruba.IdentityServer4.Admin.BusinessLogic.Identity.Services
 
             var userLoginInfos = await IdentityRepository.GetUserProvidersAsync(userId);
             var providersDto = Mapper.Map<TUserProvidersDto>(userLoginInfos);
-            providersDto.UserId = ConvertUserDtoKeyFromString(userId);
+            providersDto.UserId = ConvertToKeyFromString(userId);
 
             var user = await IdentityRepository.GetUserAsync(userId);
             providersDto.UserName = user.UserName;

--- a/src/Skoruba.IdentityServer4.Admin.BusinessLogic.Identity/Services/Interfaces/IIdentityService.cs
+++ b/src/Skoruba.IdentityServer4.Admin.BusinessLogic.Identity/Services/Interfaces/IIdentityService.cs
@@ -6,11 +6,11 @@ using Skoruba.IdentityServer4.Admin.BusinessLogic.Identity.Dtos.Identity;
 
 namespace Skoruba.IdentityServer4.Admin.BusinessLogic.Identity.Services.Interfaces
 {
-    public interface IIdentityService<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUser, TRole, TKey, TUserClaim, TUserRole,
+    public interface IIdentityService<TUserDto, TRoleDto, TUser, TRole, TKey, TUserClaim, TUserRole,
         TUserLogin, TRoleClaim, TUserToken, 
         TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
         TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto>        
-        where TUserDto : UserDto<TUserDtoKey>
+        where TUserDto : UserDto<TKey>
         where TUser : IdentityUser<TKey>
         where TRole : IdentityRole<TKey>
         where TKey : IEquatable<TKey>
@@ -19,15 +19,15 @@ namespace Skoruba.IdentityServer4.Admin.BusinessLogic.Identity.Services.Interfac
         where TUserLogin : IdentityUserLogin<TKey>
         where TRoleClaim : IdentityRoleClaim<TKey>
         where TUserToken : IdentityUserToken<TKey>
-        where TRoleDto : RoleDto<TRoleDtoKey>
-        where TUsersDto : UsersDto<TUserDto, TUserDtoKey>
-        where TRolesDto : RolesDto<TRoleDto, TRoleDtoKey>
-        where TUserRolesDto : UserRolesDto<TRoleDto, TUserDtoKey, TRoleDtoKey>
-        where TUserClaimsDto: UserClaimsDto<TUserDtoKey>
-        where TUserProviderDto : UserProviderDto<TUserDtoKey>
-        where TUserProvidersDto : UserProvidersDto<TUserDtoKey>
-        where TUserChangePasswordDto: UserChangePasswordDto<TUserDtoKey>
-        where TRoleClaimsDto : RoleClaimsDto<TRoleDtoKey>
+        where TRoleDto : RoleDto<TKey>
+        where TUsersDto : UsersDto<TUserDto, TKey>
+        where TRolesDto : RolesDto<TRoleDto, TKey>
+        where TUserRolesDto : UserRolesDto<TRoleDto, TKey>
+        where TUserClaimsDto: UserClaimsDto<TKey>
+        where TUserProviderDto : UserProviderDto<TKey>
+        where TUserProvidersDto : UserProvidersDto<TKey>
+        where TUserChangePasswordDto: UserChangePasswordDto<TKey>
+        where TRoleClaimsDto : RoleClaimsDto<TKey>
     {
         Task<bool> ExistsUserAsync(string userId);
 
@@ -55,7 +55,7 @@ namespace Skoruba.IdentityServer4.Admin.BusinessLogic.Identity.Services.Interfac
 
         Task<IdentityResult> CreateUserRoleAsync(TUserRolesDto role);
 
-        Task<TUserRolesDto> BuildUserRolesViewModel(TUserDtoKey id, int? page);
+        Task<TUserRolesDto> BuildUserRolesViewModel(TKey id, int? page);
 
         Task<TUserRolesDto> GetUserRolesAsync(string userId, int page = 1,
             int pageSize = 10);
@@ -73,7 +73,7 @@ namespace Skoruba.IdentityServer4.Admin.BusinessLogic.Identity.Services.Interfac
 
         Task<TUserProvidersDto> GetUserProvidersAsync(string userId);
 
-        TUserDtoKey ConvertUserDtoKeyFromString(string id);
+        TKey ConvertToKeyFromString(string id);
 
         Task<IdentityResult> DeleteUserProvidersAsync(TUserProviderDto provider);
 

--- a/src/Skoruba.IdentityServer4.Admin.BusinessLogic.Identity/Services/Interfaces/IIdentityService.cs
+++ b/src/Skoruba.IdentityServer4.Admin.BusinessLogic.Identity/Services/Interfaces/IIdentityService.cs
@@ -6,7 +6,7 @@ using Skoruba.IdentityServer4.Admin.BusinessLogic.Identity.Dtos.Identity;
 
 namespace Skoruba.IdentityServer4.Admin.BusinessLogic.Identity.Services.Interfaces
 {
-    public interface IIdentityService<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUserKey, TRoleKey, TUser, TRole, TKey, TUserClaim, TUserRole, 
+    public interface IIdentityService<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUser, TRole, TKey, TUserClaim, TUserRole,
         TUserLogin, TRoleClaim, TUserToken, 
         TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
         TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto>        

--- a/src/Skoruba.IdentityServer4.Admin.EntityFramework.Identity/Repositories/IdentityRepository.cs
+++ b/src/Skoruba.IdentityServer4.Admin.EntityFramework.Identity/Repositories/IdentityRepository.cs
@@ -16,8 +16,8 @@ using Skoruba.IdentityServer4.Admin.EntityFramework.Identity.Repositories.Interf
 
 namespace Skoruba.IdentityServer4.Admin.EntityFramework.Identity.Repositories
 {
-    public class IdentityRepository<TIdentityDbContext, TUserKey, TRoleKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken>
-        : IIdentityRepository<TUserKey, TRoleKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken>
+    public class IdentityRepository<TIdentityDbContext, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken>
+        : IIdentityRepository<TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken>
         where TIdentityDbContext : IdentityDbContext<TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken>
         where TUser : IdentityUser<TKey>
         where TRole : IdentityRole<TKey>
@@ -46,34 +46,25 @@ namespace Skoruba.IdentityServer4.Admin.EntityFramework.Identity.Repositories
             Mapper = mapper;
         }
 
-        public virtual TUserKey ConvertUserKeyFromString(string id)
+        public virtual TKey ConvertKeyFromString(string id)
         {
             if (id == null)
             {
-                return default(TUserKey);
+                return default;
             }
-            return (TUserKey)TypeDescriptor.GetConverter(typeof(TUserKey)).ConvertFromInvariantString(id);
-        }
-
-        public virtual TRoleKey ConvertRoleKeyFromString(string id)
-        {
-            if (id == null)
-            {
-                return default(TRoleKey);
-            }
-            return (TRoleKey)TypeDescriptor.GetConverter(typeof(TRoleKey)).ConvertFromInvariantString(id);
+            return (TKey)TypeDescriptor.GetConverter(typeof(TKey)).ConvertFromInvariantString(id);
         }
 
         public virtual Task<bool> ExistsUserAsync(string userId)
         {
-            var id = ConvertUserKeyFromString(userId);
+            var id = ConvertKeyFromString(userId);
 
             return UserManager.Users.AnyAsync(x => x.Id.Equals(id));
         }
 
         public virtual Task<bool> ExistsRoleAsync(string roleId)
         {
-            var id = ConvertRoleKeyFromString(roleId);
+            var id = ConvertKeyFromString(roleId);
 
             return RoleManager.Roles.AnyAsync(x => x.Id.Equals(id));
         }
@@ -95,7 +86,7 @@ namespace Skoruba.IdentityServer4.Admin.EntityFramework.Identity.Repositories
 
         public virtual async Task<PagedList<TUser>> GetRoleUsersAsync(string roleId, string search, int page = 1, int pageSize = 10)
         {
-            var id = ConvertRoleKeyFromString(roleId);
+            var id = ConvertKeyFromString(roleId);
             
             var pagedList = new PagedList<TUser>();
             var users = DbContext.Set<TUser>()
@@ -197,7 +188,7 @@ namespace Skoruba.IdentityServer4.Admin.EntityFramework.Identity.Repositories
 
         public virtual async Task<PagedList<TRole>> GetUserRolesAsync(string userId, int page = 1, int pageSize = 10)
         {
-            var id = ConvertUserKeyFromString(userId);
+            var id = ConvertKeyFromString(userId);
 
             var pagedList = new PagedList<TRole>();
             var roles = from r in DbContext.Set<TRole>()
@@ -225,7 +216,7 @@ namespace Skoruba.IdentityServer4.Admin.EntityFramework.Identity.Repositories
 
         public virtual async Task<PagedList<TUserClaim>> GetUserClaimsAsync(string userId, int page, int pageSize)
         {
-            var id = ConvertUserKeyFromString(userId);
+            var id = ConvertKeyFromString(userId);
             var pagedList = new PagedList<TUserClaim>();
 
             var claims = await DbContext.Set<TUserClaim>().Where(x => x.UserId.Equals(id))
@@ -241,7 +232,7 @@ namespace Skoruba.IdentityServer4.Admin.EntityFramework.Identity.Repositories
 
         public virtual async Task<PagedList<TRoleClaim>> GetRoleClaimsAsync(string roleId, int page = 1, int pageSize = 10)
         {
-            var id = ConvertRoleKeyFromString(roleId);
+            var id = ConvertKeyFromString(roleId);
             var pagedList = new PagedList<TRoleClaim>();
             var claims = await DbContext.Set<TRoleClaim>().Where(x => x.RoleId.Equals(id))
                 .PageBy(x => x.Id, page, pageSize)
@@ -256,7 +247,7 @@ namespace Skoruba.IdentityServer4.Admin.EntityFramework.Identity.Repositories
 
 		public virtual async Task<PagedList<TRoleClaim>> GetUserRoleClaimsAsync(string userId, string claimSearchText, int page = 1, int pageSize = 10)
 		{
-			var id = ConvertUserKeyFromString(userId);
+			var id = ConvertKeyFromString(userId);
 			Expression<Func<TRoleClaim, bool>> searchCondition = x => x.ClaimType.Contains(claimSearchText);
 			var claimsQ = DbContext.Set<TUserRole>().Where(x => x.UserId.Equals(id))
 				.Join(DbContext.Set<TRoleClaim>().WhereIf(!string.IsNullOrEmpty(claimSearchText), searchCondition), ur => ur.RoleId, rc => rc.RoleId, (ur, rc) => rc);
@@ -274,7 +265,7 @@ namespace Skoruba.IdentityServer4.Admin.EntityFramework.Identity.Repositories
 
 		public virtual Task<TUserClaim> GetUserClaimAsync(string userId, int claimId)
         {
-            var userIdConverted = ConvertUserKeyFromString(userId);
+            var userIdConverted = ConvertKeyFromString(userId);
 
             return DbContext.Set<TUserClaim>().Where(x => x.UserId.Equals(userIdConverted) && x.Id == claimId)
                 .SingleOrDefaultAsync();
@@ -282,7 +273,7 @@ namespace Skoruba.IdentityServer4.Admin.EntityFramework.Identity.Repositories
 
         public virtual Task<TRoleClaim> GetRoleClaimAsync(string roleId, int claimId)
         {
-            var roleIdConverted = ConvertRoleKeyFromString(roleId);
+            var roleIdConverted = ConvertKeyFromString(roleId);
 
             return DbContext.Set<TRoleClaim>().Where(x => x.RoleId.Equals(roleIdConverted) && x.Id == claimId)
                 .SingleOrDefaultAsync();
@@ -330,7 +321,7 @@ namespace Skoruba.IdentityServer4.Admin.EntityFramework.Identity.Repositories
 
         public virtual Task<TUserLogin> GetUserProviderAsync(string userId, string providerKey)
         {
-            var userIdConverted = ConvertUserKeyFromString(userId);
+            var userIdConverted = ConvertKeyFromString(userId);
 
             return DbContext.Set<TUserLogin>().Where(x => x.UserId.Equals(userIdConverted) && x.ProviderKey == providerKey)
                 .SingleOrDefaultAsync();
@@ -338,7 +329,7 @@ namespace Skoruba.IdentityServer4.Admin.EntityFramework.Identity.Repositories
 
         public virtual async Task<IdentityResult> DeleteUserProvidersAsync(string userId, string providerKey, string loginProvider)
         {
-            var userIdConverted = ConvertUserKeyFromString(userId);
+            var userIdConverted = ConvertKeyFromString(userId);
 
             var user = await UserManager.FindByIdAsync(userId);
             var login = await DbContext.Set<TUserLogin>().Where(x => x.UserId.Equals(userIdConverted) && x.ProviderKey == providerKey && x.LoginProvider == loginProvider).SingleOrDefaultAsync();

--- a/src/Skoruba.IdentityServer4.Admin.EntityFramework.Identity/Repositories/Interfaces/IIdentityRepository.cs
+++ b/src/Skoruba.IdentityServer4.Admin.EntityFramework.Identity/Repositories/Interfaces/IIdentityRepository.cs
@@ -6,7 +6,7 @@ using Skoruba.IdentityServer4.Admin.EntityFramework.Extensions.Common;
 
 namespace Skoruba.IdentityServer4.Admin.EntityFramework.Identity.Repositories.Interfaces
 {
-	public interface IIdentityRepository<TUserKey, TRoleKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken>	    
+	public interface IIdentityRepository<TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken>
 	    where TUser : IdentityUser<TKey>
 	    where TRole : IdentityRole<TKey>
 	    where TKey : IEquatable<TKey>

--- a/src/Skoruba.IdentityServer4.Admin/Configuration/ApplicationParts/GenericTypeControllerFeatureProvider.cs
+++ b/src/Skoruba.IdentityServer4.Admin/Configuration/ApplicationParts/GenericTypeControllerFeatureProvider.cs
@@ -10,7 +10,7 @@ using Skoruba.IdentityServer4.Admin.BusinessLogic.Identity.Dtos.Identity;
 
 namespace Skoruba.IdentityServer4.Admin.Configuration.ApplicationParts
 {      
-    public class GenericTypeControllerFeatureProvider<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUserKey, TRoleKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
+    public class GenericTypeControllerFeatureProvider<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
         TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
         TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto> : IApplicationFeatureProvider<ControllerFeature>
         where TUserDto : UserDto<TUserDtoKey>, new()
@@ -36,7 +36,7 @@ namespace Skoruba.IdentityServer4.Admin.Configuration.ApplicationParts
     {
         public void PopulateFeature(IEnumerable<ApplicationPart> parts, ControllerFeature feature)
         {
-            var currentAssembly = typeof(GenericTypeControllerFeatureProvider<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUserKey, TRoleKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
+            var currentAssembly = typeof(GenericTypeControllerFeatureProvider<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
                 TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
                 TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto>).Assembly;
             var controllerTypes = currentAssembly.GetExportedTypes()

--- a/src/Skoruba.IdentityServer4.Admin/Configuration/ApplicationParts/GenericTypeControllerFeatureProvider.cs
+++ b/src/Skoruba.IdentityServer4.Admin/Configuration/ApplicationParts/GenericTypeControllerFeatureProvider.cs
@@ -10,11 +10,11 @@ using Skoruba.IdentityServer4.Admin.BusinessLogic.Identity.Dtos.Identity;
 
 namespace Skoruba.IdentityServer4.Admin.Configuration.ApplicationParts
 {      
-    public class GenericTypeControllerFeatureProvider<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
+    public class GenericTypeControllerFeatureProvider<TUserDto, TRoleDto, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
         TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
         TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto> : IApplicationFeatureProvider<ControllerFeature>
-        where TUserDto : UserDto<TUserDtoKey>, new()
-        where TRoleDto : RoleDto<TRoleDtoKey>, new()
+        where TUserDto : UserDto<TKey>, new()
+        where TRoleDto : RoleDto<TKey>, new()
         where TUser : IdentityUser<TKey>
         where TRole : IdentityRole<TKey>
         where TKey : IEquatable<TKey>
@@ -23,20 +23,20 @@ namespace Skoruba.IdentityServer4.Admin.Configuration.ApplicationParts
         where TUserLogin : IdentityUserLogin<TKey>
         where TRoleClaim : IdentityRoleClaim<TKey>
         where TUserToken : IdentityUserToken<TKey>
-        where TRoleDtoKey : IEquatable<TRoleDtoKey>
-        where TUserDtoKey : IEquatable<TUserDtoKey>
-        where TUsersDto : UsersDto<TUserDto, TUserDtoKey>
-        where TRolesDto : RolesDto<TRoleDto, TRoleDtoKey>
-        where TUserRolesDto : UserRolesDto<TRoleDto, TUserDtoKey, TRoleDtoKey>
-        where TUserClaimsDto : UserClaimsDto<TUserDtoKey>
-        where TUserProviderDto : UserProviderDto<TUserDtoKey>
-        where TUserProvidersDto : UserProvidersDto<TUserDtoKey>
-        where TUserChangePasswordDto : UserChangePasswordDto<TUserDtoKey>
-        where TRoleClaimsDto : RoleClaimsDto<TRoleDtoKey>
+
+
+        where TUsersDto : UsersDto<TUserDto, TKey>
+        where TRolesDto : RolesDto<TRoleDto, TKey>
+        where TUserRolesDto : UserRolesDto<TRoleDto, TKey>
+        where TUserClaimsDto : UserClaimsDto<TKey>
+        where TUserProviderDto : UserProviderDto<TKey>
+        where TUserProvidersDto : UserProvidersDto<TKey>
+        where TUserChangePasswordDto : UserChangePasswordDto<TKey>
+        where TRoleClaimsDto : RoleClaimsDto<TKey>
     {
         public void PopulateFeature(IEnumerable<ApplicationPart> parts, ControllerFeature feature)
         {
-            var currentAssembly = typeof(GenericTypeControllerFeatureProvider<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
+            var currentAssembly = typeof(GenericTypeControllerFeatureProvider<TUserDto, TRoleDto, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
                 TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
                 TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto>).Assembly;
             var controllerTypes = currentAssembly.GetExportedTypes()

--- a/src/Skoruba.IdentityServer4.Admin/Controllers/IdentityController.cs
+++ b/src/Skoruba.IdentityServer4.Admin/Controllers/IdentityController.cs
@@ -18,11 +18,11 @@ namespace Skoruba.IdentityServer4.Admin.Controllers
 {
     [Authorize(Policy = AuthorizationConsts.AdministrationPolicy)]
     [TypeFilter(typeof(ControllerExceptionFilterAttribute))]
-    public class IdentityController<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
+    public class IdentityController<TUserDto, TRoleDto, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
             TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
             TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto> : BaseController
-        where TUserDto : UserDto<TUserDtoKey>, new()
-        where TRoleDto : RoleDto<TRoleDtoKey>, new()
+        where TUserDto : UserDto<TKey>, new()
+        where TRoleDto : RoleDto<TKey>, new()
         where TUser : IdentityUser<TKey>
         where TRole : IdentityRole<TKey>
         where TKey : IEquatable<TKey>
@@ -31,29 +31,29 @@ namespace Skoruba.IdentityServer4.Admin.Controllers
         where TUserLogin : IdentityUserLogin<TKey>
         where TRoleClaim : IdentityRoleClaim<TKey>
         where TUserToken : IdentityUserToken<TKey>
-        where TRoleDtoKey : IEquatable<TRoleDtoKey>
-        where TUserDtoKey : IEquatable<TUserDtoKey>
-        where TUsersDto : UsersDto<TUserDto, TUserDtoKey>
-        where TRolesDto : RolesDto<TRoleDto, TRoleDtoKey>
-        where TUserRolesDto : UserRolesDto<TRoleDto, TUserDtoKey, TRoleDtoKey>
-        where TUserClaimsDto : UserClaimsDto<TUserDtoKey>
-        where TUserProviderDto : UserProviderDto<TUserDtoKey>
-        where TUserProvidersDto : UserProvidersDto<TUserDtoKey>
-        where TUserChangePasswordDto : UserChangePasswordDto<TUserDtoKey>
-        where TRoleClaimsDto : RoleClaimsDto<TRoleDtoKey>
+
+
+        where TUsersDto : UsersDto<TUserDto, TKey>
+        where TRolesDto : RolesDto<TRoleDto, TKey>
+        where TUserRolesDto : UserRolesDto<TRoleDto, TKey>
+        where TUserClaimsDto : UserClaimsDto<TKey>
+        where TUserProviderDto : UserProviderDto<TKey>
+        where TUserProvidersDto : UserProvidersDto<TKey>
+        where TUserChangePasswordDto : UserChangePasswordDto<TKey>
+        where TRoleClaimsDto : RoleClaimsDto<TKey>
     {
-        private readonly IIdentityService<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
+        private readonly IIdentityService<TUserDto, TRoleDto, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
             TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
             TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto> _identityService;
-        private readonly IGenericControllerLocalizer<IdentityController<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
+        private readonly IGenericControllerLocalizer<IdentityController<TUserDto, TRoleDto, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
             TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
             TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto>> _localizer;
 
-        public IdentityController(IIdentityService<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
+        public IdentityController(IIdentityService<TUserDto, TRoleDto, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
                 TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
                 TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto> identityService,
             ILogger<ConfigurationController> logger,
-            IGenericControllerLocalizer<IdentityController<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
+            IGenericControllerLocalizer<IdentityController<TUserDto, TRoleDto, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
                 TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
                 TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto>> localizer) : base(logger)
         {
@@ -73,9 +73,9 @@ namespace Skoruba.IdentityServer4.Admin.Controllers
         [HttpGet]
         [Route("[controller]/[action]")]
         [Route("[controller]/[action]/{id}")]
-        public async Task<IActionResult> Role(TRoleDtoKey id)
+        public async Task<IActionResult> Role(TKey id)
         {
-            if (EqualityComparer<TRoleDtoKey>.Default.Equals(id, default))
+            if (EqualityComparer<TKey>.Default.Equals(id, default))
             {
                 return View(new TRoleDto());
             }
@@ -96,7 +96,7 @@ namespace Skoruba.IdentityServer4.Admin.Controllers
 
             TKey roleId;
 
-            if (EqualityComparer<TRoleDtoKey>.Default.Equals(role.Id, default))
+            if (EqualityComparer<TKey>.Default.Equals(role.Id, default))
             {
                 var roleData = await _identityService.CreateRoleAsync(role);
                 roleId = roleData.roleId;
@@ -144,7 +144,7 @@ namespace Skoruba.IdentityServer4.Admin.Controllers
 
             TKey userId;
 
-            if (EqualityComparer<TUserDtoKey>.Default.Equals(user.Id, default))
+            if (EqualityComparer<TKey>.Default.Equals(user.Id, default))
             {
                 var userData = await _identityService.CreateUserAsync(user);
                 userId = userData.userId;
@@ -170,7 +170,7 @@ namespace Skoruba.IdentityServer4.Admin.Controllers
 
         [HttpGet]
         [Route("[controller]/UserProfile/{id}")]
-        public async Task<IActionResult> UserProfile(TUserDtoKey id)
+        public async Task<IActionResult> UserProfile(TKey id)
         {
             var user = await _identityService.GetUserAsync(id.ToString());
             if (user == null) return NotFound();
@@ -179,9 +179,9 @@ namespace Skoruba.IdentityServer4.Admin.Controllers
         }
 
         [HttpGet]
-        public async Task<IActionResult> UserRoles(TUserDtoKey id, int? page)
+        public async Task<IActionResult> UserRoles(TKey id, int? page)
         {
-            if (EqualityComparer<TUserDtoKey>.Default.Equals(id, default)) return NotFound();
+            if (EqualityComparer<TKey>.Default.Equals(id, default)) return NotFound();
 
             var userRoles = await _identityService.BuildUserRolesViewModel(id, page);
 
@@ -199,7 +199,7 @@ namespace Skoruba.IdentityServer4.Admin.Controllers
         }
 
         [HttpGet]
-        public async Task<IActionResult> UserRolesDelete(TUserDtoKey id, TRoleDtoKey roleId)
+        public async Task<IActionResult> UserRolesDelete(TKey id, TKey roleId)
         {
             await _identityService.ExistsUserAsync(id.ToString());
             await _identityService.ExistsRoleAsync(roleId.ToString());
@@ -207,7 +207,7 @@ namespace Skoruba.IdentityServer4.Admin.Controllers
             var userDto = await _identityService.GetUserAsync(id.ToString());
             var roles = await _identityService.GetRolesAsync();
 
-            var rolesDto = new UserRolesDto<TRoleDto, TUserDtoKey, TRoleDtoKey>
+            var rolesDto = new UserRolesDto<TRoleDto, TKey>
             {
                 UserId = id,
                 RolesList = roles.Select(x => new SelectItemDto(x.Id.ToString(), x.Name)).ToList(),
@@ -244,9 +244,9 @@ namespace Skoruba.IdentityServer4.Admin.Controllers
         }
 
         [HttpGet]
-        public async Task<IActionResult> UserClaims(TUserDtoKey id, int? page)
+        public async Task<IActionResult> UserClaims(TKey id, int? page)
         {
-            if (EqualityComparer<TUserDtoKey>.Default.Equals(id, default)) return NotFound();
+            if (EqualityComparer<TKey>.Default.Equals(id, default)) return NotFound();
 
             var claims = await _identityService.GetUserClaimsAsync(id.ToString(), page ?? 1);
             claims.UserId = id;
@@ -255,9 +255,9 @@ namespace Skoruba.IdentityServer4.Admin.Controllers
         }
 
         [HttpGet]
-        public async Task<IActionResult> UserClaimsDelete(TUserDtoKey id, int claimId)
+        public async Task<IActionResult> UserClaimsDelete(TKey id, int claimId)
         {
-            if (EqualityComparer<TUserDtoKey>.Default.Equals(id, default)
+            if (EqualityComparer<TKey>.Default.Equals(id, default)
             || EqualityComparer<int>.Default.Equals(claimId, default)) return NotFound();
 
             var claim = await _identityService.GetUserClaimAsync(id.ToString(), claimId);
@@ -280,9 +280,9 @@ namespace Skoruba.IdentityServer4.Admin.Controllers
         }
 
         [HttpGet]
-        public async Task<IActionResult> UserProviders(TUserDtoKey id)
+        public async Task<IActionResult> UserProviders(TKey id)
         {
-            if (EqualityComparer<TUserDtoKey>.Default.Equals(id, default)) return NotFound();
+            if (EqualityComparer<TKey>.Default.Equals(id, default)) return NotFound();
 
             var providers = await _identityService.GetUserProvidersAsync(id.ToString());
 
@@ -290,9 +290,9 @@ namespace Skoruba.IdentityServer4.Admin.Controllers
         }
 
         [HttpGet]
-        public async Task<IActionResult> UserProvidersDelete(TUserDtoKey id, string providerKey)
+        public async Task<IActionResult> UserProvidersDelete(TKey id, string providerKey)
         {
-            if (EqualityComparer<TUserDtoKey>.Default.Equals(id, default) || string.IsNullOrEmpty(providerKey)) return NotFound();
+            if (EqualityComparer<TKey>.Default.Equals(id, default) || string.IsNullOrEmpty(providerKey)) return NotFound();
 
             var provider = await _identityService.GetUserProviderAsync(id.ToString(), providerKey);
             if (provider == null) return NotFound();
@@ -311,12 +311,12 @@ namespace Skoruba.IdentityServer4.Admin.Controllers
         }
 
         [HttpGet]
-        public async Task<IActionResult> UserChangePassword(TUserDtoKey id)
+        public async Task<IActionResult> UserChangePassword(TKey id)
         {
-            if (EqualityComparer<TUserDtoKey>.Default.Equals(id, default)) return NotFound();
+            if (EqualityComparer<TKey>.Default.Equals(id, default)) return NotFound();
 
             var user = await _identityService.GetUserAsync(id.ToString());
-            var userDto = new UserChangePasswordDto<TUserDtoKey> { UserId = id, UserName = user.UserName };
+            var userDto = new UserChangePasswordDto<TKey> { UserId = id, UserName = user.UserName };
 
             return View(userDto);
         }
@@ -363,9 +363,9 @@ namespace Skoruba.IdentityServer4.Admin.Controllers
         }
 
         [HttpGet]
-        public async Task<IActionResult> RoleClaims(TRoleDtoKey id, int? page)
+        public async Task<IActionResult> RoleClaims(TKey id, int? page)
         {
-            if (EqualityComparer<TRoleDtoKey>.Default.Equals(id, default)) return NotFound();
+            if (EqualityComparer<TKey>.Default.Equals(id, default)) return NotFound();
 
             var claims = await _identityService.GetRoleClaimsAsync(id.ToString(), page ?? 1);
             claims.RoleId = id;
@@ -374,9 +374,9 @@ namespace Skoruba.IdentityServer4.Admin.Controllers
         }
 
         [HttpGet]
-        public async Task<IActionResult> RoleClaimsDelete(TRoleDtoKey id, int claimId)
+        public async Task<IActionResult> RoleClaimsDelete(TKey id, int claimId)
         {
-            if (EqualityComparer<TRoleDtoKey>.Default.Equals(id, default) ||
+            if (EqualityComparer<TKey>.Default.Equals(id, default) ||
                 EqualityComparer<int>.Default.Equals(claimId, default)) return NotFound();
 
             var claim = await _identityService.GetRoleClaimAsync(id.ToString(), claimId);
@@ -395,9 +395,9 @@ namespace Skoruba.IdentityServer4.Admin.Controllers
         }
 
         [HttpGet]
-        public async Task<IActionResult> RoleDelete(TRoleDtoKey id)
+        public async Task<IActionResult> RoleDelete(TKey id)
         {
-            if (EqualityComparer<TRoleDtoKey>.Default.Equals(id, default)) return NotFound();
+            if (EqualityComparer<TKey>.Default.Equals(id, default)) return NotFound();
 
             var roleDto = await _identityService.GetRoleAsync(id.ToString());
             if (roleDto == null) return NotFound();
@@ -435,9 +435,9 @@ namespace Skoruba.IdentityServer4.Admin.Controllers
         }
 
         [HttpGet]
-        public async Task<IActionResult> UserDelete(TUserDtoKey id)
+        public async Task<IActionResult> UserDelete(TKey id)
         {
-            if (EqualityComparer<TUserDtoKey>.Default.Equals(id, default)) return NotFound();
+            if (EqualityComparer<TKey>.Default.Equals(id, default)) return NotFound();
 
             var user = await _identityService.GetUserAsync(id.ToString());
             if (user == null) return NotFound();

--- a/src/Skoruba.IdentityServer4.Admin/Controllers/IdentityController.cs
+++ b/src/Skoruba.IdentityServer4.Admin/Controllers/IdentityController.cs
@@ -18,7 +18,7 @@ namespace Skoruba.IdentityServer4.Admin.Controllers
 {
     [Authorize(Policy = AuthorizationConsts.AdministrationPolicy)]
     [TypeFilter(typeof(ControllerExceptionFilterAttribute))]
-    public class IdentityController<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUserKey, TRoleKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
+    public class IdentityController<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
             TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
             TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto> : BaseController
         where TUserDto : UserDto<TUserDtoKey>, new()
@@ -42,18 +42,18 @@ namespace Skoruba.IdentityServer4.Admin.Controllers
         where TUserChangePasswordDto : UserChangePasswordDto<TUserDtoKey>
         where TRoleClaimsDto : RoleClaimsDto<TRoleDtoKey>
     {
-        private readonly IIdentityService<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUserKey, TRoleKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
+        private readonly IIdentityService<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
             TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
             TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto> _identityService;
-        private readonly IGenericControllerLocalizer<IdentityController<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUserKey, TRoleKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
+        private readonly IGenericControllerLocalizer<IdentityController<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
             TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
             TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto>> _localizer;
 
-        public IdentityController(IIdentityService<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUserKey, TRoleKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
+        public IdentityController(IIdentityService<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
                 TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
                 TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto> identityService,
             ILogger<ConfigurationController> logger,
-            IGenericControllerLocalizer<IdentityController<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUserKey, TRoleKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
+            IGenericControllerLocalizer<IdentityController<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
                 TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
                 TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto>> localizer) : base(logger)
         {

--- a/src/Skoruba.IdentityServer4.Admin/Helpers/StartupHelpers.cs
+++ b/src/Skoruba.IdentityServer4.Admin/Helpers/StartupHelpers.cs
@@ -42,6 +42,8 @@ using Skoruba.IdentityServer4.Admin.EntityFramework.Shared.Configuration;
 using Skoruba.IdentityServer4.Admin.EntityFramework.SqlServer.Extensions;
 using Skoruba.IdentityServer4.Admin.EntityFramework.PostgreSQL.Extensions;
 using Skoruba.IdentityServer4.Admin.EntityFramework.Helpers;
+using Skoruba.IdentityServer4.Admin.EntityFramework.Shared.Entities.Identity;
+using Skoruba.IdentityServer4.Admin.EntityFramework.Shared.DbContexts;
 
 namespace Skoruba.IdentityServer4.Admin.Helpers
 {
@@ -492,6 +494,31 @@ namespace Skoruba.IdentityServer4.Admin.Helpers
                         throw new NotImplementedException($"Health checks not defined for database provider {databaseProvider.ProviderType}");
                 }
             }
+        }
+
+        public static void AddAdminAspNetIdentityServices(this IServiceCollection services, HashSet<Type> profileTypes = null)
+        {
+            services.AddAdminAspNetIdentityServices(adminBuilder => adminBuilder.UseUser<UserIdentity>()
+                    .UseRole<UserIdentityRole>()
+                    .UseUserClaim<UserIdentityUserClaim>()
+                    .UseUserRole<UserIdentityUserRole>()
+                    .UseUserLogin<UserIdentityUserLogin>()
+                    .UseRoleClaim<UserIdentityRoleClaim>()
+                    .UseUserToken<UserIdentityUserToken>()
+                    .UseIdentityDbContext<AdminIdentityDbContext>()
+                    .UsePersistedGrantDbContext<IdentityServerPersistedGrantDbContext>()
+                    .UseDto(dtoBuilder => dtoBuilder.UseRole<RoleDto<string>, RolesDto<RoleDto<string>, string>, UserRolesDto<RoleDto<string>, string>>()
+                        .UseRoleClaim<RoleClaimDto<string>>()
+                        .UseRoleClaims<RoleClaimsDto<string>>()
+                        .UseUser<UserDto<string>, UsersDto<UserDto<string>, string>>()
+                        .UseUserClaim<UserClaimDto<string>>()
+                        .UseUserClaims<UserClaimsDto<string>>()
+                        .UseUserProvider<UserProviderDto<string>>()
+                        .UseUserProviders<UserProvidersDto<string>>()
+                        .UseUserChangePassword<UserChangePasswordDto<string>>()
+                    ),
+                    profileTypes
+            );
         }
     }
 }

--- a/src/Skoruba.IdentityServer4.Admin/Helpers/StartupHelpers.cs
+++ b/src/Skoruba.IdentityServer4.Admin/Helpers/StartupHelpers.cs
@@ -236,7 +236,7 @@ namespace Skoruba.IdentityServer4.Admin.Helpers
         /// Register services for MVC and localization including available languages
         /// </summary>
         /// <param name="services"></param>
-        public static void AddMvcWithLocalization<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUserKey, TRoleKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
+        public static void AddMvcWithLocalization<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
             TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
             TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto>(this IServiceCollection services, IConfiguration configuration)
             where TUserDto : UserDto<TUserDtoKey>, new()
@@ -276,7 +276,7 @@ namespace Skoruba.IdentityServer4.Admin.Helpers
                 .AddDataAnnotationsLocalization()
                 .ConfigureApplicationPartManager(m =>
                 {
-                    m.FeatureProviders.Add(new GenericTypeControllerFeatureProvider<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUserKey, TRoleKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
+                    m.FeatureProviders.Add(new GenericTypeControllerFeatureProvider<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
                         TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
                         TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto>());
                 });

--- a/src/Skoruba.IdentityServer4.Admin/Helpers/StartupHelpers.cs
+++ b/src/Skoruba.IdentityServer4.Admin/Helpers/StartupHelpers.cs
@@ -236,11 +236,11 @@ namespace Skoruba.IdentityServer4.Admin.Helpers
         /// Register services for MVC and localization including available languages
         /// </summary>
         /// <param name="services"></param>
-        public static void AddMvcWithLocalization<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
+        public static void AddMvcWithLocalization<TUserDto, TRoleDto, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
             TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
             TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto>(this IServiceCollection services, IConfiguration configuration)
-            where TUserDto : UserDto<TUserDtoKey>, new()
-            where TRoleDto : RoleDto<TRoleDtoKey>, new()
+            where TUserDto : UserDto<TKey>, new()
+            where TRoleDto : RoleDto<TKey>, new()
             where TUser : IdentityUser<TKey>
             where TRole : IdentityRole<TKey>
             where TKey : IEquatable<TKey>
@@ -249,16 +249,16 @@ namespace Skoruba.IdentityServer4.Admin.Helpers
             where TUserLogin : IdentityUserLogin<TKey>
             where TRoleClaim : IdentityRoleClaim<TKey>
             where TUserToken : IdentityUserToken<TKey>
-            where TRoleDtoKey : IEquatable<TRoleDtoKey>
-            where TUserDtoKey : IEquatable<TUserDtoKey>
-            where TUsersDto : UsersDto<TUserDto, TUserDtoKey>
-            where TRolesDto : RolesDto<TRoleDto, TRoleDtoKey>
-            where TUserRolesDto : UserRolesDto<TRoleDto, TUserDtoKey, TRoleDtoKey>
-            where TUserClaimsDto : UserClaimsDto<TUserDtoKey>
-            where TUserProviderDto : UserProviderDto<TUserDtoKey>
-            where TUserProvidersDto : UserProvidersDto<TUserDtoKey>
-            where TUserChangePasswordDto : UserChangePasswordDto<TUserDtoKey>
-            where TRoleClaimsDto : RoleClaimsDto<TRoleDtoKey>
+
+
+            where TUsersDto : UsersDto<TUserDto, TKey>
+            where TRolesDto : RolesDto<TRoleDto, TKey>
+            where TUserRolesDto : UserRolesDto<TRoleDto, TKey>
+            where TUserClaimsDto : UserClaimsDto<TKey>
+            where TUserProviderDto : UserProviderDto<TKey>
+            where TUserProvidersDto : UserProvidersDto<TKey>
+            where TUserChangePasswordDto : UserChangePasswordDto<TKey>
+            where TRoleClaimsDto : RoleClaimsDto<TKey>
         {
             services.AddSingleton<ITempDataProvider, CookieTempDataProvider>();
 
@@ -276,7 +276,7 @@ namespace Skoruba.IdentityServer4.Admin.Helpers
                 .AddDataAnnotationsLocalization()
                 .ConfigureApplicationPartManager(m =>
                 {
-                    m.FeatureProviders.Add(new GenericTypeControllerFeatureProvider<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
+                    m.FeatureProviders.Add(new GenericTypeControllerFeatureProvider<TUserDto, TRoleDto, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
                         TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
                         TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto>());
                 });

--- a/src/Skoruba.IdentityServer4.Admin/Startup.cs
+++ b/src/Skoruba.IdentityServer4.Admin/Startup.cs
@@ -49,13 +49,30 @@ namespace Skoruba.IdentityServer4.Admin
             services.AddAdminServices<IdentityServerConfigurationDbContext, IdentityServerPersistedGrantDbContext, AdminLogDbContext>();
 
             // Add all dependencies for Asp.Net Core Identity
-            // If you want to change primary keys or use another db model for Asp.Net Core Identity:
-            services.AddAdminAspNetIdentityServices<AdminIdentityDbContext, IdentityServerPersistedGrantDbContext, UserDto<string>, RoleDto<string>,
-                                UserIdentity, UserIdentityRole, string, UserIdentityUserClaim, UserIdentityUserRole,
-                                UserIdentityUserLogin, UserIdentityRoleClaim, UserIdentityUserToken,
-                                UsersDto<UserDto<string>, string>, RolesDto<RoleDto<string>, string>, UserRolesDto<RoleDto<string>, string>,
-                                UserClaimsDto<string>, UserProviderDto<string>, UserProvidersDto<string>, UserChangePasswordDto<string>,
-                                RoleClaimsDto<string>, UserClaimDto<string>, RoleClaimDto<string>>();
+            // If you want to change primary keys or use another db model for Asp.Net Core Identity
+            // Default configuration which we can not use for now cause we have no default IdentityDbContext and IdentityServerPersistedGrantDbContext in Skoruba.IdentityServer4.Admin.BusinessLogic.Identity
+            //services.AddAdminAspNetIdentityServices();
+            // Custom configuration
+            services.AddAdminAspNetIdentityServices<string>(adminBuilder => adminBuilder.UseUser<UserIdentity>()
+                    .UseRole<UserIdentityRole>()
+                    .UseUserClaim<UserIdentityUserClaim>()
+                    .UseUserRole<UserIdentityUserRole>()
+                    .UseUserLogin<UserIdentityUserLogin>()
+                    .UseRoleClaim<UserIdentityRoleClaim>()
+                    .UseUserToken<UserIdentityUserToken>()
+                    .UseIdentityDbContext<AdminIdentityDbContext>()
+                    .UsePersistedGrantDbContext<IdentityServerPersistedGrantDbContext>()
+                    .UseDto(dtoBuilder => dtoBuilder.UseRole<RoleDto<string>, RolesDto<RoleDto<string>, string>, UserRolesDto<RoleDto<string>, string>>()
+                        .UseRoleClaim<RoleClaimDto<string>>()
+                        .UseRoleClaims<RoleClaimsDto<string>>()
+                        .UseUser<UserDto<string>, UsersDto<UserDto<string>, string>>()
+                        .UseUserClaim<UserClaimDto<string>>()
+                        .UseUserClaims<UserClaimsDto<string>>()
+                        .UseUserProvider<UserProviderDto<string>>()
+                        .UseUserProviders<UserProvidersDto<string>>()
+                        .UseUserChangePassword<UserChangePasswordDto<string>>()
+                    )
+            );
             
             // Add all dependencies for Asp.Net Core Identity in MVC - these dependencies are injected into generic Controllers
             // Including settings for MVC and Localization

--- a/src/Skoruba.IdentityServer4.Admin/Startup.cs
+++ b/src/Skoruba.IdentityServer4.Admin/Startup.cs
@@ -50,7 +50,7 @@ namespace Skoruba.IdentityServer4.Admin
 
             // Add all dependencies for Asp.Net Core Identity
             // If you want to change primary keys or use another db model for Asp.Net Core Identity:
-            services.AddAdminAspNetIdentityServices<AdminIdentityDbContext, IdentityServerPersistedGrantDbContext, UserDto<string>, string, RoleDto<string>, string, string, string,
+            services.AddAdminAspNetIdentityServices<AdminIdentityDbContext, IdentityServerPersistedGrantDbContext, UserDto<string>, string, RoleDto<string>, string,
                                 UserIdentity, UserIdentityRole, string, UserIdentityUserClaim, UserIdentityUserRole,
                                 UserIdentityUserLogin, UserIdentityRoleClaim, UserIdentityUserToken,
                                 UsersDto<UserDto<string>, string>, RolesDto<RoleDto<string>, string>, UserRolesDto<RoleDto<string>, string, string>,
@@ -60,7 +60,7 @@ namespace Skoruba.IdentityServer4.Admin
             // Add all dependencies for Asp.Net Core Identity in MVC - these dependencies are injected into generic Controllers
             // Including settings for MVC and Localization
             // If you want to change primary keys or use another db model for Asp.Net Core Identity:
-            services.AddMvcWithLocalization<UserDto<string>, string, RoleDto<string>, string, string, string,
+            services.AddMvcWithLocalization<UserDto<string>, string, RoleDto<string>, string,
                 UserIdentity, UserIdentityRole, string, UserIdentityUserClaim, UserIdentityUserRole,
                 UserIdentityUserLogin, UserIdentityRoleClaim, UserIdentityUserToken,
                 UsersDto<UserDto<string>, string>, RolesDto<RoleDto<string>, string>, UserRolesDto<RoleDto<string>, string, string>,

--- a/src/Skoruba.IdentityServer4.Admin/Startup.cs
+++ b/src/Skoruba.IdentityServer4.Admin/Startup.cs
@@ -50,20 +50,20 @@ namespace Skoruba.IdentityServer4.Admin
 
             // Add all dependencies for Asp.Net Core Identity
             // If you want to change primary keys or use another db model for Asp.Net Core Identity:
-            services.AddAdminAspNetIdentityServices<AdminIdentityDbContext, IdentityServerPersistedGrantDbContext, UserDto<string>, string, RoleDto<string>, string,
+            services.AddAdminAspNetIdentityServices<AdminIdentityDbContext, IdentityServerPersistedGrantDbContext, UserDto<string>, RoleDto<string>,
                                 UserIdentity, UserIdentityRole, string, UserIdentityUserClaim, UserIdentityUserRole,
                                 UserIdentityUserLogin, UserIdentityRoleClaim, UserIdentityUserToken,
-                                UsersDto<UserDto<string>, string>, RolesDto<RoleDto<string>, string>, UserRolesDto<RoleDto<string>, string, string>,
+                                UsersDto<UserDto<string>, string>, RolesDto<RoleDto<string>, string>, UserRolesDto<RoleDto<string>, string>,
                                 UserClaimsDto<string>, UserProviderDto<string>, UserProvidersDto<string>, UserChangePasswordDto<string>,
                                 RoleClaimsDto<string>, UserClaimDto<string>, RoleClaimDto<string>>();
             
             // Add all dependencies for Asp.Net Core Identity in MVC - these dependencies are injected into generic Controllers
             // Including settings for MVC and Localization
             // If you want to change primary keys or use another db model for Asp.Net Core Identity:
-            services.AddMvcWithLocalization<UserDto<string>, string, RoleDto<string>, string,
+            services.AddMvcWithLocalization<UserDto<string>, RoleDto<string>,
                 UserIdentity, UserIdentityRole, string, UserIdentityUserClaim, UserIdentityUserRole,
                 UserIdentityUserLogin, UserIdentityRoleClaim, UserIdentityUserToken,
-                UsersDto<UserDto<string>, string>, RolesDto<RoleDto<string>, string>, UserRolesDto<RoleDto<string>, string, string>,
+                UsersDto<UserDto<string>, string>, RolesDto<RoleDto<string>, string>, UserRolesDto<RoleDto<string>, string>,
                 UserClaimsDto<string>, UserProviderDto<string>, UserProvidersDto<string>, UserChangePasswordDto<string>,
                 RoleClaimsDto<string>>(Configuration);
 

--- a/src/Skoruba.IdentityServer4.Admin/Startup.cs
+++ b/src/Skoruba.IdentityServer4.Admin/Startup.cs
@@ -49,11 +49,10 @@ namespace Skoruba.IdentityServer4.Admin
             services.AddAdminServices<IdentityServerConfigurationDbContext, IdentityServerPersistedGrantDbContext, AdminLogDbContext>();
 
             // Add all dependencies for Asp.Net Core Identity
-            // If you want to change primary keys or use another db model for Asp.Net Core Identity
-            // Default configuration which we can not use for now cause we have no default IdentityDbContext and IdentityServerPersistedGrantDbContext in Skoruba.IdentityServer4.Admin.BusinessLogic.Identity
-            //services.AddAdminAspNetIdentityServices();
-            // Custom configuration
-            services.AddAdminAspNetIdentityServices<string>(adminBuilder => adminBuilder.UseUser<UserIdentity>()
+            // Default configuration
+            services.AddAdminAspNetIdentityServices();
+            // Custom configuration (If you want to change primary keys or use another db model for Asp.Net Core Identity)
+            /*services.AddAdminAspNetIdentityServices<string>(adminBuilder => adminBuilder.UseUser<UserIdentity>()
                     .UseRole<UserIdentityRole>()
                     .UseUserClaim<UserIdentityUserClaim>()
                     .UseUserRole<UserIdentityUserRole>()
@@ -72,7 +71,7 @@ namespace Skoruba.IdentityServer4.Admin
                         .UseUserProviders<UserProvidersDto<string>>()
                         .UseUserChangePassword<UserChangePasswordDto<string>>()
                     )
-            );
+            );*/
             
             // Add all dependencies for Asp.Net Core Identity in MVC - these dependencies are injected into generic Controllers
             // Including settings for MVC and Localization

--- a/templates/template-publish/content/src/SkorubaIdentityServer4Admin.Admin.Api/Configuration/ApplicationParts/GenericTypeControllerFeatureProvider.cs
+++ b/templates/template-publish/content/src/SkorubaIdentityServer4Admin.Admin.Api/Configuration/ApplicationParts/GenericTypeControllerFeatureProvider.cs
@@ -10,7 +10,7 @@ using Skoruba.IdentityServer4.Admin.BusinessLogic.Identity.Dtos.Identity;
 
 namespace SkorubaIdentityServer4Admin.Admin.Api.Configuration.ApplicationParts
 {
-    public class GenericTypeControllerFeatureProvider<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUserKey, TRoleKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
+    public class GenericTypeControllerFeatureProvider<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
         TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
         TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto> : IApplicationFeatureProvider<ControllerFeature>
         where TUserDto : UserDto<TUserDtoKey>, new()
@@ -36,7 +36,7 @@ namespace SkorubaIdentityServer4Admin.Admin.Api.Configuration.ApplicationParts
     {
         public void PopulateFeature(IEnumerable<ApplicationPart> parts, ControllerFeature feature)
         {
-            var currentAssembly = typeof(GenericTypeControllerFeatureProvider<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUserKey, TRoleKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
+            var currentAssembly = typeof(GenericTypeControllerFeatureProvider<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
                 TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
                 TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto>).Assembly;
             var controllerTypes = currentAssembly.GetExportedTypes()

--- a/templates/template-publish/content/src/SkorubaIdentityServer4Admin.Admin.Api/Configuration/ApplicationParts/GenericTypeControllerFeatureProvider.cs
+++ b/templates/template-publish/content/src/SkorubaIdentityServer4Admin.Admin.Api/Configuration/ApplicationParts/GenericTypeControllerFeatureProvider.cs
@@ -10,11 +10,11 @@ using Skoruba.IdentityServer4.Admin.BusinessLogic.Identity.Dtos.Identity;
 
 namespace SkorubaIdentityServer4Admin.Admin.Api.Configuration.ApplicationParts
 {
-    public class GenericTypeControllerFeatureProvider<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
+    public class GenericTypeControllerFeatureProvider<TUserDto, TRoleDto, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
         TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
         TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto> : IApplicationFeatureProvider<ControllerFeature>
-        where TUserDto : UserDto<TUserDtoKey>, new()
-        where TRoleDto : RoleDto<TRoleDtoKey>, new()
+        where TUserDto : UserDto<TKey>, new()
+        where TRoleDto : RoleDto<TKey>, new()
         where TUser : IdentityUser<TKey>
         where TRole : IdentityRole<TKey>
         where TKey : IEquatable<TKey>
@@ -23,20 +23,20 @@ namespace SkorubaIdentityServer4Admin.Admin.Api.Configuration.ApplicationParts
         where TUserLogin : IdentityUserLogin<TKey>
         where TRoleClaim : IdentityRoleClaim<TKey>
         where TUserToken : IdentityUserToken<TKey>
-        where TRoleDtoKey : IEquatable<TRoleDtoKey>
-        where TUserDtoKey : IEquatable<TUserDtoKey>
-        where TUsersDto : UsersDto<TUserDto, TUserDtoKey>
-        where TRolesDto : RolesDto<TRoleDto, TRoleDtoKey>
-        where TUserRolesDto : UserRolesDto<TRoleDto, TUserDtoKey, TRoleDtoKey>
-        where TUserClaimsDto : UserClaimsDto<TUserDtoKey>
-        where TUserProviderDto : UserProviderDto<TUserDtoKey>
-        where TUserProvidersDto : UserProvidersDto<TUserDtoKey>
-        where TUserChangePasswordDto : UserChangePasswordDto<TUserDtoKey>
-        where TRoleClaimsDto : RoleClaimsDto<TRoleDtoKey>
+
+
+        where TUsersDto : UsersDto<TUserDto, TKey>
+        where TRolesDto : RolesDto<TRoleDto, TKey>
+        where TUserRolesDto : UserRolesDto<TRoleDto, TKey>
+        where TUserClaimsDto : UserClaimsDto<TKey>
+        where TUserProviderDto : UserProviderDto<TKey>
+        where TUserProvidersDto : UserProvidersDto<TKey>
+        where TUserChangePasswordDto : UserChangePasswordDto<TKey>
+        where TRoleClaimsDto : RoleClaimsDto<TKey>
     {
         public void PopulateFeature(IEnumerable<ApplicationPart> parts, ControllerFeature feature)
         {
-            var currentAssembly = typeof(GenericTypeControllerFeatureProvider<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
+            var currentAssembly = typeof(GenericTypeControllerFeatureProvider<TUserDto, TRoleDto, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
                 TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
                 TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto>).Assembly;
             var controllerTypes = currentAssembly.GetExportedTypes()

--- a/templates/template-publish/content/src/SkorubaIdentityServer4Admin.Admin.Api/Controllers/RolesController.cs
+++ b/templates/template-publish/content/src/SkorubaIdentityServer4Admin.Admin.Api/Controllers/RolesController.cs
@@ -21,7 +21,7 @@ namespace SkorubaIdentityServer4Admin.Admin.Api.Controllers
     [TypeFilter(typeof(ControllerExceptionFilterAttribute))]
     [Produces("application/json", "application/problem+json")]
     [Authorize(Policy = AuthorizationConsts.AdministrationPolicy)]
-    public class RolesController<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUserKey, TRoleKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
+    public class RolesController<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
             TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
             TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto> : ControllerBase
         where TUserDto : UserDto<TUserDtoKey>, new()
@@ -45,20 +45,20 @@ namespace SkorubaIdentityServer4Admin.Admin.Api.Controllers
         where TUserChangePasswordDto : UserChangePasswordDto<TUserDtoKey>
         where TRoleClaimsDto : RoleClaimsDto<TRoleDtoKey>, new()
     {
-        private readonly IIdentityService<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUserKey, TRoleKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
+        private readonly IIdentityService<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
             TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
             TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto> _identityService;
-        private readonly IGenericControllerLocalizer<UsersController<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUserKey, TRoleKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
+        private readonly IGenericControllerLocalizer<UsersController<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
             TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
             TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto>> _localizer;
 
         private readonly IMapper _mapper;
         private readonly IApiErrorResources _errorResources;
 
-        public RolesController(IIdentityService<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUserKey, TRoleKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
+        public RolesController(IIdentityService<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
                 TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
                 TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto> identityService,
-            IGenericControllerLocalizer<UsersController<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUserKey, TRoleKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
+            IGenericControllerLocalizer<UsersController<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
                 TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
                 TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto>> localizer, IMapper mapper, IApiErrorResources errorResources)
         {

--- a/templates/template-publish/content/src/SkorubaIdentityServer4Admin.Admin.Api/Controllers/RolesController.cs
+++ b/templates/template-publish/content/src/SkorubaIdentityServer4Admin.Admin.Api/Controllers/RolesController.cs
@@ -21,11 +21,11 @@ namespace SkorubaIdentityServer4Admin.Admin.Api.Controllers
     [TypeFilter(typeof(ControllerExceptionFilterAttribute))]
     [Produces("application/json", "application/problem+json")]
     [Authorize(Policy = AuthorizationConsts.AdministrationPolicy)]
-    public class RolesController<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
+    public class RolesController<TUserDto, TRoleDto, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
             TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
             TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto> : ControllerBase
-        where TUserDto : UserDto<TUserDtoKey>, new()
-        where TRoleDto : RoleDto<TRoleDtoKey>, new()
+        where TUserDto : UserDto<TKey>, new()
+        where TRoleDto : RoleDto<TKey>, new()
         where TUser : IdentityUser<TKey>
         where TRole : IdentityRole<TKey>
         where TKey : IEquatable<TKey>
@@ -34,31 +34,31 @@ namespace SkorubaIdentityServer4Admin.Admin.Api.Controllers
         where TUserLogin : IdentityUserLogin<TKey>
         where TRoleClaim : IdentityRoleClaim<TKey>
         where TUserToken : IdentityUserToken<TKey>
-        where TRoleDtoKey : IEquatable<TRoleDtoKey>
-        where TUserDtoKey : IEquatable<TUserDtoKey>
-        where TUsersDto : UsersDto<TUserDto, TUserDtoKey>
-        where TRolesDto : RolesDto<TRoleDto, TRoleDtoKey>
-        where TUserRolesDto : UserRolesDto<TRoleDto, TUserDtoKey, TRoleDtoKey>
-        where TUserClaimsDto : UserClaimsDto<TUserDtoKey>, new()
-        where TUserProviderDto : UserProviderDto<TUserDtoKey>
-        where TUserProvidersDto : UserProvidersDto<TUserDtoKey>
-        where TUserChangePasswordDto : UserChangePasswordDto<TUserDtoKey>
-        where TRoleClaimsDto : RoleClaimsDto<TRoleDtoKey>, new()
+
+
+        where TUsersDto : UsersDto<TUserDto, TKey>
+        where TRolesDto : RolesDto<TRoleDto, TKey>
+        where TUserRolesDto : UserRolesDto<TRoleDto, TKey>
+        where TUserClaimsDto : UserClaimsDto<TKey>, new()
+        where TUserProviderDto : UserProviderDto<TKey>
+        where TUserProvidersDto : UserProvidersDto<TKey>
+        where TUserChangePasswordDto : UserChangePasswordDto<TKey>
+        where TRoleClaimsDto : RoleClaimsDto<TKey>, new()
     {
-        private readonly IIdentityService<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
+        private readonly IIdentityService<TUserDto, TRoleDto, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
             TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
             TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto> _identityService;
-        private readonly IGenericControllerLocalizer<UsersController<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
+        private readonly IGenericControllerLocalizer<UsersController<TUserDto, TRoleDto, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
             TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
             TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto>> _localizer;
 
         private readonly IMapper _mapper;
         private readonly IApiErrorResources _errorResources;
 
-        public RolesController(IIdentityService<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
+        public RolesController(IIdentityService<TUserDto, TRoleDto, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
                 TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
                 TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto> identityService,
-            IGenericControllerLocalizer<UsersController<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
+            IGenericControllerLocalizer<UsersController<TUserDto, TRoleDto, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
                 TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
                 TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto>> localizer, IMapper mapper, IApiErrorResources errorResources)
         {
@@ -69,7 +69,7 @@ namespace SkorubaIdentityServer4Admin.Admin.Api.Controllers
         }
 
         [HttpGet("{id}")]
-        public async Task<ActionResult<TRoleDto>> Get(TUserDtoKey id)
+        public async Task<ActionResult<TRoleDto>> Get(TKey id)
         {
             var role = await _identityService.GetRoleAsync(id.ToString());
 
@@ -110,7 +110,7 @@ namespace SkorubaIdentityServer4Admin.Admin.Api.Controllers
         }
 
         [HttpDelete("{id}")]
-        public async Task<IActionResult> Delete(TRoleDtoKey id)
+        public async Task<IActionResult> Delete(TKey id)
         {
             var roleDto = new TRoleDto { Id = id };
 
@@ -129,16 +129,16 @@ namespace SkorubaIdentityServer4Admin.Admin.Api.Controllers
         }
 
         [HttpGet("{id}/Claims")]
-        public async Task<ActionResult<RoleClaimsApiDto<TRoleDtoKey>>> GetRoleClaims(string id, int page = 1, int pageSize = 10)
+        public async Task<ActionResult<RoleClaimsApiDto<TKey>>> GetRoleClaims(string id, int page = 1, int pageSize = 10)
         {
             var roleClaimsDto = await _identityService.GetRoleClaimsAsync(id, page, pageSize);
-            var roleClaimsApiDto = _mapper.Map<RoleClaimsApiDto<TRoleDtoKey>>(roleClaimsDto);
+            var roleClaimsApiDto = _mapper.Map<RoleClaimsApiDto<TKey>>(roleClaimsDto);
 
             return Ok(roleClaimsApiDto);
         }
 
         [HttpPost("Claims")]
-        public async Task<IActionResult> PostRoleClaims([FromBody]RoleClaimApiDto<TRoleDtoKey> roleClaims)
+        public async Task<IActionResult> PostRoleClaims([FromBody]RoleClaimApiDto<TKey> roleClaims)
         {
             var roleClaimsDto = _mapper.Map<TRoleClaimsDto>(roleClaims);
 
@@ -153,7 +153,7 @@ namespace SkorubaIdentityServer4Admin.Admin.Api.Controllers
         }
 
         [HttpDelete("{id}/Claims")]
-        public async Task<IActionResult> DeleteRoleClaims(TRoleDtoKey id, int claimId)
+        public async Task<IActionResult> DeleteRoleClaims(TKey id, int claimId)
         {
             var roleDto = new TRoleClaimsDto { ClaimId = claimId, RoleId = id };
 

--- a/templates/template-publish/content/src/SkorubaIdentityServer4Admin.Admin.Api/Controllers/UsersController.cs
+++ b/templates/template-publish/content/src/SkorubaIdentityServer4Admin.Admin.Api/Controllers/UsersController.cs
@@ -23,7 +23,7 @@ namespace SkorubaIdentityServer4Admin.Admin.Api.Controllers
     [TypeFilter(typeof(ControllerExceptionFilterAttribute))]
     [Produces("application/json", "application/problem+json")]
     [Authorize(Policy = AuthorizationConsts.AdministrationPolicy)]
-    public class UsersController<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUserKey, TRoleKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
+    public class UsersController<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
             TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
             TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto> : ControllerBase
         where TUserDto : UserDto<TUserDtoKey>, new()
@@ -47,20 +47,20 @@ namespace SkorubaIdentityServer4Admin.Admin.Api.Controllers
         where TUserChangePasswordDto : UserChangePasswordDto<TUserDtoKey>
         where TRoleClaimsDto : RoleClaimsDto<TRoleDtoKey>
     {
-        private readonly IIdentityService<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUserKey, TRoleKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
+        private readonly IIdentityService<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
             TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
             TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto> _identityService;
-        private readonly IGenericControllerLocalizer<UsersController<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUserKey, TRoleKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
+        private readonly IGenericControllerLocalizer<UsersController<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
             TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
             TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto>> _localizer;
 
         private readonly IMapper _mapper;
         private readonly IApiErrorResources _errorResources;
 
-        public UsersController(IIdentityService<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUserKey, TRoleKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
+        public UsersController(IIdentityService<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
                 TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
                 TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto> identityService,
-            IGenericControllerLocalizer<UsersController<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUserKey, TRoleKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
+            IGenericControllerLocalizer<UsersController<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
                 TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
                 TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto>> localizer, IMapper mapper, IApiErrorResources errorResources)
         {

--- a/templates/template-publish/content/src/SkorubaIdentityServer4Admin.Admin.Api/Controllers/UsersController.cs
+++ b/templates/template-publish/content/src/SkorubaIdentityServer4Admin.Admin.Api/Controllers/UsersController.cs
@@ -23,11 +23,11 @@ namespace SkorubaIdentityServer4Admin.Admin.Api.Controllers
     [TypeFilter(typeof(ControllerExceptionFilterAttribute))]
     [Produces("application/json", "application/problem+json")]
     [Authorize(Policy = AuthorizationConsts.AdministrationPolicy)]
-    public class UsersController<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
+    public class UsersController<TUserDto, TRoleDto, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
             TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
             TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto> : ControllerBase
-        where TUserDto : UserDto<TUserDtoKey>, new()
-        where TRoleDto : RoleDto<TRoleDtoKey>, new()
+        where TUserDto : UserDto<TKey>, new()
+        where TRoleDto : RoleDto<TKey>, new()
         where TUser : IdentityUser<TKey>
         where TRole : IdentityRole<TKey>
         where TKey : IEquatable<TKey>
@@ -36,31 +36,31 @@ namespace SkorubaIdentityServer4Admin.Admin.Api.Controllers
         where TUserLogin : IdentityUserLogin<TKey>
         where TRoleClaim : IdentityRoleClaim<TKey>
         where TUserToken : IdentityUserToken<TKey>
-        where TRoleDtoKey : IEquatable<TRoleDtoKey>
-        where TUserDtoKey : IEquatable<TUserDtoKey>
-        where TUsersDto : UsersDto<TUserDto, TUserDtoKey>
-        where TRolesDto : RolesDto<TRoleDto, TRoleDtoKey>
-        where TUserRolesDto : UserRolesDto<TRoleDto, TUserDtoKey, TRoleDtoKey>
-        where TUserClaimsDto : UserClaimsDto<TUserDtoKey>, new()
-        where TUserProviderDto : UserProviderDto<TUserDtoKey>
-        where TUserProvidersDto : UserProvidersDto<TUserDtoKey>
-        where TUserChangePasswordDto : UserChangePasswordDto<TUserDtoKey>
-        where TRoleClaimsDto : RoleClaimsDto<TRoleDtoKey>
+
+
+        where TUsersDto : UsersDto<TUserDto, TKey>
+        where TRolesDto : RolesDto<TRoleDto, TKey>
+        where TUserRolesDto : UserRolesDto<TRoleDto, TKey>
+        where TUserClaimsDto : UserClaimsDto<TKey>, new()
+        where TUserProviderDto : UserProviderDto<TKey>
+        where TUserProvidersDto : UserProvidersDto<TKey>
+        where TUserChangePasswordDto : UserChangePasswordDto<TKey>
+        where TRoleClaimsDto : RoleClaimsDto<TKey>
     {
-        private readonly IIdentityService<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
+        private readonly IIdentityService<TUserDto, TRoleDto, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
             TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
             TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto> _identityService;
-        private readonly IGenericControllerLocalizer<UsersController<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
+        private readonly IGenericControllerLocalizer<UsersController<TUserDto, TRoleDto, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
             TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
             TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto>> _localizer;
 
         private readonly IMapper _mapper;
         private readonly IApiErrorResources _errorResources;
 
-        public UsersController(IIdentityService<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
+        public UsersController(IIdentityService<TUserDto, TRoleDto, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
                 TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
                 TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto> identityService,
-            IGenericControllerLocalizer<UsersController<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
+            IGenericControllerLocalizer<UsersController<TUserDto, TRoleDto, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
                 TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
                 TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto>> localizer, IMapper mapper, IApiErrorResources errorResources)
         {
@@ -71,7 +71,7 @@ namespace SkorubaIdentityServer4Admin.Admin.Api.Controllers
         }
 
         [HttpGet("{id}")]
-        public async Task<ActionResult<TUserDto>> Get(TUserDtoKey id)
+        public async Task<ActionResult<TUserDto>> Get(TKey id)
         {
             var user = await _identityService.GetUserAsync(id.ToString());
 
@@ -112,7 +112,7 @@ namespace SkorubaIdentityServer4Admin.Admin.Api.Controllers
         }
 
         [HttpDelete("{id}")]
-        public async Task<IActionResult> Delete(TUserDtoKey id)
+        public async Task<IActionResult> Delete(TKey id)
         {
             var currentUserId = User.GetSubjectId();
             if (id.ToString() == currentUserId)
@@ -136,7 +136,7 @@ namespace SkorubaIdentityServer4Admin.Admin.Api.Controllers
         }
 
         [HttpPost("Roles")]
-        public async Task<IActionResult> PostUserRoles([FromBody]UserRoleApiDto<TUserDtoKey, TRoleDtoKey> role)
+        public async Task<IActionResult> PostUserRoles([FromBody]UserRoleApiDto<TKey> role)
         {
             var userRolesDto = _mapper.Map<TUserRolesDto>(role);
 
@@ -146,7 +146,7 @@ namespace SkorubaIdentityServer4Admin.Admin.Api.Controllers
         }
 
         [HttpDelete("Roles")]
-        public async Task<IActionResult> DeleteUserRoles([FromBody]UserRoleApiDto<TUserDtoKey, TRoleDtoKey> role)
+        public async Task<IActionResult> DeleteUserRoles([FromBody]UserRoleApiDto<TKey> role)
         {
             var userRolesDto = _mapper.Map<TUserRolesDto>(role);
 
@@ -159,17 +159,17 @@ namespace SkorubaIdentityServer4Admin.Admin.Api.Controllers
         }
 
         [HttpGet("{id}/Claims")]
-        public async Task<ActionResult<UserClaimsApiDto<TUserDtoKey>>> GetUserClaims(TUserDtoKey id, int page = 1, int pageSize = 10)
+        public async Task<ActionResult<UserClaimsApiDto<TKey>>> GetUserClaims(TKey id, int page = 1, int pageSize = 10)
         {
             var claims = await _identityService.GetUserClaimsAsync(id.ToString(), page, pageSize);
 
-            var userClaimsApiDto = _mapper.Map<UserClaimsApiDto<TUserDtoKey>>(claims);
+            var userClaimsApiDto = _mapper.Map<UserClaimsApiDto<TKey>>(claims);
 
             return Ok(userClaimsApiDto);
         }
 
         [HttpPost("Claims")]
-        public async Task<IActionResult> PostUserClaims([FromBody]UserClaimApiDto<TUserDtoKey> claim)
+        public async Task<IActionResult> PostUserClaims([FromBody]UserClaimApiDto<TKey> claim)
         {
             var userClaimDto = _mapper.Map<TUserClaimsDto>(claim);
 
@@ -184,7 +184,7 @@ namespace SkorubaIdentityServer4Admin.Admin.Api.Controllers
         }
 
         [HttpDelete("{id}/Claims")]
-        public async Task<IActionResult> DeleteUserClaims([FromRoute]TUserDtoKey id, int claimId)
+        public async Task<IActionResult> DeleteUserClaims([FromRoute]TKey id, int claimId)
         {
             var userClaimsDto = new TUserClaimsDto
             {
@@ -199,16 +199,16 @@ namespace SkorubaIdentityServer4Admin.Admin.Api.Controllers
         }
 
         [HttpGet("{id}/Providers")]
-        public async Task<ActionResult<UserProvidersApiDto<TUserDtoKey>>> GetUserProviders(TUserDtoKey id)
+        public async Task<ActionResult<UserProvidersApiDto<TKey>>> GetUserProviders(TKey id)
         {
             var userProvidersDto = await _identityService.GetUserProvidersAsync(id.ToString());
-            var userProvidersApiDto = _mapper.Map<UserProvidersApiDto<TUserDtoKey>>(userProvidersDto);
+            var userProvidersApiDto = _mapper.Map<UserProvidersApiDto<TKey>>(userProvidersDto);
 
             return Ok(userProvidersApiDto);
         }
 
         [HttpDelete("Providers")]
-        public async Task<IActionResult> DeleteUserProviders([FromBody]UserProviderDeleteApiDto<TUserDtoKey> provider)
+        public async Task<IActionResult> DeleteUserProviders([FromBody]UserProviderDeleteApiDto<TKey> provider)
         {
             var providerDto = _mapper.Map<TUserProviderDto>(provider);
 
@@ -219,7 +219,7 @@ namespace SkorubaIdentityServer4Admin.Admin.Api.Controllers
         }
 
         [HttpPost("ChangePassword")]
-        public async Task<IActionResult> PostChangePassword([FromBody]UserChangePasswordApiDto<TUserDtoKey> password)
+        public async Task<IActionResult> PostChangePassword([FromBody]UserChangePasswordApiDto<TKey> password)
         {
             var userChangePasswordDto = _mapper.Map<TUserChangePasswordDto>(password);
 

--- a/templates/template-publish/content/src/SkorubaIdentityServer4Admin.Admin.Api/Dtos/Roles/RoleClaimApiDto.cs
+++ b/templates/template-publish/content/src/SkorubaIdentityServer4Admin.Admin.Api/Dtos/Roles/RoleClaimApiDto.cs
@@ -2,11 +2,11 @@ using System.ComponentModel.DataAnnotations;
 
 namespace SkorubaIdentityServer4Admin.Admin.Api.Dtos.Roles
 {
-    public class RoleClaimApiDto<TRoleDtoKey>
+    public class RoleClaimApiDto<TKey>
     {
         public int ClaimId { get; set; }
 
-        public TRoleDtoKey RoleId { get; set; }
+        public TKey RoleId { get; set; }
 
         [Required]
         public string ClaimType { get; set; }

--- a/templates/template-publish/content/src/SkorubaIdentityServer4Admin.Admin.Api/Dtos/Roles/RoleClaimsApiDto.cs
+++ b/templates/template-publish/content/src/SkorubaIdentityServer4Admin.Admin.Api/Dtos/Roles/RoleClaimsApiDto.cs
@@ -2,14 +2,14 @@ using System.Collections.Generic;
 
 namespace SkorubaIdentityServer4Admin.Admin.Api.Dtos.Roles
 {
-    public class RoleClaimsApiDto<TRoleDtoKey>
+    public class RoleClaimsApiDto<TKey>
     {
         public RoleClaimsApiDto()
         {
-            Claims = new List<RoleClaimApiDto<TRoleDtoKey>>();
+            Claims = new List<RoleClaimApiDto<TKey>>();
         }
 
-        public List<RoleClaimApiDto<TRoleDtoKey>> Claims { get; set; }
+        public List<RoleClaimApiDto<TKey>> Claims { get; set; }
 
         public int TotalCount { get; set; }
 

--- a/templates/template-publish/content/src/SkorubaIdentityServer4Admin.Admin.Api/Dtos/Users/UserChangePasswordApiDto.cs
+++ b/templates/template-publish/content/src/SkorubaIdentityServer4Admin.Admin.Api/Dtos/Users/UserChangePasswordApiDto.cs
@@ -2,9 +2,9 @@ using System.ComponentModel.DataAnnotations;
 
 namespace SkorubaIdentityServer4Admin.Admin.Api.Dtos.Users
 {
-    public class UserChangePasswordApiDto<TUserDtoKey>
+    public class UserChangePasswordApiDto<TKey>
     {
-        public TUserDtoKey UserId { get; set; }
+        public TKey UserId { get; set; }
 
         [Required]
         public string Password { get; set; }

--- a/templates/template-publish/content/src/SkorubaIdentityServer4Admin.Admin.Api/Dtos/Users/UserClaimApiDto.cs
+++ b/templates/template-publish/content/src/SkorubaIdentityServer4Admin.Admin.Api/Dtos/Users/UserClaimApiDto.cs
@@ -2,11 +2,11 @@ using System.ComponentModel.DataAnnotations;
 
 namespace SkorubaIdentityServer4Admin.Admin.Api.Dtos.Users
 {
-    public class UserClaimApiDto<TUserDtoKey>
+    public class UserClaimApiDto<TKey>
     {
         public int ClaimId { get; set; }
 
-        public TUserDtoKey UserId { get; set; }
+        public TKey UserId { get; set; }
 
         [Required]
         public string ClaimType { get; set; }

--- a/templates/template-publish/content/src/SkorubaIdentityServer4Admin.Admin.Api/Dtos/Users/UserClaimsApiDto.cs
+++ b/templates/template-publish/content/src/SkorubaIdentityServer4Admin.Admin.Api/Dtos/Users/UserClaimsApiDto.cs
@@ -2,14 +2,14 @@ using System.Collections.Generic;
 
 namespace SkorubaIdentityServer4Admin.Admin.Api.Dtos.Users
 {
-    public class UserClaimsApiDto<TUserDtoKey>
+    public class UserClaimsApiDto<TKey>
     {
         public UserClaimsApiDto()
         {
-            Claims = new List<UserClaimApiDto<TUserDtoKey>>();
+            Claims = new List<UserClaimApiDto<TKey>>();
         }
 
-        public List<UserClaimApiDto<TUserDtoKey>> Claims { get; set; }
+        public List<UserClaimApiDto<TKey>> Claims { get; set; }
 
         public int TotalCount { get; set; }
 

--- a/templates/template-publish/content/src/SkorubaIdentityServer4Admin.Admin.Api/Dtos/Users/UserProviderApiDto.cs
+++ b/templates/template-publish/content/src/SkorubaIdentityServer4Admin.Admin.Api/Dtos/Users/UserProviderApiDto.cs
@@ -1,8 +1,8 @@
 namespace SkorubaIdentityServer4Admin.Admin.Api.Dtos.Users
 {
-    public class UserProviderApiDto<TUserDtoKey>
+    public class UserProviderApiDto<TKey>
     {
-        public TUserDtoKey UserId { get; set; }
+        public TKey UserId { get; set; }
 
         public string UserName { get; set; }
 

--- a/templates/template-publish/content/src/SkorubaIdentityServer4Admin.Admin.Api/Dtos/Users/UserProviderDeleteApiDto.cs
+++ b/templates/template-publish/content/src/SkorubaIdentityServer4Admin.Admin.Api/Dtos/Users/UserProviderDeleteApiDto.cs
@@ -1,8 +1,8 @@
 namespace SkorubaIdentityServer4Admin.Admin.Api.Dtos.Users
 {
-    public class UserProviderDeleteApiDto<TUserDtoKey>
+    public class UserProviderDeleteApiDto<TKey>
     {
-        public TUserDtoKey UserId { get; set; }
+        public TKey UserId { get; set; }
 
         public string ProviderKey { get; set; }
 

--- a/templates/template-publish/content/src/SkorubaIdentityServer4Admin.Admin.Api/Dtos/Users/UserProvidersApiDto.cs
+++ b/templates/template-publish/content/src/SkorubaIdentityServer4Admin.Admin.Api/Dtos/Users/UserProvidersApiDto.cs
@@ -2,14 +2,14 @@ using System.Collections.Generic;
 
 namespace SkorubaIdentityServer4Admin.Admin.Api.Dtos.Users
 {
-    public class UserProvidersApiDto<TUserDtoKey>
+    public class UserProvidersApiDto<TKey>
     {
         public UserProvidersApiDto()
         {
-            Providers = new List<UserProviderApiDto<TUserDtoKey>>();
+            Providers = new List<UserProviderApiDto<TKey>>();
         }
 
-        public List<UserProviderApiDto<TUserDtoKey>> Providers { get; set; }
+        public List<UserProviderApiDto<TKey>> Providers { get; set; }
     }
 }
 

--- a/templates/template-publish/content/src/SkorubaIdentityServer4Admin.Admin.Api/Dtos/Users/UserRoleApiDto.cs
+++ b/templates/template-publish/content/src/SkorubaIdentityServer4Admin.Admin.Api/Dtos/Users/UserRoleApiDto.cs
@@ -1,10 +1,10 @@
 namespace SkorubaIdentityServer4Admin.Admin.Api.Dtos.Users
 {
-    public class UserRoleApiDto<TUserDtoKey, TRoleDtoKey>
+    public class UserRoleApiDto<TKey>
     {
-        public TUserDtoKey UserId { get; set; }
+        public TKey UserId { get; set; }
 
-        public TRoleDtoKey RoleId { get; set; }
+        public TKey RoleId { get; set; }
     }
 }
 

--- a/templates/template-publish/content/src/SkorubaIdentityServer4Admin.Admin.Api/Helpers/StartupHelpers.cs
+++ b/templates/template-publish/content/src/SkorubaIdentityServer4Admin.Admin.Api/Helpers/StartupHelpers.cs
@@ -78,13 +78,13 @@ namespace SkorubaIdentityServer4Admin.Admin.Api.Helpers
         /// Register services for MVC
         /// </summary>
         /// <param name="services"></param>
-        public static void AddMvcServices<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey,
+        public static void AddMvcServices<TUserDto, TRoleDto,
             TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
             TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
             TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto>(
             this IServiceCollection services)
-            where TUserDto : UserDto<TUserDtoKey>, new()
-            where TRoleDto : RoleDto<TRoleDtoKey>, new()
+            where TUserDto : UserDto<TKey>, new()
+            where TRoleDto : RoleDto<TKey>, new()
             where TUser : IdentityUser<TKey>
             where TRole : IdentityRole<TKey>
             where TKey : IEquatable<TKey>
@@ -93,16 +93,16 @@ namespace SkorubaIdentityServer4Admin.Admin.Api.Helpers
             where TUserLogin : IdentityUserLogin<TKey>
             where TRoleClaim : IdentityRoleClaim<TKey>
             where TUserToken : IdentityUserToken<TKey>
-            where TRoleDtoKey : IEquatable<TRoleDtoKey>
-            where TUserDtoKey : IEquatable<TUserDtoKey>
-            where TUsersDto : UsersDto<TUserDto, TUserDtoKey>
-            where TRolesDto : RolesDto<TRoleDto, TRoleDtoKey>
-            where TUserRolesDto : UserRolesDto<TRoleDto, TUserDtoKey, TRoleDtoKey>
-            where TUserClaimsDto : UserClaimsDto<TUserDtoKey>
-            where TUserProviderDto : UserProviderDto<TUserDtoKey>
-            where TUserProvidersDto : UserProvidersDto<TUserDtoKey>
-            where TUserChangePasswordDto : UserChangePasswordDto<TUserDtoKey>
-            where TRoleClaimsDto : RoleClaimsDto<TRoleDtoKey>
+
+
+            where TUsersDto : UsersDto<TUserDto, TKey>
+            where TRolesDto : RolesDto<TRoleDto, TKey>
+            where TUserRolesDto : UserRolesDto<TRoleDto, TKey>
+            where TUserClaimsDto : UserClaimsDto<TKey>
+            where TUserProviderDto : UserProviderDto<TKey>
+            where TUserProvidersDto : UserProvidersDto<TKey>
+            where TUserChangePasswordDto : UserChangePasswordDto<TKey>
+            where TRoleClaimsDto : RoleClaimsDto<TKey>
         {
             services.TryAddTransient(typeof(IGenericControllerLocalizer<>), typeof(GenericControllerLocalizer<>));
 
@@ -111,7 +111,7 @@ namespace SkorubaIdentityServer4Admin.Admin.Api.Helpers
                 .ConfigureApplicationPartManager(m =>
                 {
                     m.FeatureProviders.Add(
-                        new GenericTypeControllerFeatureProvider<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey,
+                        new GenericTypeControllerFeatureProvider<TUserDto, TRoleDto,
                             TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
                             TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
                             TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto>());

--- a/templates/template-publish/content/src/SkorubaIdentityServer4Admin.Admin.Api/Helpers/StartupHelpers.cs
+++ b/templates/template-publish/content/src/SkorubaIdentityServer4Admin.Admin.Api/Helpers/StartupHelpers.cs
@@ -78,7 +78,7 @@ namespace SkorubaIdentityServer4Admin.Admin.Api.Helpers
         /// Register services for MVC
         /// </summary>
         /// <param name="services"></param>
-        public static void AddMvcServices<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUserKey, TRoleKey,
+        public static void AddMvcServices<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey,
             TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
             TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
             TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto>(
@@ -111,8 +111,8 @@ namespace SkorubaIdentityServer4Admin.Admin.Api.Helpers
                 .ConfigureApplicationPartManager(m =>
                 {
                     m.FeatureProviders.Add(
-                        new GenericTypeControllerFeatureProvider<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUserKey,
-                            TRoleKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
+                        new GenericTypeControllerFeatureProvider<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey,
+                            TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
                             TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
                             TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto>());
                 });

--- a/templates/template-publish/content/src/SkorubaIdentityServer4Admin.Admin.Api/Mappers/IdentityMapperProfile.cs
+++ b/templates/template-publish/content/src/SkorubaIdentityServer4Admin.Admin.Api/Mappers/IdentityMapperProfile.cs
@@ -6,37 +6,37 @@ using Skoruba.IdentityServer4.Admin.BusinessLogic.Identity.Dtos.Identity;
 namespace SkorubaIdentityServer4Admin.Admin.Api.Mappers
 {
     public class IdentityMapperProfile<TRoleDto, TRoleDtoKey, TUserRolesDto, TUserDtoKey, TUserClaimsDto, TUserClaimDto, TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimDto, TRoleClaimsDto> : Profile
-        where TUserClaimsDto : UserClaimsDto<TUserDtoKey>
-        where TUserClaimDto : UserClaimDto<TUserDtoKey>
-        where TRoleDto : RoleDto<TRoleDtoKey>
-        where TUserRolesDto : UserRolesDto<TRoleDto, TUserDtoKey, TRoleDtoKey>
-        where TUserProviderDto : UserProviderDto<TUserDtoKey>
-        where TUserProvidersDto : UserProvidersDto<TUserDtoKey>
-        where TUserChangePasswordDto : UserChangePasswordDto<TUserDtoKey>
-        where TRoleClaimsDto : RoleClaimsDto<TRoleDtoKey>
-        where TRoleClaimDto : RoleClaimDto<TRoleDtoKey>
+        where TUserClaimsDto : UserClaimsDto<TKey>
+        where TUserClaimDto : UserClaimDto<TKey>
+        where TRoleDto : RoleDto<TKey>
+        where TUserRolesDto : UserRolesDto<TRoleDto, TKey>
+        where TUserProviderDto : UserProviderDto<TKey>
+        where TUserProvidersDto : UserProvidersDto<TKey>
+        where TUserChangePasswordDto : UserChangePasswordDto<TKey>
+        where TRoleClaimsDto : RoleClaimsDto<TKey>
+        where TRoleClaimDto : RoleClaimDto<TKey>
     {
         public IdentityMapperProfile()
         {
             // entity to model
-            CreateMap<TUserClaimsDto, UserClaimsApiDto<TUserDtoKey>>(MemberList.Destination);
-            CreateMap<TUserClaimsDto, UserClaimApiDto<TUserDtoKey>>(MemberList.Destination);
+            CreateMap<TUserClaimsDto, UserClaimsApiDto<TKey>>(MemberList.Destination);
+            CreateMap<TUserClaimsDto, UserClaimApiDto<TKey>>(MemberList.Destination);
 
-            CreateMap<UserClaimApiDto<TUserDtoKey>, TUserClaimsDto>(MemberList.Source);
-            CreateMap<TUserClaimDto, UserClaimApiDto<TUserDtoKey>>(MemberList.Destination);
+            CreateMap<UserClaimApiDto<TKey>, TUserClaimsDto>(MemberList.Source);
+            CreateMap<TUserClaimDto, UserClaimApiDto<TKey>>(MemberList.Destination);
 
             CreateMap<TUserRolesDto, UserRolesApiDto<TRoleDto>>(MemberList.Destination);
-            CreateMap<UserRoleApiDto<TUserDtoKey, TRoleDtoKey>, TUserRolesDto>(MemberList.Destination);
+            CreateMap<UserRoleApiDto<TKey>, TUserRolesDto>(MemberList.Destination);
 
-            CreateMap<TUserProviderDto, UserProviderApiDto<TUserDtoKey>>(MemberList.Destination);
-            CreateMap<TUserProvidersDto, UserProvidersApiDto<TUserDtoKey>>(MemberList.Destination);
-            CreateMap<UserProviderDeleteApiDto<TUserDtoKey>, TUserProviderDto>(MemberList.Source);
+            CreateMap<TUserProviderDto, UserProviderApiDto<TKey>>(MemberList.Destination);
+            CreateMap<TUserProvidersDto, UserProvidersApiDto<TKey>>(MemberList.Destination);
+            CreateMap<UserProviderDeleteApiDto<TKey>, TUserProviderDto>(MemberList.Source);
 
-            CreateMap<UserChangePasswordApiDto<TUserDtoKey>, TUserChangePasswordDto>(MemberList.Destination);
+            CreateMap<UserChangePasswordApiDto<TKey>, TUserChangePasswordDto>(MemberList.Destination);
 
-            CreateMap<RoleClaimsApiDto<TRoleDtoKey>, TRoleClaimsDto>(MemberList.Source);
-            CreateMap<RoleClaimApiDto<TRoleDtoKey>, TRoleClaimDto>(MemberList.Destination);
-            CreateMap<RoleClaimApiDto<TRoleDtoKey>, TRoleClaimsDto>(MemberList.Destination);
+            CreateMap<RoleClaimsApiDto<TKey>, TRoleClaimsDto>(MemberList.Source);
+            CreateMap<RoleClaimApiDto<TKey>, TRoleClaimDto>(MemberList.Destination);
+            CreateMap<RoleClaimApiDto<TKey>, TRoleClaimsDto>(MemberList.Destination);
         }
     }
 }

--- a/templates/template-publish/content/src/SkorubaIdentityServer4Admin.Admin/Configuration/ApplicationParts/GenericTypeControllerFeatureProvider.cs
+++ b/templates/template-publish/content/src/SkorubaIdentityServer4Admin.Admin/Configuration/ApplicationParts/GenericTypeControllerFeatureProvider.cs
@@ -10,7 +10,7 @@ using Skoruba.IdentityServer4.Admin.BusinessLogic.Identity.Dtos.Identity;
 
 namespace SkorubaIdentityServer4Admin.Admin.Configuration.ApplicationParts
 {      
-    public class GenericTypeControllerFeatureProvider<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUserKey, TRoleKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
+    public class GenericTypeControllerFeatureProvider<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
         TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
         TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto> : IApplicationFeatureProvider<ControllerFeature>
         where TUserDto : UserDto<TUserDtoKey>, new()
@@ -36,7 +36,7 @@ namespace SkorubaIdentityServer4Admin.Admin.Configuration.ApplicationParts
     {
         public void PopulateFeature(IEnumerable<ApplicationPart> parts, ControllerFeature feature)
         {
-            var currentAssembly = typeof(GenericTypeControllerFeatureProvider<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUserKey, TRoleKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
+            var currentAssembly = typeof(GenericTypeControllerFeatureProvider<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
                 TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
                 TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto>).Assembly;
             var controllerTypes = currentAssembly.GetExportedTypes()

--- a/templates/template-publish/content/src/SkorubaIdentityServer4Admin.Admin/Configuration/ApplicationParts/GenericTypeControllerFeatureProvider.cs
+++ b/templates/template-publish/content/src/SkorubaIdentityServer4Admin.Admin/Configuration/ApplicationParts/GenericTypeControllerFeatureProvider.cs
@@ -10,11 +10,11 @@ using Skoruba.IdentityServer4.Admin.BusinessLogic.Identity.Dtos.Identity;
 
 namespace SkorubaIdentityServer4Admin.Admin.Configuration.ApplicationParts
 {      
-    public class GenericTypeControllerFeatureProvider<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
+    public class GenericTypeControllerFeatureProvider<TUserDto, TRoleDto, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
         TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
         TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto> : IApplicationFeatureProvider<ControllerFeature>
-        where TUserDto : UserDto<TUserDtoKey>, new()
-        where TRoleDto : RoleDto<TRoleDtoKey>, new()
+        where TUserDto : UserDto<TKey>, new()
+        where TRoleDto : RoleDto<TKey>, new()
         where TUser : IdentityUser<TKey>
         where TRole : IdentityRole<TKey>
         where TKey : IEquatable<TKey>
@@ -23,20 +23,20 @@ namespace SkorubaIdentityServer4Admin.Admin.Configuration.ApplicationParts
         where TUserLogin : IdentityUserLogin<TKey>
         where TRoleClaim : IdentityRoleClaim<TKey>
         where TUserToken : IdentityUserToken<TKey>
-        where TRoleDtoKey : IEquatable<TRoleDtoKey>
-        where TUserDtoKey : IEquatable<TUserDtoKey>
-        where TUsersDto : UsersDto<TUserDto, TUserDtoKey>
-        where TRolesDto : RolesDto<TRoleDto, TRoleDtoKey>
-        where TUserRolesDto : UserRolesDto<TRoleDto, TUserDtoKey, TRoleDtoKey>
-        where TUserClaimsDto : UserClaimsDto<TUserDtoKey>
-        where TUserProviderDto : UserProviderDto<TUserDtoKey>
-        where TUserProvidersDto : UserProvidersDto<TUserDtoKey>
-        where TUserChangePasswordDto : UserChangePasswordDto<TUserDtoKey>
-        where TRoleClaimsDto : RoleClaimsDto<TRoleDtoKey>
+
+
+        where TUsersDto : UsersDto<TUserDto, TKey>
+        where TRolesDto : RolesDto<TRoleDto, TKey>
+        where TUserRolesDto : UserRolesDto<TRoleDto, TKey>
+        where TUserClaimsDto : UserClaimsDto<TKey>
+        where TUserProviderDto : UserProviderDto<TKey>
+        where TUserProvidersDto : UserProvidersDto<TKey>
+        where TUserChangePasswordDto : UserChangePasswordDto<TKey>
+        where TRoleClaimsDto : RoleClaimsDto<TKey>
     {
         public void PopulateFeature(IEnumerable<ApplicationPart> parts, ControllerFeature feature)
         {
-            var currentAssembly = typeof(GenericTypeControllerFeatureProvider<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
+            var currentAssembly = typeof(GenericTypeControllerFeatureProvider<TUserDto, TRoleDto, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
                 TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
                 TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto>).Assembly;
             var controllerTypes = currentAssembly.GetExportedTypes()

--- a/templates/template-publish/content/src/SkorubaIdentityServer4Admin.Admin/Controllers/IdentityController.cs
+++ b/templates/template-publish/content/src/SkorubaIdentityServer4Admin.Admin/Controllers/IdentityController.cs
@@ -18,11 +18,11 @@ namespace SkorubaIdentityServer4Admin.Admin.Controllers
 {
     [Authorize(Policy = AuthorizationConsts.AdministrationPolicy)]
     [TypeFilter(typeof(ControllerExceptionFilterAttribute))]
-    public class IdentityController<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
+    public class IdentityController<TUserDto, TRoleDto, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
             TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
             TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto> : BaseController
-        where TUserDto : UserDto<TUserDtoKey>, new()
-        where TRoleDto : RoleDto<TRoleDtoKey>, new()
+        where TUserDto : UserDto<TKey>, new()
+        where TRoleDto : RoleDto<TKey>, new()
         where TUser : IdentityUser<TKey>
         where TRole : IdentityRole<TKey>
         where TKey : IEquatable<TKey>
@@ -31,29 +31,29 @@ namespace SkorubaIdentityServer4Admin.Admin.Controllers
         where TUserLogin : IdentityUserLogin<TKey>
         where TRoleClaim : IdentityRoleClaim<TKey>
         where TUserToken : IdentityUserToken<TKey>
-        where TRoleDtoKey : IEquatable<TRoleDtoKey>
-        where TUserDtoKey : IEquatable<TUserDtoKey>
-        where TUsersDto : UsersDto<TUserDto, TUserDtoKey>
-        where TRolesDto : RolesDto<TRoleDto, TRoleDtoKey>
-        where TUserRolesDto : UserRolesDto<TRoleDto, TUserDtoKey, TRoleDtoKey>
-        where TUserClaimsDto : UserClaimsDto<TUserDtoKey>
-        where TUserProviderDto : UserProviderDto<TUserDtoKey>
-        where TUserProvidersDto : UserProvidersDto<TUserDtoKey>
-        where TUserChangePasswordDto : UserChangePasswordDto<TUserDtoKey>
-        where TRoleClaimsDto : RoleClaimsDto<TRoleDtoKey>
+
+
+        where TUsersDto : UsersDto<TUserDto, TKey>
+        where TRolesDto : RolesDto<TRoleDto, TKey>
+        where TUserRolesDto : UserRolesDto<TRoleDto, TKey>
+        where TUserClaimsDto : UserClaimsDto<TKey>
+        where TUserProviderDto : UserProviderDto<TKey>
+        where TUserProvidersDto : UserProvidersDto<TKey>
+        where TUserChangePasswordDto : UserChangePasswordDto<TKey>
+        where TRoleClaimsDto : RoleClaimsDto<TKey>
     {
-        private readonly IIdentityService<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
+        private readonly IIdentityService<TUserDto, TRoleDto, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
             TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
             TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto> _identityService;
-        private readonly IGenericControllerLocalizer<IdentityController<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
+        private readonly IGenericControllerLocalizer<IdentityController<TUserDto, TRoleDto, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
             TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
             TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto>> _localizer;
 
-        public IdentityController(IIdentityService<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
+        public IdentityController(IIdentityService<TUserDto, TRoleDto, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
                 TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
                 TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto> identityService,
             ILogger<ConfigurationController> logger,
-            IGenericControllerLocalizer<IdentityController<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
+            IGenericControllerLocalizer<IdentityController<TUserDto, TRoleDto, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
                 TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
                 TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto>> localizer) : base(logger)
         {
@@ -73,9 +73,9 @@ namespace SkorubaIdentityServer4Admin.Admin.Controllers
         [HttpGet]
         [Route("[controller]/[action]")]
         [Route("[controller]/[action]/{id}")]
-        public async Task<IActionResult> Role(TRoleDtoKey id)
+        public async Task<IActionResult> Role(TKey id)
         {
-            if (EqualityComparer<TRoleDtoKey>.Default.Equals(id, default))
+            if (EqualityComparer<TKey>.Default.Equals(id, default))
             {
                 return View(new TRoleDto());
             }
@@ -96,7 +96,7 @@ namespace SkorubaIdentityServer4Admin.Admin.Controllers
 
             TKey roleId;
 
-            if (EqualityComparer<TRoleDtoKey>.Default.Equals(role.Id, default))
+            if (EqualityComparer<TKey>.Default.Equals(role.Id, default))
             {
                 var roleData = await _identityService.CreateRoleAsync(role);
                 roleId = roleData.roleId;
@@ -144,7 +144,7 @@ namespace SkorubaIdentityServer4Admin.Admin.Controllers
 
             TKey userId;
 
-            if (EqualityComparer<TUserDtoKey>.Default.Equals(user.Id, default))
+            if (EqualityComparer<TKey>.Default.Equals(user.Id, default))
             {
                 var userData = await _identityService.CreateUserAsync(user);
                 userId = userData.userId;
@@ -170,7 +170,7 @@ namespace SkorubaIdentityServer4Admin.Admin.Controllers
 
         [HttpGet]
         [Route("[controller]/UserProfile/{id}")]
-        public async Task<IActionResult> UserProfile(TUserDtoKey id)
+        public async Task<IActionResult> UserProfile(TKey id)
         {
             var user = await _identityService.GetUserAsync(id.ToString());
             if (user == null) return NotFound();
@@ -179,9 +179,9 @@ namespace SkorubaIdentityServer4Admin.Admin.Controllers
         }
 
         [HttpGet]
-        public async Task<IActionResult> UserRoles(TUserDtoKey id, int? page)
+        public async Task<IActionResult> UserRoles(TKey id, int? page)
         {
-            if (EqualityComparer<TUserDtoKey>.Default.Equals(id, default)) return NotFound();
+            if (EqualityComparer<TKey>.Default.Equals(id, default)) return NotFound();
 
             var userRoles = await _identityService.BuildUserRolesViewModel(id, page);
 
@@ -199,7 +199,7 @@ namespace SkorubaIdentityServer4Admin.Admin.Controllers
         }
 
         [HttpGet]
-        public async Task<IActionResult> UserRolesDelete(TUserDtoKey id, TRoleDtoKey roleId)
+        public async Task<IActionResult> UserRolesDelete(TKey id, TRoleDtoKey roleId)
         {
             await _identityService.ExistsUserAsync(id.ToString());
             await _identityService.ExistsRoleAsync(roleId.ToString());
@@ -207,7 +207,7 @@ namespace SkorubaIdentityServer4Admin.Admin.Controllers
             var userDto = await _identityService.GetUserAsync(id.ToString());
             var roles = await _identityService.GetRolesAsync();
 
-            var rolesDto = new UserRolesDto<TRoleDto, TUserDtoKey, TRoleDtoKey>
+            var rolesDto = new UserRolesDto<TRoleDto, TKey>
             {
                 UserId = id,
                 RolesList = roles.Select(x => new SelectItemDto(x.Id.ToString(), x.Name)).ToList(),
@@ -244,9 +244,9 @@ namespace SkorubaIdentityServer4Admin.Admin.Controllers
         }
 
         [HttpGet]
-        public async Task<IActionResult> UserClaims(TUserDtoKey id, int? page)
+        public async Task<IActionResult> UserClaims(TKey id, int? page)
         {
-            if (EqualityComparer<TUserDtoKey>.Default.Equals(id, default)) return NotFound();
+            if (EqualityComparer<TKey>.Default.Equals(id, default)) return NotFound();
 
             var claims = await _identityService.GetUserClaimsAsync(id.ToString(), page ?? 1);
             claims.UserId = id;
@@ -255,9 +255,9 @@ namespace SkorubaIdentityServer4Admin.Admin.Controllers
         }
 
         [HttpGet]
-        public async Task<IActionResult> UserClaimsDelete(TUserDtoKey id, int claimId)
+        public async Task<IActionResult> UserClaimsDelete(TKey id, int claimId)
         {
-            if (EqualityComparer<TUserDtoKey>.Default.Equals(id, default)
+            if (EqualityComparer<TKey>.Default.Equals(id, default)
             || EqualityComparer<int>.Default.Equals(claimId, default)) return NotFound();
 
             var claim = await _identityService.GetUserClaimAsync(id.ToString(), claimId);
@@ -280,9 +280,9 @@ namespace SkorubaIdentityServer4Admin.Admin.Controllers
         }
 
         [HttpGet]
-        public async Task<IActionResult> UserProviders(TUserDtoKey id)
+        public async Task<IActionResult> UserProviders(TKey id)
         {
-            if (EqualityComparer<TUserDtoKey>.Default.Equals(id, default)) return NotFound();
+            if (EqualityComparer<TKey>.Default.Equals(id, default)) return NotFound();
 
             var providers = await _identityService.GetUserProvidersAsync(id.ToString());
 
@@ -290,9 +290,9 @@ namespace SkorubaIdentityServer4Admin.Admin.Controllers
         }
 
         [HttpGet]
-        public async Task<IActionResult> UserProvidersDelete(TUserDtoKey id, string providerKey)
+        public async Task<IActionResult> UserProvidersDelete(TKey id, string providerKey)
         {
-            if (EqualityComparer<TUserDtoKey>.Default.Equals(id, default) || string.IsNullOrEmpty(providerKey)) return NotFound();
+            if (EqualityComparer<TKey>.Default.Equals(id, default) || string.IsNullOrEmpty(providerKey)) return NotFound();
 
             var provider = await _identityService.GetUserProviderAsync(id.ToString(), providerKey);
             if (provider == null) return NotFound();
@@ -311,12 +311,12 @@ namespace SkorubaIdentityServer4Admin.Admin.Controllers
         }
 
         [HttpGet]
-        public async Task<IActionResult> UserChangePassword(TUserDtoKey id)
+        public async Task<IActionResult> UserChangePassword(TKey id)
         {
-            if (EqualityComparer<TUserDtoKey>.Default.Equals(id, default)) return NotFound();
+            if (EqualityComparer<TKey>.Default.Equals(id, default)) return NotFound();
 
             var user = await _identityService.GetUserAsync(id.ToString());
-            var userDto = new UserChangePasswordDto<TUserDtoKey> { UserId = id, UserName = user.UserName };
+            var userDto = new UserChangePasswordDto<TKey> { UserId = id, UserName = user.UserName };
 
             return View(userDto);
         }
@@ -363,9 +363,9 @@ namespace SkorubaIdentityServer4Admin.Admin.Controllers
         }
 
         [HttpGet]
-        public async Task<IActionResult> RoleClaims(TRoleDtoKey id, int? page)
+        public async Task<IActionResult> RoleClaims(TKey id, int? page)
         {
-            if (EqualityComparer<TRoleDtoKey>.Default.Equals(id, default)) return NotFound();
+            if (EqualityComparer<TKey>.Default.Equals(id, default)) return NotFound();
 
             var claims = await _identityService.GetRoleClaimsAsync(id.ToString(), page ?? 1);
             claims.RoleId = id;
@@ -374,9 +374,9 @@ namespace SkorubaIdentityServer4Admin.Admin.Controllers
         }
 
         [HttpGet]
-        public async Task<IActionResult> RoleClaimsDelete(TRoleDtoKey id, int claimId)
+        public async Task<IActionResult> RoleClaimsDelete(TKey id, int claimId)
         {
-            if (EqualityComparer<TRoleDtoKey>.Default.Equals(id, default) ||
+            if (EqualityComparer<TKey>.Default.Equals(id, default) ||
                 EqualityComparer<int>.Default.Equals(claimId, default)) return NotFound();
 
             var claim = await _identityService.GetRoleClaimAsync(id.ToString(), claimId);
@@ -395,9 +395,9 @@ namespace SkorubaIdentityServer4Admin.Admin.Controllers
         }
 
         [HttpGet]
-        public async Task<IActionResult> RoleDelete(TRoleDtoKey id)
+        public async Task<IActionResult> RoleDelete(TKey id)
         {
-            if (EqualityComparer<TRoleDtoKey>.Default.Equals(id, default)) return NotFound();
+            if (EqualityComparer<TKey>.Default.Equals(id, default)) return NotFound();
 
             var roleDto = await _identityService.GetRoleAsync(id.ToString());
             if (roleDto == null) return NotFound();
@@ -435,9 +435,9 @@ namespace SkorubaIdentityServer4Admin.Admin.Controllers
         }
 
         [HttpGet]
-        public async Task<IActionResult> UserDelete(TUserDtoKey id)
+        public async Task<IActionResult> UserDelete(TKey id)
         {
-            if (EqualityComparer<TUserDtoKey>.Default.Equals(id, default)) return NotFound();
+            if (EqualityComparer<TKey>.Default.Equals(id, default)) return NotFound();
 
             var user = await _identityService.GetUserAsync(id.ToString());
             if (user == null) return NotFound();

--- a/templates/template-publish/content/src/SkorubaIdentityServer4Admin.Admin/Controllers/IdentityController.cs
+++ b/templates/template-publish/content/src/SkorubaIdentityServer4Admin.Admin/Controllers/IdentityController.cs
@@ -18,7 +18,7 @@ namespace SkorubaIdentityServer4Admin.Admin.Controllers
 {
     [Authorize(Policy = AuthorizationConsts.AdministrationPolicy)]
     [TypeFilter(typeof(ControllerExceptionFilterAttribute))]
-    public class IdentityController<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUserKey, TRoleKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
+    public class IdentityController<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
             TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
             TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto> : BaseController
         where TUserDto : UserDto<TUserDtoKey>, new()
@@ -42,18 +42,18 @@ namespace SkorubaIdentityServer4Admin.Admin.Controllers
         where TUserChangePasswordDto : UserChangePasswordDto<TUserDtoKey>
         where TRoleClaimsDto : RoleClaimsDto<TRoleDtoKey>
     {
-        private readonly IIdentityService<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUserKey, TRoleKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
+        private readonly IIdentityService<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
             TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
             TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto> _identityService;
-        private readonly IGenericControllerLocalizer<IdentityController<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUserKey, TRoleKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
+        private readonly IGenericControllerLocalizer<IdentityController<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
             TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
             TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto>> _localizer;
 
-        public IdentityController(IIdentityService<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUserKey, TRoleKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
+        public IdentityController(IIdentityService<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
                 TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
                 TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto> identityService,
             ILogger<ConfigurationController> logger,
-            IGenericControllerLocalizer<IdentityController<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUserKey, TRoleKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
+            IGenericControllerLocalizer<IdentityController<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
                 TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
                 TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto>> localizer) : base(logger)
         {

--- a/templates/template-publish/content/src/SkorubaIdentityServer4Admin.Admin/Helpers/StartupHelpers.cs
+++ b/templates/template-publish/content/src/SkorubaIdentityServer4Admin.Admin/Helpers/StartupHelpers.cs
@@ -236,7 +236,7 @@ namespace SkorubaIdentityServer4Admin.Admin.Helpers
         /// Register services for MVC and localization including available languages
         /// </summary>
         /// <param name="services"></param>
-        public static void AddMvcWithLocalization<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUserKey, TRoleKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
+        public static void AddMvcWithLocalization<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
             TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
             TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto>(this IServiceCollection services, IConfiguration configuration)
             where TUserDto : UserDto<TUserDtoKey>, new()
@@ -276,7 +276,7 @@ namespace SkorubaIdentityServer4Admin.Admin.Helpers
                 .AddDataAnnotationsLocalization()
                 .ConfigureApplicationPartManager(m =>
                 {
-                    m.FeatureProviders.Add(new GenericTypeControllerFeatureProvider<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUserKey, TRoleKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
+                    m.FeatureProviders.Add(new GenericTypeControllerFeatureProvider<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
                         TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
                         TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto>());
                 });

--- a/templates/template-publish/content/src/SkorubaIdentityServer4Admin.Admin/Helpers/StartupHelpers.cs
+++ b/templates/template-publish/content/src/SkorubaIdentityServer4Admin.Admin/Helpers/StartupHelpers.cs
@@ -236,11 +236,11 @@ namespace SkorubaIdentityServer4Admin.Admin.Helpers
         /// Register services for MVC and localization including available languages
         /// </summary>
         /// <param name="services"></param>
-        public static void AddMvcWithLocalization<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
+        public static void AddMvcWithLocalization<TUserDto, TRoleDto, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
             TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
             TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto>(this IServiceCollection services, IConfiguration configuration)
-            where TUserDto : UserDto<TUserDtoKey>, new()
-            where TRoleDto : RoleDto<TRoleDtoKey>, new()
+            where TUserDto : UserDto<TKey>, new()
+            where TRoleDto : RoleDto<TKey>, new()
             where TUser : IdentityUser<TKey>
             where TRole : IdentityRole<TKey>
             where TKey : IEquatable<TKey>
@@ -249,16 +249,16 @@ namespace SkorubaIdentityServer4Admin.Admin.Helpers
             where TUserLogin : IdentityUserLogin<TKey>
             where TRoleClaim : IdentityRoleClaim<TKey>
             where TUserToken : IdentityUserToken<TKey>
-            where TRoleDtoKey : IEquatable<TRoleDtoKey>
-            where TUserDtoKey : IEquatable<TUserDtoKey>
-            where TUsersDto : UsersDto<TUserDto, TUserDtoKey>
-            where TRolesDto : RolesDto<TRoleDto, TRoleDtoKey>
-            where TUserRolesDto : UserRolesDto<TRoleDto, TUserDtoKey, TRoleDtoKey>
-            where TUserClaimsDto : UserClaimsDto<TUserDtoKey>
-            where TUserProviderDto : UserProviderDto<TUserDtoKey>
-            where TUserProvidersDto : UserProvidersDto<TUserDtoKey>
-            where TUserChangePasswordDto : UserChangePasswordDto<TUserDtoKey>
-            where TRoleClaimsDto : RoleClaimsDto<TRoleDtoKey>
+
+
+            where TUsersDto : UsersDto<TUserDto, TKey>
+            where TRolesDto : RolesDto<TRoleDto, TKey>
+            where TUserRolesDto : UserRolesDto<TRoleDto, TKey>
+            where TUserClaimsDto : UserClaimsDto<TKey>
+            where TUserProviderDto : UserProviderDto<TKey>
+            where TUserProvidersDto : UserProvidersDto<TKey>
+            where TUserChangePasswordDto : UserChangePasswordDto<TKey>
+            where TRoleClaimsDto : RoleClaimsDto<TKey>
         {
             services.AddSingleton<ITempDataProvider, CookieTempDataProvider>();
 
@@ -276,7 +276,7 @@ namespace SkorubaIdentityServer4Admin.Admin.Helpers
                 .AddDataAnnotationsLocalization()
                 .ConfigureApplicationPartManager(m =>
                 {
-                    m.FeatureProviders.Add(new GenericTypeControllerFeatureProvider<TUserDto, TUserDtoKey, TRoleDto, TRoleDtoKey, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
+                    m.FeatureProviders.Add(new GenericTypeControllerFeatureProvider<TUserDto, TRoleDto, TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken,
                         TUsersDto, TRolesDto, TUserRolesDto, TUserClaimsDto,
                         TUserProviderDto, TUserProvidersDto, TUserChangePasswordDto, TRoleClaimsDto>());
                 });

--- a/tests/Skoruba.IdentityServer4.Admin.UnitTests/Controllers/ConfigurationControllerTests.cs
+++ b/tests/Skoruba.IdentityServer4.Admin.UnitTests/Controllers/ConfigurationControllerTests.cs
@@ -813,10 +813,10 @@ namespace Skoruba.IdentityServer4.Admin.UnitTests.Controllers
 
             services.AddAdminServices<IdentityServerConfigurationDbContext, IdentityServerPersistedGrantDbContext, AdminLogDbContext>();
 
-            services.AddAdminAspNetIdentityServices<AdminIdentityDbContext, IdentityServerPersistedGrantDbContext, UserDto<string>, string, RoleDto<string>, string,
+            services.AddAdminAspNetIdentityServices<AdminIdentityDbContext, IdentityServerPersistedGrantDbContext, UserDto<string>, RoleDto<string>,
                 UserIdentity, UserIdentityRole, string, UserIdentityUserClaim, UserIdentityUserRole,
                 UserIdentityUserLogin, UserIdentityRoleClaim, UserIdentityUserToken,
-                UsersDto<UserDto<string>, string>, RolesDto<RoleDto<string>, string>, UserRolesDto<RoleDto<string>, string, string>,
+                UsersDto<UserDto<string>, string>, RolesDto<RoleDto<string>, string>, UserRolesDto<RoleDto<string>, string>,
                 UserClaimsDto<string>, UserProviderDto<string>, UserProvidersDto<string>, UserChangePasswordDto<string>,
                 RoleClaimsDto<string>, UserClaimDto<string>, RoleClaimDto<string>>();
 

--- a/tests/Skoruba.IdentityServer4.Admin.UnitTests/Controllers/ConfigurationControllerTests.cs
+++ b/tests/Skoruba.IdentityServer4.Admin.UnitTests/Controllers/ConfigurationControllerTests.cs
@@ -813,7 +813,7 @@ namespace Skoruba.IdentityServer4.Admin.UnitTests.Controllers
 
             services.AddAdminServices<IdentityServerConfigurationDbContext, IdentityServerPersistedGrantDbContext, AdminLogDbContext>();
 
-            services.AddAdminAspNetIdentityServices<AdminIdentityDbContext, IdentityServerPersistedGrantDbContext, UserDto<string>, string, RoleDto<string>, string, string, string,
+            services.AddAdminAspNetIdentityServices<AdminIdentityDbContext, IdentityServerPersistedGrantDbContext, UserDto<string>, string, RoleDto<string>, string,
                 UserIdentity, UserIdentityRole, string, UserIdentityUserClaim, UserIdentityUserRole,
                 UserIdentityUserLogin, UserIdentityRoleClaim, UserIdentityUserToken,
                 UsersDto<UserDto<string>, string>, RolesDto<RoleDto<string>, string>, UserRolesDto<RoleDto<string>, string, string>,

--- a/tests/Skoruba.IdentityServer4.Admin.UnitTests/Controllers/ConfigurationControllerTests.cs
+++ b/tests/Skoruba.IdentityServer4.Admin.UnitTests/Controllers/ConfigurationControllerTests.cs
@@ -813,12 +813,29 @@ namespace Skoruba.IdentityServer4.Admin.UnitTests.Controllers
 
             services.AddAdminServices<IdentityServerConfigurationDbContext, IdentityServerPersistedGrantDbContext, AdminLogDbContext>();
 
-            services.AddAdminAspNetIdentityServices<AdminIdentityDbContext, IdentityServerPersistedGrantDbContext, UserDto<string>, RoleDto<string>,
-                UserIdentity, UserIdentityRole, string, UserIdentityUserClaim, UserIdentityUserRole,
-                UserIdentityUserLogin, UserIdentityRoleClaim, UserIdentityUserToken,
-                UsersDto<UserDto<string>, string>, RolesDto<RoleDto<string>, string>, UserRolesDto<RoleDto<string>, string>,
-                UserClaimsDto<string>, UserProviderDto<string>, UserProvidersDto<string>, UserChangePasswordDto<string>,
-                RoleClaimsDto<string>, UserClaimDto<string>, RoleClaimDto<string>>();
+            // Default configuration which we can not use for now cause we have no default IdentityDbContext and IdentityServerPersistedGrantDbContext in Skoruba.IdentityServer4.Admin.BusinessLogic.Identity
+            //services.AddAdminAspNetIdentityServices();
+            // Custom configuration
+            services.AddAdminAspNetIdentityServices<string>(adminBuilder => adminBuilder.UseUser<UserIdentity>()
+                    .UseRole<UserIdentityRole>()
+                    .UseUserClaim<UserIdentityUserClaim>()
+                    .UseUserRole<UserIdentityUserRole>()
+                    .UseUserLogin<UserIdentityUserLogin>()
+                    .UseRoleClaim<UserIdentityRoleClaim>()
+                    .UseUserToken<UserIdentityUserToken>()
+                    .UseIdentityDbContext<AdminIdentityDbContext>()
+                    .UsePersistedGrantDbContext<IdentityServerPersistedGrantDbContext>()
+                    .UseDto(dtoBuilder => dtoBuilder.UseRole<RoleDto<string>, RolesDto<RoleDto<string>, string>, UserRolesDto<RoleDto<string>, string>>()
+                        .UseRoleClaim<RoleClaimDto<string>>()
+                        .UseRoleClaims<RoleClaimsDto<string>>()
+                        .UseUser<UserDto<string>, UsersDto<UserDto<string>, string>>()
+                        .UseUserClaim<UserClaimDto<string>>()
+                        .UseUserClaims<UserClaimsDto<string>>()
+                        .UseUserProvider<UserProviderDto<string>>()
+                        .UseUserProviders<UserProvidersDto<string>>()
+                        .UseUserChangePassword<UserChangePasswordDto<string>>()
+                    )
+            );
 
             services.AddSession();
             services.AddMvc()

--- a/tests/Skoruba.IdentityServer4.Admin.UnitTests/Controllers/IdentityControllerTests.cs
+++ b/tests/Skoruba.IdentityServer4.Admin.UnitTests/Controllers/IdentityControllerTests.cs
@@ -615,12 +615,29 @@ namespace Skoruba.IdentityServer4.Admin.UnitTests.Controllers
 
             services.AddAdminServices<IdentityServerConfigurationDbContext, IdentityServerPersistedGrantDbContext, AdminLogDbContext>();
 
-            services.AddAdminAspNetIdentityServices<AdminIdentityDbContext, IdentityServerPersistedGrantDbContext,UserDto<string>, RoleDto<string>,
-                UserIdentity, UserIdentityRole, string, UserIdentityUserClaim, UserIdentityUserRole,
-                UserIdentityUserLogin, UserIdentityRoleClaim, UserIdentityUserToken,
-                UsersDto<UserDto<string>, string>, RolesDto<RoleDto<string>, string>, UserRolesDto<RoleDto<string>, string>,
-                UserClaimsDto<string>, UserProviderDto<string>, UserProvidersDto<string>, UserChangePasswordDto<string>,
-                RoleClaimsDto<string>, UserClaimDto<string>, RoleClaimDto<string>>();
+            // Default configuration which we can not use for now cause we have no default IdentityDbContext and IdentityServerPersistedGrantDbContext in Skoruba.IdentityServer4.Admin.BusinessLogic.Identity
+            //services.AddAdminAspNetIdentityServices();
+            // Custom configuration
+            services.AddAdminAspNetIdentityServices<string>(adminBuilder => adminBuilder.UseUser<UserIdentity>()
+                    .UseRole<UserIdentityRole>()
+                    .UseUserClaim<UserIdentityUserClaim>()
+                    .UseUserRole<UserIdentityUserRole>()
+                    .UseUserLogin<UserIdentityUserLogin>()
+                    .UseRoleClaim<UserIdentityRoleClaim>()
+                    .UseUserToken<UserIdentityUserToken>()
+                    .UseIdentityDbContext<AdminIdentityDbContext>()
+                    .UsePersistedGrantDbContext<IdentityServerPersistedGrantDbContext>()
+                    .UseDto(dtoBuilder => dtoBuilder.UseRole<RoleDto<string>, RolesDto<RoleDto<string>, string>, UserRolesDto<RoleDto<string>, string>>()
+                        .UseRoleClaim<RoleClaimDto<string>>()
+                        .UseRoleClaims<RoleClaimsDto<string>>()
+                        .UseUser<UserDto<string>, UsersDto<UserDto<string>, string>>()
+                        .UseUserClaim<UserClaimDto<string>>()
+                        .UseUserClaims<UserClaimsDto<string>>()
+                        .UseUserProvider<UserProviderDto<string>>()
+                        .UseUserProviders<UserProvidersDto<string>>()
+                        .UseUserChangePassword<UserChangePasswordDto<string>>()
+                    )
+            );
 
             services.AddIdentity<UserIdentity, UserIdentityRole>()
                 .AddEntityFrameworkStores<AdminIdentityDbContext>()

--- a/tests/Skoruba.IdentityServer4.Admin.UnitTests/Controllers/IdentityControllerTests.cs
+++ b/tests/Skoruba.IdentityServer4.Admin.UnitTests/Controllers/IdentityControllerTests.cs
@@ -35,17 +35,17 @@ namespace Skoruba.IdentityServer4.Admin.UnitTests.Controllers
 {
     public class IdentityControllerTests
     {
-        private IIdentityService<UserDto<string>, string, RoleDto<string>, string,
+        private IIdentityService<UserDto<string>, RoleDto<string>,
             UserIdentity, UserIdentityRole, string, UserIdentityUserClaim, UserIdentityUserRole,
             UserIdentityUserLogin, UserIdentityRoleClaim, UserIdentityUserToken,
-            UsersDto<UserDto<string>, string>, RolesDto<RoleDto<string>, string>, UserRolesDto<RoleDto<string>, string, string>,
+            UsersDto<UserDto<string>, string>, RolesDto<RoleDto<string>, string>, UserRolesDto<RoleDto<string>, string>,
             UserClaimsDto<string>, UserProviderDto<string>, UserProvidersDto<string>, UserChangePasswordDto<string>,
             RoleClaimsDto<string>> GetIdentityService(IServiceProvider services)
         {
-            return services.GetRequiredService<IIdentityService<UserDto<string>, string, RoleDto<string>, string,
+            return services.GetRequiredService<IIdentityService<UserDto<string>, RoleDto<string>,
                 UserIdentity, UserIdentityRole, string, UserIdentityUserClaim, UserIdentityUserRole,
                 UserIdentityUserLogin, UserIdentityRoleClaim, UserIdentityUserToken,
-                UsersDto<UserDto<string>, string>, RolesDto<RoleDto<string>, string>, UserRolesDto<RoleDto<string>, string, string>,
+                UsersDto<UserDto<string>, string>, RolesDto<RoleDto<string>, string>, UserRolesDto<RoleDto<string>, string>,
                 UserClaimsDto<string>, UserProviderDto<string>, UserProvidersDto<string>, UserChangePasswordDto<string>,
                 RoleClaimsDto<string>>>();
         }
@@ -549,18 +549,18 @@ namespace Skoruba.IdentityServer4.Admin.UnitTests.Controllers
             userProvider.Should().BeNull();
         }
 
-        private IdentityController<UserDto<string>, string, RoleDto<string>, string,
+        private IdentityController<UserDto<string>, RoleDto<string>,
             UserIdentity, UserIdentityRole, string, UserIdentityUserClaim, UserIdentityUserRole,
             UserIdentityUserLogin, UserIdentityRoleClaim, UserIdentityUserToken,
-            UsersDto<UserDto<string>, string>, RolesDto<RoleDto<string>, string>, UserRolesDto<RoleDto<string>, string, string>,
+            UsersDto<UserDto<string>, string>, RolesDto<RoleDto<string>, string>, UserRolesDto<RoleDto<string>, string>,
             UserClaimsDto<string>, UserProviderDto<string>, UserProvidersDto<string>, UserChangePasswordDto<string>,
             RoleClaimsDto<string>> PrepareIdentityController(IServiceProvider serviceProvider)
         {
             // Arrange
-            var localizer = serviceProvider.GetRequiredService<IGenericControllerLocalizer<IdentityController<UserDto<string>, string, RoleDto<string>, string,
+            var localizer = serviceProvider.GetRequiredService<IGenericControllerLocalizer<IdentityController<UserDto<string>, RoleDto<string>,
                 UserIdentity, UserIdentityRole, string, UserIdentityUserClaim, UserIdentityUserRole,
                 UserIdentityUserLogin, UserIdentityRoleClaim, UserIdentityUserToken,
-                UsersDto<UserDto<string>, string>, RolesDto<RoleDto<string>, string>, UserRolesDto<RoleDto<string>, string, string>,
+                UsersDto<UserDto<string>, string>, RolesDto<RoleDto<string>, string>, UserRolesDto<RoleDto<string>, string>,
                 UserClaimsDto<string>, UserProviderDto<string>, UserProvidersDto<string>, UserChangePasswordDto<string>,
                 RoleClaimsDto<string>>>>();
             var logger = serviceProvider.GetRequiredService<ILogger<ConfigurationController>>();
@@ -568,10 +568,10 @@ namespace Skoruba.IdentityServer4.Admin.UnitTests.Controllers
             var identityService = GetIdentityService(serviceProvider);
 
             //Get Controller
-            var controller = new IdentityController<UserDto<string>, string, RoleDto<string>, string,
+            var controller = new IdentityController<UserDto<string>, RoleDto<string>,
                 UserIdentity, UserIdentityRole, string, UserIdentityUserClaim, UserIdentityUserRole,
                 UserIdentityUserLogin, UserIdentityRoleClaim, UserIdentityUserToken,
-                UsersDto<UserDto<string>, string>, RolesDto<RoleDto<string>, string>, UserRolesDto<RoleDto<string>, string, string>,
+                UsersDto<UserDto<string>, string>, RolesDto<RoleDto<string>, string>, UserRolesDto<RoleDto<string>, string>,
                 UserClaimsDto<string>, UserProviderDto<string>, UserProvidersDto<string>, UserChangePasswordDto<string>,
                 RoleClaimsDto<string>>(identityService, logger, localizer);
 
@@ -615,10 +615,10 @@ namespace Skoruba.IdentityServer4.Admin.UnitTests.Controllers
 
             services.AddAdminServices<IdentityServerConfigurationDbContext, IdentityServerPersistedGrantDbContext, AdminLogDbContext>();
 
-            services.AddAdminAspNetIdentityServices<AdminIdentityDbContext, IdentityServerPersistedGrantDbContext,UserDto<string>, string, RoleDto<string>, string,
+            services.AddAdminAspNetIdentityServices<AdminIdentityDbContext, IdentityServerPersistedGrantDbContext,UserDto<string>, RoleDto<string>,
                 UserIdentity, UserIdentityRole, string, UserIdentityUserClaim, UserIdentityUserRole,
                 UserIdentityUserLogin, UserIdentityRoleClaim, UserIdentityUserToken,
-                UsersDto<UserDto<string>, string>, RolesDto<RoleDto<string>, string>, UserRolesDto<RoleDto<string>, string, string>,
+                UsersDto<UserDto<string>, string>, RolesDto<RoleDto<string>, string>, UserRolesDto<RoleDto<string>, string>,
                 UserClaimsDto<string>, UserProviderDto<string>, UserProvidersDto<string>, UserChangePasswordDto<string>,
                 RoleClaimsDto<string>, UserClaimDto<string>, RoleClaimDto<string>>();
 

--- a/tests/Skoruba.IdentityServer4.Admin.UnitTests/Controllers/IdentityControllerTests.cs
+++ b/tests/Skoruba.IdentityServer4.Admin.UnitTests/Controllers/IdentityControllerTests.cs
@@ -35,14 +35,14 @@ namespace Skoruba.IdentityServer4.Admin.UnitTests.Controllers
 {
     public class IdentityControllerTests
     {
-        private IIdentityService<UserDto<string>, string, RoleDto<string>, string, string, string,
+        private IIdentityService<UserDto<string>, string, RoleDto<string>, string,
             UserIdentity, UserIdentityRole, string, UserIdentityUserClaim, UserIdentityUserRole,
             UserIdentityUserLogin, UserIdentityRoleClaim, UserIdentityUserToken,
             UsersDto<UserDto<string>, string>, RolesDto<RoleDto<string>, string>, UserRolesDto<RoleDto<string>, string, string>,
             UserClaimsDto<string>, UserProviderDto<string>, UserProvidersDto<string>, UserChangePasswordDto<string>,
             RoleClaimsDto<string>> GetIdentityService(IServiceProvider services)
         {
-            return services.GetRequiredService<IIdentityService<UserDto<string>, string, RoleDto<string>, string, string, string,
+            return services.GetRequiredService<IIdentityService<UserDto<string>, string, RoleDto<string>, string,
                 UserIdentity, UserIdentityRole, string, UserIdentityUserClaim, UserIdentityUserRole,
                 UserIdentityUserLogin, UserIdentityRoleClaim, UserIdentityUserToken,
                 UsersDto<UserDto<string>, string>, RolesDto<RoleDto<string>, string>, UserRolesDto<RoleDto<string>, string, string>,
@@ -549,7 +549,7 @@ namespace Skoruba.IdentityServer4.Admin.UnitTests.Controllers
             userProvider.Should().BeNull();
         }
 
-        private IdentityController<UserDto<string>, string, RoleDto<string>, string, string, string,
+        private IdentityController<UserDto<string>, string, RoleDto<string>, string,
             UserIdentity, UserIdentityRole, string, UserIdentityUserClaim, UserIdentityUserRole,
             UserIdentityUserLogin, UserIdentityRoleClaim, UserIdentityUserToken,
             UsersDto<UserDto<string>, string>, RolesDto<RoleDto<string>, string>, UserRolesDto<RoleDto<string>, string, string>,
@@ -557,7 +557,7 @@ namespace Skoruba.IdentityServer4.Admin.UnitTests.Controllers
             RoleClaimsDto<string>> PrepareIdentityController(IServiceProvider serviceProvider)
         {
             // Arrange
-            var localizer = serviceProvider.GetRequiredService<IGenericControllerLocalizer<IdentityController<UserDto<string>, string, RoleDto<string>, string, string, string,
+            var localizer = serviceProvider.GetRequiredService<IGenericControllerLocalizer<IdentityController<UserDto<string>, string, RoleDto<string>, string,
                 UserIdentity, UserIdentityRole, string, UserIdentityUserClaim, UserIdentityUserRole,
                 UserIdentityUserLogin, UserIdentityRoleClaim, UserIdentityUserToken,
                 UsersDto<UserDto<string>, string>, RolesDto<RoleDto<string>, string>, UserRolesDto<RoleDto<string>, string, string>,
@@ -568,7 +568,7 @@ namespace Skoruba.IdentityServer4.Admin.UnitTests.Controllers
             var identityService = GetIdentityService(serviceProvider);
 
             //Get Controller
-            var controller = new IdentityController<UserDto<string>, string, RoleDto<string>, string, string, string,
+            var controller = new IdentityController<UserDto<string>, string, RoleDto<string>, string,
                 UserIdentity, UserIdentityRole, string, UserIdentityUserClaim, UserIdentityUserRole,
                 UserIdentityUserLogin, UserIdentityRoleClaim, UserIdentityUserToken,
                 UsersDto<UserDto<string>, string>, RolesDto<RoleDto<string>, string>, UserRolesDto<RoleDto<string>, string, string>,
@@ -615,7 +615,7 @@ namespace Skoruba.IdentityServer4.Admin.UnitTests.Controllers
 
             services.AddAdminServices<IdentityServerConfigurationDbContext, IdentityServerPersistedGrantDbContext, AdminLogDbContext>();
 
-            services.AddAdminAspNetIdentityServices<AdminIdentityDbContext, IdentityServerPersistedGrantDbContext,UserDto<string>, string, RoleDto<string>, string, string, string,
+            services.AddAdminAspNetIdentityServices<AdminIdentityDbContext, IdentityServerPersistedGrantDbContext,UserDto<string>, string, RoleDto<string>, string,
                 UserIdentity, UserIdentityRole, string, UserIdentityUserClaim, UserIdentityUserRole,
                 UserIdentityUserLogin, UserIdentityRoleClaim, UserIdentityUserToken,
                 UsersDto<UserDto<string>, string>, RolesDto<RoleDto<string>, string>, UserRolesDto<RoleDto<string>, string, string>,

--- a/tests/Skoruba.IdentityServer4.Admin.UnitTests/Mocks/IdentityDtoMock.cs
+++ b/tests/Skoruba.IdentityServer4.Admin.UnitTests/Mocks/IdentityDtoMock.cs
@@ -81,17 +81,17 @@ namespace Skoruba.IdentityServer4.Admin.UnitTests.Mocks
             return userClaim;
         }
 
-        public static Faker<UserRolesDto<TRoleDto, TKey, TKey>> GetUserRoleFaker<TRoleDto>(TKey id, TKey userId)
+        public static Faker<UserRolesDto<TRoleDto, TKey>> GetUserRoleFaker<TRoleDto>(TKey id, TKey userId)
             where TRoleDto : RoleDto<TKey>
         {
-            var userRoleFaker = new Faker<UserRolesDto<TRoleDto, TKey, TKey>>()
+            var userRoleFaker = new Faker<UserRolesDto<TRoleDto, TKey>>()
                 .RuleFor(o => o.RoleId, id)
                 .RuleFor(o => o.UserId, userId);
 
             return userRoleFaker;
         }
 
-        public static UserRolesDto<TRoleDto, TKey, TKey> GenerateRandomUserRole<TRoleDto>(TKey id, TKey userId)
+        public static UserRolesDto<TRoleDto, TKey> GenerateRandomUserRole<TRoleDto>(TKey id, TKey userId)
             where TRoleDto : RoleDto<TKey>
         {
             var userRole = GetUserRoleFaker<TRoleDto>(id, userId).Generate();

--- a/tests/Skoruba.IdentityServer4.Admin.UnitTests/Services/IdentityServiceTests.cs
+++ b/tests/Skoruba.IdentityServer4.Admin.UnitTests/Services/IdentityServiceTests.cs
@@ -53,31 +53,31 @@ namespace Skoruba.IdentityServer4.Admin.UnitTests.Services
                 UserIdentityUserToken>(dbContext, userManager, roleManager, mapper);
         }
 
-        private IIdentityService<UserDto<string>, string, RoleDto<string>, string, UserIdentity,
+        private IIdentityService<UserDto<string>, RoleDto<string>, UserIdentity,
             UserIdentityRole, string,
             UserIdentityUserClaim, UserIdentityUserRole, UserIdentityUserLogin, UserIdentityRoleClaim,
             UserIdentityUserToken,
-            UsersDto<UserDto<string>, string>, RolesDto<RoleDto<string>, string>, UserRolesDto<RoleDto<string>, string, string>,
+            UsersDto<UserDto<string>, string>, RolesDto<RoleDto<string>, string>, UserRolesDto<RoleDto<string>, string>,
             UserClaimsDto<string>, UserProviderDto<string>, UserProvidersDto<string>, UserChangePasswordDto<string>,
             RoleClaimsDto<string>> GetIdentityService(IIdentityRepository<UserIdentity, UserIdentityRole, string, UserIdentityUserClaim, UserIdentityUserRole, UserIdentityUserLogin, UserIdentityRoleClaim, UserIdentityUserToken> identityRepository,
             IIdentityServiceResources identityServiceResources,
             IMapper mapper, IAuditEventLogger auditEventLogger)
         {
-            return new IdentityService<UserDto<string>, string, RoleDto<string>, string, UserIdentity,
+            return new IdentityService<UserDto<string>, RoleDto<string>, UserIdentity,
                 UserIdentityRole, string,
                 UserIdentityUserClaim, UserIdentityUserRole, UserIdentityUserLogin, UserIdentityRoleClaim,
                 UserIdentityUserToken,
-                UsersDto<UserDto<string>, string>, RolesDto<RoleDto<string>, string>, UserRolesDto<RoleDto<string>, string, string>,
+                UsersDto<UserDto<string>, string>, RolesDto<RoleDto<string>, string>, UserRolesDto<RoleDto<string>, string>,
                 UserClaimsDto<string>, UserProviderDto<string>, UserProvidersDto<string>, UserChangePasswordDto<string>,
                 RoleClaimsDto<string>>(identityRepository, identityServiceResources, mapper, auditEventLogger);
         }
 
         private IMapper GetMapper()
         {
-            return new MapperConfiguration(cfg => cfg.AddProfile<IdentityMapperProfile<UserDto<string>, string, RoleDto<string>, string, UserIdentity, UserIdentityRole, string,
+            return new MapperConfiguration(cfg => cfg.AddProfile<IdentityMapperProfile<UserDto<string>, RoleDto<string>, UserIdentity, UserIdentityRole, string,
                         UserIdentityUserClaim, UserIdentityUserRole, UserIdentityUserLogin, UserIdentityRoleClaim,
                         UserIdentityUserToken,
-                        UsersDto<UserDto<string>, string>, RolesDto<RoleDto<string>, string>, UserRolesDto<RoleDto<string>, string, string>,
+                        UsersDto<UserDto<string>, string>, RolesDto<RoleDto<string>, string>, UserRolesDto<RoleDto<string>, string>,
                         UserClaimsDto<string>, UserProviderDto<string>, UserProvidersDto<string>,
                         RoleClaimsDto<string>, UserClaimDto<string>, RoleClaimDto<string>>
                 >())
@@ -98,12 +98,12 @@ namespace Skoruba.IdentityServer4.Admin.UnitTests.Services
             return testRoleManager;
         }
 
-        private IIdentityService<UserDto<string>, string, RoleDto<string>, string, UserIdentity,
+        private IIdentityService<UserDto<string>, RoleDto<string>, UserIdentity,
             UserIdentityRole, string,
             UserIdentityUserClaim, UserIdentityUserRole, UserIdentityUserLogin, UserIdentityRoleClaim,
             UserIdentityUserToken,
             UsersDto<UserDto<string>, string>, RolesDto<RoleDto<string>, string>,
-            UserRolesDto<RoleDto<string>, string, string>,
+            UserRolesDto<RoleDto<string>, string>,
             UserClaimsDto<string>, UserProviderDto<string>, UserProvidersDto<string>, UserChangePasswordDto<string>,
             RoleClaimsDto<string>> GetIdentityService(AdminIdentityDbContext context)
         {

--- a/tests/Skoruba.IdentityServer4.Admin.UnitTests/Services/IdentityServiceTests.cs
+++ b/tests/Skoruba.IdentityServer4.Admin.UnitTests/Services/IdentityServiceTests.cs
@@ -41,29 +41,29 @@ namespace Skoruba.IdentityServer4.Admin.UnitTests.Services
         private readonly ConfigurationStoreOptions _storeOptions;
         private readonly OperationalStoreOptions _operationalStore;
 
-        private IIdentityRepository<string, string, UserIdentity, UserIdentityRole, string,
+        private IIdentityRepository<UserIdentity, UserIdentityRole, string,
             UserIdentityUserClaim, UserIdentityUserRole, UserIdentityUserLogin, UserIdentityRoleClaim,
             UserIdentityUserToken> GetIdentityRepository(AdminIdentityDbContext dbContext,
             UserManager<UserIdentity> userManager,
             RoleManager<UserIdentityRole> roleManager,
             IMapper mapper)
         {
-            return new IdentityRepository<AdminIdentityDbContext, string, string, UserIdentity, UserIdentityRole, string,
+            return new IdentityRepository<AdminIdentityDbContext, UserIdentity, UserIdentityRole, string,
                 UserIdentityUserClaim, UserIdentityUserRole, UserIdentityUserLogin, UserIdentityRoleClaim,
                 UserIdentityUserToken>(dbContext, userManager, roleManager, mapper);
         }
 
-        private IIdentityService<UserDto<string>, string, RoleDto<string>, string, string, string, UserIdentity,
+        private IIdentityService<UserDto<string>, string, RoleDto<string>, string, UserIdentity,
             UserIdentityRole, string,
             UserIdentityUserClaim, UserIdentityUserRole, UserIdentityUserLogin, UserIdentityRoleClaim,
             UserIdentityUserToken,
             UsersDto<UserDto<string>, string>, RolesDto<RoleDto<string>, string>, UserRolesDto<RoleDto<string>, string, string>,
             UserClaimsDto<string>, UserProviderDto<string>, UserProvidersDto<string>, UserChangePasswordDto<string>,
-            RoleClaimsDto<string>> GetIdentityService(IIdentityRepository<string, string, UserIdentity, UserIdentityRole, string, UserIdentityUserClaim, UserIdentityUserRole, UserIdentityUserLogin, UserIdentityRoleClaim, UserIdentityUserToken> identityRepository,
+            RoleClaimsDto<string>> GetIdentityService(IIdentityRepository<UserIdentity, UserIdentityRole, string, UserIdentityUserClaim, UserIdentityUserRole, UserIdentityUserLogin, UserIdentityRoleClaim, UserIdentityUserToken> identityRepository,
             IIdentityServiceResources identityServiceResources,
             IMapper mapper, IAuditEventLogger auditEventLogger)
         {
-            return new IdentityService<UserDto<string>, string, RoleDto<string>, string, string, string, UserIdentity,
+            return new IdentityService<UserDto<string>, string, RoleDto<string>, string, UserIdentity,
                 UserIdentityRole, string,
                 UserIdentityUserClaim, UserIdentityUserRole, UserIdentityUserLogin, UserIdentityRoleClaim,
                 UserIdentityUserToken,
@@ -98,7 +98,7 @@ namespace Skoruba.IdentityServer4.Admin.UnitTests.Services
             return testRoleManager;
         }
 
-        private IIdentityService<UserDto<string>, string, RoleDto<string>, string, string, string, UserIdentity,
+        private IIdentityService<UserDto<string>, string, RoleDto<string>, string, UserIdentity,
             UserIdentityRole, string,
             UserIdentityUserClaim, UserIdentityUserRole, UserIdentityUserLogin, UserIdentityRoleClaim,
             UserIdentityUserToken,


### PR DESCRIPTION
Resolves #430.

Hi! Sorry for a long delay, I was very busy at work last 2 months.

What do you think about this way to make a configuration?

~Also I have one issue with making a zero-conf code.
In project `Skoruba.IdentityServer4.Admin.BusinessLogic.Identity` we don't have a reference to project `Skoruba.IdentityServer4.Admin.EntityFramework.Shared.DbContexts` where `AdminIdentityDbContext` and `IdentityServerPersistedGrantDbContext` present.~

~Also if I'll try to make everything except this two contexts are defaults like using `IdentityUser<TKey>` in [`AdminAspNetIdentityConfigurationBuilder<TKey>`](https://github.com/fatalistt/IdentityServer4.Admin/blob/features/admin-configuration-builder/src/Skoruba.IdentityServer4.Admin.BusinessLogic.Identity/Extensions/AdminServicesExtensions.cs) and specify only a contexts, I've another problem: I can't use `AdminIdentityDbContext` with `IdentityUser<TKey>`.~