### PR TITLE
Add ResourcePath config to Admin.Api

### DIFF
--- a/src/Skoruba.IdentityServer4.Admin.Api/Configuration/Constants/ConfigurationConsts.cs
+++ b/src/Skoruba.IdentityServer4.Admin.Api/Configuration/Constants/ConfigurationConsts.cs
@@ -11,5 +11,7 @@
         public const string AdminLogDbConnectionStringKey = "AdminLogDbConnection";
 
         public const string AdminAuditLogDbConnectionStringKey = "AdminAuditLogDbConnection";
+        
+        public const string ResourcesPath = "Resources";
     }
 }

--- a/src/Skoruba.IdentityServer4.Admin.Api/Helpers/StartupHelpers.cs
+++ b/src/Skoruba.IdentityServer4.Admin.Api/Helpers/StartupHelpers.cs
@@ -104,6 +104,8 @@ namespace Skoruba.IdentityServer4.Admin.Api.Helpers
             where TUserChangePasswordDto : UserChangePasswordDto<TUserDtoKey>
             where TRoleClaimsDto : RoleClaimsDto<TRoleDtoKey>
         {
+            services.AddLocalization(opts => { opts.ResourcesPath = ConfigurationConsts.ResourcesPath; });
+
             services.TryAddTransient(typeof(IGenericControllerLocalizer<>), typeof(GenericControllerLocalizer<>));
 
             services.AddControllersWithViews(o => { o.Conventions.Add(new GenericControllerRouteConvention()); })


### PR DESCRIPTION
As Admin and STS projects use Resources from Resources folder Api project should use that too.
IGenericControllerLocalizer is already in use but fails bcs config is missing.

This PR fixes that.

Thank you