### PR TITLE
check for existence or role and claim before doing operation

### DIFF
--- a/src/Skoruba.IdentityServer4.Admin.Api/Controllers/UsersController.cs
+++ b/src/Skoruba.IdentityServer4.Admin.Api/Controllers/UsersController.cs
@@ -188,8 +188,6 @@ namespace Skoruba.IdentityServer4.Admin.Api.Controllers
                 return BadRequest(_errorResources.CannotSetId());
             }
 
-            await _identityService.GetUserClaimAsync(userClaimDto.UserId.ToString(), userClaimDto.ClaimId);
-
             await _identityService.CreateUserClaimsAsync(userClaimDto);
 
             return Ok();

--- a/src/Skoruba.IdentityServer4.Admin.Api/Controllers/UsersController.cs
+++ b/src/Skoruba.IdentityServer4.Admin.Api/Controllers/UsersController.cs
@@ -147,6 +147,9 @@ namespace Skoruba.IdentityServer4.Admin.Api.Controllers
         {
             var userRolesDto = _mapper.Map<TUserRolesDto>(role);
 
+            await _identityService.GetUserAsync(userRolesDto.UserId.ToString());
+            await _identityService.GetRoleAsync(userRolesDto.RoleId.ToString());
+            
             await _identityService.CreateUserRoleAsync(userRolesDto);
 
             return Ok();
@@ -184,6 +187,8 @@ namespace Skoruba.IdentityServer4.Admin.Api.Controllers
             {
                 return BadRequest(_errorResources.CannotSetId());
             }
+
+            await _identityService.GetUserClaimAsync(userClaimDto.UserId.ToString(), userClaimDto.ClaimId);
 
             await _identityService.CreateUserClaimsAsync(userClaimDto);
 


### PR DESCRIPTION
Hi @skoruba,

currently when you try to PostUserClaims or PostUserRoles with non existent roleId, claimId api would break with NullReferenceExcpetion and return 500.

I just added missing check so now it returns ProblemDetails and there is no exception.

Thank you