### PR TITLE
Fix CORS issue when not launching with iis

### DIFF
--- a/src/Skoruba.IdentityServer4.Admin.Api/Properties/launchSettings.json
+++ b/src/Skoruba.IdentityServer4.Admin.Api/Properties/launchSettings.json
@@ -24,7 +24,7 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
-      "applicationUrl": "http://localhost:5002"
+      "applicationUrl": "http://localhost:5001"
     },
     "Docker": {
       "commandName": "Docker",


### PR DESCRIPTION
When using Skoruba.IdentityServer4.Admin.Api launch setting, you will get the error as below.
```
Fetch errorFailed to fetch http://localhost:5001/swagger/v1/swagger.json
Fetch errorPossible cross-origin (CORS) issue? The URL origin (http://localhost:5001) does not match the page (http://localhost:5002). Check the server returns the correct 'Access-Control-Allow-*' headers.
```