### PR TITLE
#514 PostgreSQL health check failure

### DIFF
--- a/src/Skoruba.IdentityServer4.Admin.Api/Helpers/StartupHelpers.cs
+++ b/src/Skoruba.IdentityServer4.Admin.Api/Helpers/StartupHelpers.cs
@@ -299,15 +299,15 @@ namespace Skoruba.IdentityServer4.Admin.Api.Helpers
                     case DatabaseProviderType.PostgreSQL:
                         healthChecksBuilder
                             .AddNpgSql(configurationDbConnectionString, name: "ConfigurationDb",
-                                healthQuery: $"SELECT * FROM {configurationTableName} LIMIT 1")
+                                healthQuery: $"SELECT * FROM \"{configurationTableName}\" LIMIT 1")
                             .AddNpgSql(persistedGrantsDbConnectionString, name: "PersistentGrantsDb",
-                                healthQuery: $"SELECT * FROM {persistedGrantTableName} LIMIT 1")
+                                healthQuery: $"SELECT * FROM \"{persistedGrantTableName}\" LIMIT 1")
                             .AddNpgSql(identityDbConnectionString, name: "IdentityDb",
-                                healthQuery: $"SELECT * FROM {identityTableName} LIMIT 1")
+                                healthQuery: $"SELECT * FROM \"{identityTableName}\" LIMIT 1")
                             .AddNpgSql(logDbConnectionString, name: "LogDb",
-                                healthQuery: $"SELECT * FROM {logTableName} LIMIT 1")
+                                healthQuery: $"SELECT * FROM \"{logTableName}\" LIMIT 1")
                             .AddNpgSql(auditLogDbConnectionString, name: "AuditLogDb",
-                                healthQuery: $"SELECT * FROM {auditLogTableName}  LIMIT 1");
+                                healthQuery: $"SELECT * FROM \"{auditLogTableName}\"  LIMIT 1");
                         break;
                     case DatabaseProviderType.MySql:
                         healthChecksBuilder

--- a/src/Skoruba.IdentityServer4.Admin/Helpers/StartupHelpers.cs
+++ b/src/Skoruba.IdentityServer4.Admin/Helpers/StartupHelpers.cs
@@ -470,15 +470,15 @@ namespace Skoruba.IdentityServer4.Admin.Helpers
                     case DatabaseProviderType.PostgreSQL:
                         healthChecksBuilder
                             .AddNpgSql(configurationDbConnectionString, name: "ConfigurationDb",
-                                healthQuery: $"SELECT * FROM {configurationTableName} LIMIT 1")
+                                healthQuery: $"SELECT * FROM \"{configurationTableName}\" LIMIT 1")
                             .AddNpgSql(persistedGrantsDbConnectionString, name: "PersistentGrantsDb",
-                                healthQuery: $"SELECT * FROM {persistedGrantTableName} LIMIT 1")
+                                healthQuery: $"SELECT * FROM \"{persistedGrantTableName}\" LIMIT 1")
                             .AddNpgSql(identityDbConnectionString, name: "IdentityDb",
-                                healthQuery: $"SELECT * FROM {identityTableName} LIMIT 1")
+                                healthQuery: $"SELECT * FROM \"{identityTableName}\" LIMIT 1")
                             .AddNpgSql(logDbConnectionString, name: "LogDb",
-                                healthQuery: $"SELECT * FROM {logTableName} LIMIT 1")
+                                healthQuery: $"SELECT * FROM \"{logTableName}\" LIMIT 1")
                             .AddNpgSql(auditLogDbConnectionString, name: "AuditLogDb",
-                                healthQuery: $"SELECT * FROM {auditLogTableName}  LIMIT 1");
+                                healthQuery: $"SELECT * FROM \"{auditLogTableName}\"  LIMIT 1");
                         break;
                     case DatabaseProviderType.MySql:
                         healthChecksBuilder

--- a/src/Skoruba.IdentityServer4.STS.Identity/Helpers/StartupHelpers.cs
+++ b/src/Skoruba.IdentityServer4.STS.Identity/Helpers/StartupHelpers.cs
@@ -383,11 +383,11 @@ namespace Skoruba.IdentityServer4.STS.Identity.Helpers
                     case DatabaseProviderType.PostgreSQL:
                         healthChecksBuilder
                             .AddNpgSql(configurationDbConnectionString, name: "ConfigurationDb",
-                                healthQuery: $"SELECT * FROM {configurationTableName} LIMIT 1")
+                                healthQuery: $"SELECT * FROM \"{configurationTableName}\" LIMIT 1")
                             .AddNpgSql(persistedGrantsDbConnectionString, name: "PersistentGrantsDb",
-                                healthQuery: $"SELECT * FROM {persistedGrantTableName} LIMIT 1")
+                                healthQuery: $"SELECT * FROM \"{persistedGrantTableName}\" LIMIT 1")
                             .AddNpgSql(identityDbConnectionString, name: "IdentityDb",
-                                healthQuery: $"SELECT * FROM {identityTableName} LIMIT 1");
+                                healthQuery: $"SELECT * FROM \"{identityTableName}\" LIMIT 1");
                         break;
                     case DatabaseProviderType.MySql:
                         healthChecksBuilder


### PR DESCRIPTION
Fixed PostgreSQL health checks by wrapping table names in health checks with `"`.