### PR TITLE
move port and environment config to override.yml

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -5,14 +5,15 @@ services:
     environment:
       - ASPNETCORE_ENVIRONMENT=Development
     ports:
-      - "80"
+      - 9000:80
     volumes:
       - ${APPDATA}/Microsoft/UserSecrets:/root/.microsoft/usersecrets:ro
+  
   skoruba.identityserver4.admin.api:
     environment:
       - ASPNETCORE_ENVIRONMENT=Development
     ports:
-      - "80"
+      - 5000:80
     volumes:
       - ${APPDATA}/Microsoft/UserSecrets:/root/.microsoft/usersecrets:ro
 
@@ -20,6 +21,6 @@ services:
     environment:
       - ASPNETCORE_ENVIRONMENT=Development
     ports:
-      - "80"
+      - 80:80
     volumes:
       - ${APPDATA}/Microsoft/UserSecrets:/root/.microsoft/usersecrets:ro

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,14 +3,11 @@ version: '3.4'
 services:
   skoruba.identityserver4.admin:
     image: ${DOCKER_REGISTRY-}skoruba-identityserver4-admin
-    ports:
-      - 9000:80
     build:
       context: .
       dockerfile: src/Skoruba.IdentityServer4.Admin/Dockerfile
     container_name: skoruba-identityserver4-admin
     environment:
-      - ASPNETCORE_ENVIRONMENT=Development
       - "ConnectionStrings__ConfigurationDbConnection=Server=db;Database=IdentityServer4Admin;User Id=sa;Password=${DB_PASSWORD:-Password_123};MultipleActiveResultSets=true"
       - "ConnectionStrings__PersistedGrantDbConnection=Server=db;Database=IdentityServer4Admin;User Id=sa;Password=${DB_PASSWORD:-Password_123};MultipleActiveResultSets=true"
       - "ConnectionStrings__IdentityDbConnection=Server=db;Database=IdentityServer4Admin;User Id=sa;Password=${DB_PASSWORD:-Password_123};MultipleActiveResultSets=true"
@@ -41,8 +38,6 @@ services:
     build:
       context: .
       dockerfile: src/Skoruba.IdentityServer4.Admin.Api/Dockerfile
-    ports:
-      - 5000:80
     environment:
       - "AdminApiConfiguration__RequireHttpsMetadata=false"
       - "AdminApiConfiguration__ApiBaseUrl=http://127.0.0.1.xip.io:5000"
@@ -58,14 +53,11 @@ services:
 
   skoruba.identityserver4.sts.identity:
     image: ${DOCKER_REGISTRY-}skoruba-identityserver4-sts-identity
-    ports:
-      - 80:80
     build:
       context: .
       dockerfile: src/Skoruba.IdentityServer4.STS.Identity/Dockerfile
     container_name: skoruba-identityserver4-sts-identity
     environment:
-      - ASPNETCORE_ENVIRONMENT=Development
       - "ConnectionStrings__ConfigurationDbConnection=Server=db;Database=IdentityServer4Admin;User Id=sa;Password=${DB_PASSWORD:-Password_123};MultipleActiveResultSets=true"
       - "ConnectionStrings__PersistedGrantDbConnection=Server=db;Database=IdentityServer4Admin;User Id=sa;Password=${DB_PASSWORD:-Password_123};MultipleActiveResultSets=true"
       - "ConnectionStrings__IdentityDbConnection=Server=db;Database=IdentityServer4Admin;User Id=sa;Password=${DB_PASSWORD:-Password_123};MultipleActiveResultSets=true"


### PR DESCRIPTION
Hi @skoruba ,

I have made small changes to docker-compose.yml and docker-compose.override.yml.
Currenty, they were incorrectly used. 

docker-compose.yml should define services but for example not ports nor some of environment variables.

Ports should be moved into .override.yml for development purposes, and another, new file for production or staging.

Great and simple example is on [Docker compose](https://docs.docker.com/compose/extends/) and it deals with this exact situation: define services, and in overrides ports and envirnoment(development, production)

Anyway, this PR will not change how docker containers behave, it's just done in a slightly better way.

Thank you


