### PR TITLE
return `UserName` from external login provider

### DIFF
--- a/src/Skoruba.IdentityServer4.STS.Identity/Controllers/AccountController.cs
+++ b/src/Skoruba.IdentityServer4.STS.Identity/Controllers/AccountController.cs
@@ -372,8 +372,9 @@ namespace Skoruba.IdentityServer4.STS.Identity.Controllers
             ViewData["ReturnUrl"] = returnUrl;
             ViewData["LoginProvider"] = info.LoginProvider;
             var email = info.Principal.FindFirstValue(ClaimTypes.Email);
+            var userName = info.Principal.Identity.Name;
 
-            return View("ExternalLoginConfirmation", new ExternalLoginConfirmationViewModel { Email = email });
+            return View("ExternalLoginConfirmation", new ExternalLoginConfirmationViewModel { Email = email, UserName = userName });
         }
 
         [HttpPost]


### PR DESCRIPTION
return `UserName` from external login provider so that user could create account without refill 
the `UserName` field