### PR TITLE
Improved suggested claims.

### DIFF
--- a/src/Skoruba.IdentityServer4.Admin.BusinessLogic/Services/ClientService.cs
+++ b/src/Skoruba.IdentityServer4.Admin.BusinessLogic/Services/ClientService.cs
@@ -304,9 +304,9 @@ namespace Skoruba.IdentityServer4.Admin.BusinessLogic.Services
             return protocolTypes;
         }
 
-        public virtual List<string> GetStandardClaims(string claim, int limit = 0)
+        public virtual async Task<List<string>> GetStandardClaimsAsync(string claim, int limit = 0)
         {
-            var standardClaims = ClientRepository.GetStandardClaims(claim, limit);
+            var standardClaims = await ClientRepository.GetStandardClaimsAsync(claim, limit);
 
             return standardClaims;
         }

--- a/src/Skoruba.IdentityServer4.Admin.BusinessLogic/Services/ClientService.cs
+++ b/src/Skoruba.IdentityServer4.Admin.BusinessLogic/Services/ClientService.cs
@@ -13,6 +13,7 @@ using Skoruba.IdentityServer4.Admin.BusinessLogic.Resources;
 using Skoruba.IdentityServer4.Admin.BusinessLogic.Services.Interfaces;
 using Skoruba.IdentityServer4.Admin.BusinessLogic.Shared.Dtos.Common;
 using Skoruba.IdentityServer4.Admin.BusinessLogic.Shared.ExceptionHandling;
+using Skoruba.IdentityServer4.Admin.EntityFramework.Entities;
 using Skoruba.IdentityServer4.Admin.EntityFramework.Helpers;
 using Skoruba.IdentityServer4.Admin.EntityFramework.Repositories.Interfaces;
 
@@ -304,7 +305,7 @@ namespace Skoruba.IdentityServer4.Admin.BusinessLogic.Services
             return protocolTypes;
         }
 
-        public virtual async Task<List<string>> GetStandardClaimsAsync(string claim, int limit = 0)
+        public virtual async Task<List<string>> GetStandardClaimsAsync(string claim, int limit = 0, bool sortAscending = true, string sortBy = nameof(StandardClaim.ClaimType))
         {
             var standardClaims = await ClientRepository.GetStandardClaimsAsync(claim, limit);
 

--- a/src/Skoruba.IdentityServer4.Admin.BusinessLogic/Services/Interfaces/IClientService.cs
+++ b/src/Skoruba.IdentityServer4.Admin.BusinessLogic/Services/Interfaces/IClientService.cs
@@ -41,7 +41,7 @@ namespace Skoruba.IdentityServer4.Admin.BusinessLogic.Services.Interfaces
 
         List<SelectItemDto> GetSecretTypes();
 
-        List<string> GetStandardClaims(string claim, int limit = 0);
+        Task<List<string>> GetStandardClaimsAsync(string claim, int limit = 0);
 
         Task<int> AddClientSecretAsync(ClientSecretsDto clientSecret);
 

--- a/src/Skoruba.IdentityServer4.Admin.BusinessLogic/Services/Interfaces/IClientService.cs
+++ b/src/Skoruba.IdentityServer4.Admin.BusinessLogic/Services/Interfaces/IClientService.cs
@@ -2,6 +2,7 @@
 using System.Threading.Tasks;
 using Skoruba.IdentityServer4.Admin.BusinessLogic.Dtos.Configuration;
 using Skoruba.IdentityServer4.Admin.BusinessLogic.Shared.Dtos.Common;
+using Skoruba.IdentityServer4.Admin.EntityFramework.Entities;
 
 namespace Skoruba.IdentityServer4.Admin.BusinessLogic.Services.Interfaces
 {
@@ -41,7 +42,7 @@ namespace Skoruba.IdentityServer4.Admin.BusinessLogic.Services.Interfaces
 
         List<SelectItemDto> GetSecretTypes();
 
-        Task<List<string>> GetStandardClaimsAsync(string claim, int limit = 0);
+        Task<List<string>> GetStandardClaimsAsync(string claim, int limit = 0, bool sortAscending = true, string sortBy = nameof(StandardClaim.ClaimType));
 
         Task<int> AddClientSecretAsync(ClientSecretsDto clientSecret);
 

--- a/src/Skoruba.IdentityServer4.Admin.EntityFramework.MySql/Migrations/IdentityServerConfiguration/20191120085701_DbInit.cs
+++ b/src/Skoruba.IdentityServer4.Admin.EntityFramework.MySql/Migrations/IdentityServerConfiguration/20191120085701_DbInit.cs
@@ -440,6 +440,21 @@ namespace Skoruba.IdentityServer4.Admin.EntityFramework.MySql.Migrations.Identit
                         onDelete: ReferentialAction.Cascade);
                 });
 
+            migrationBuilder.CreateTable(
+                name: "StandardClaims",
+                columns: table => new
+                {
+                    Id = table.Column<int>(nullable: false)
+                        .Annotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn),
+                    ClaimType = table.Column<string>(maxLength: 200, nullable: false),
+                    LastUsedTimestamp = table.Column<DateTimeOffset>(nullable: true),
+                    UseCount = table.Column<long>(nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_StandardClaims", x => x.Id);
+                });
+
             migrationBuilder.CreateIndex(
                 name: "IX_ApiClaims_ApiResourceId",
                 table: "ApiClaims",
@@ -543,6 +558,12 @@ namespace Skoruba.IdentityServer4.Admin.EntityFramework.MySql.Migrations.Identit
                 table: "IdentityResources",
                 column: "Name",
                 unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_StandardClaims_ClaimType",
+                table: "StandardClaims",
+                column: "ClaimType",
+                unique: true);
         }
 
         protected override void Down(MigrationBuilder migrationBuilder)
@@ -603,6 +624,9 @@ namespace Skoruba.IdentityServer4.Admin.EntityFramework.MySql.Migrations.Identit
 
             migrationBuilder.DropTable(
                 name: "ApiResources");
+
+            migrationBuilder.DropTable(
+                name: "StandardClaims");
         }
     }
 }

--- a/src/Skoruba.IdentityServer4.Admin.EntityFramework.MySql/Migrations/IdentityServerConfiguration/20191120085701_DbInit.cs
+++ b/src/Skoruba.IdentityServer4.Admin.EntityFramework.MySql/Migrations/IdentityServerConfiguration/20191120085701_DbInit.cs
@@ -440,21 +440,6 @@ namespace Skoruba.IdentityServer4.Admin.EntityFramework.MySql.Migrations.Identit
                         onDelete: ReferentialAction.Cascade);
                 });
 
-            migrationBuilder.CreateTable(
-                name: "StandardClaims",
-                columns: table => new
-                {
-                    Id = table.Column<int>(nullable: false)
-                        .Annotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn),
-                    ClaimType = table.Column<string>(maxLength: 200, nullable: false),
-                    LastUsedTimestamp = table.Column<DateTimeOffset>(nullable: true),
-                    UseCount = table.Column<long>(nullable: false)
-                },
-                constraints: table =>
-                {
-                    table.PrimaryKey("PK_StandardClaims", x => x.Id);
-                });
-
             migrationBuilder.CreateIndex(
                 name: "IX_ApiClaims_ApiResourceId",
                 table: "ApiClaims",
@@ -558,12 +543,6 @@ namespace Skoruba.IdentityServer4.Admin.EntityFramework.MySql.Migrations.Identit
                 table: "IdentityResources",
                 column: "Name",
                 unique: true);
-
-            migrationBuilder.CreateIndex(
-                name: "IX_StandardClaims_ClaimType",
-                table: "StandardClaims",
-                column: "ClaimType",
-                unique: true);
         }
 
         protected override void Down(MigrationBuilder migrationBuilder)
@@ -624,9 +603,6 @@ namespace Skoruba.IdentityServer4.Admin.EntityFramework.MySql.Migrations.Identit
 
             migrationBuilder.DropTable(
                 name: "ApiResources");
-
-            migrationBuilder.DropTable(
-                name: "StandardClaims");
         }
     }
 }

--- a/src/Skoruba.IdentityServer4.Admin.EntityFramework.MySql/Migrations/IdentityServerConfiguration/20200420043337_StandardClaims.Designer.cs
+++ b/src/Skoruba.IdentityServer4.Admin.EntityFramework.MySql/Migrations/IdentityServerConfiguration/20200420043337_StandardClaims.Designer.cs
@@ -2,15 +2,17 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Skoruba.IdentityServer4.Admin.EntityFramework.Shared.DbContexts;
 
 namespace Skoruba.IdentityServer4.Admin.EntityFramework.MySql.Migrations.IdentityServerConfiguration
 {
     [DbContext(typeof(IdentityServerConfigurationDbContext))]
-    partial class IdentityServerConfigurationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20200420043337_StandardClaims")]
+    partial class StandardClaims
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Skoruba.IdentityServer4.Admin.EntityFramework.MySql/Migrations/IdentityServerConfiguration/20200420043337_StandardClaims.cs
+++ b/src/Skoruba.IdentityServer4.Admin.EntityFramework.MySql/Migrations/IdentityServerConfiguration/20200420043337_StandardClaims.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Skoruba.IdentityServer4.Admin.EntityFramework.MySql.Migrations.IdentityServerConfiguration
+{
+    public partial class StandardClaims : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "StandardClaims",
+                columns: table => new
+                {
+                    Id = table.Column<int>(nullable: false)
+                        .Annotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn),
+                    ClaimType = table.Column<string>(nullable: false),
+                    LastUsedTimestamp = table.Column<DateTimeOffset>(nullable: true),
+                    UseCount = table.Column<long>(nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_StandardClaims", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_StandardClaims_ClaimType",
+                table: "StandardClaims",
+                column: "ClaimType",
+                unique: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "StandardClaims");
+        }
+    }
+}

--- a/src/Skoruba.IdentityServer4.Admin.EntityFramework.PostgreSQL/Migrations/IdentityServerConfiguration/20191120100129_DbInit.cs
+++ b/src/Skoruba.IdentityServer4.Admin.EntityFramework.PostgreSQL/Migrations/IdentityServerConfiguration/20191120100129_DbInit.cs
@@ -440,6 +440,21 @@ namespace Skoruba.IdentityServer4.Admin.EntityFramework.PostgreSQL.Migrations.Id
                         onDelete: ReferentialAction.Cascade);
                 });
 
+            migrationBuilder.CreateTable(
+                name: "StandardClaims",
+                columns: table => new
+                {
+                    Id = table.Column<int>(nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    ClaimType = table.Column<string>(maxLength: 200, nullable: false),
+                    LastUsedTimestamp = table.Column<DateTimeOffset>(nullable: true),
+                    UseCount = table.Column<long>(nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_StandardClaims", x => x.Id);
+                });
+
             migrationBuilder.CreateIndex(
                 name: "IX_ApiClaims_ApiResourceId",
                 table: "ApiClaims",
@@ -543,6 +558,12 @@ namespace Skoruba.IdentityServer4.Admin.EntityFramework.PostgreSQL.Migrations.Id
                 table: "IdentityResources",
                 column: "Name",
                 unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_StandardClaims_ClaimType",
+                table: "StandardClaims",
+                column: "ClaimType",
+                unique: true);
         }
 
         protected override void Down(MigrationBuilder migrationBuilder)
@@ -603,6 +624,9 @@ namespace Skoruba.IdentityServer4.Admin.EntityFramework.PostgreSQL.Migrations.Id
 
             migrationBuilder.DropTable(
                 name: "ApiResources");
+
+            migrationBuilder.DropTable(
+                name: "StandardClaims");
         }
     }
 }

--- a/src/Skoruba.IdentityServer4.Admin.EntityFramework.PostgreSQL/Migrations/IdentityServerConfiguration/20191120100129_DbInit.cs
+++ b/src/Skoruba.IdentityServer4.Admin.EntityFramework.PostgreSQL/Migrations/IdentityServerConfiguration/20191120100129_DbInit.cs
@@ -440,21 +440,6 @@ namespace Skoruba.IdentityServer4.Admin.EntityFramework.PostgreSQL.Migrations.Id
                         onDelete: ReferentialAction.Cascade);
                 });
 
-            migrationBuilder.CreateTable(
-                name: "StandardClaims",
-                columns: table => new
-                {
-                    Id = table.Column<int>(nullable: false)
-                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
-                    ClaimType = table.Column<string>(maxLength: 200, nullable: false),
-                    LastUsedTimestamp = table.Column<DateTimeOffset>(nullable: true),
-                    UseCount = table.Column<long>(nullable: false)
-                },
-                constraints: table =>
-                {
-                    table.PrimaryKey("PK_StandardClaims", x => x.Id);
-                });
-
             migrationBuilder.CreateIndex(
                 name: "IX_ApiClaims_ApiResourceId",
                 table: "ApiClaims",
@@ -558,12 +543,6 @@ namespace Skoruba.IdentityServer4.Admin.EntityFramework.PostgreSQL.Migrations.Id
                 table: "IdentityResources",
                 column: "Name",
                 unique: true);
-
-            migrationBuilder.CreateIndex(
-                name: "IX_StandardClaims_ClaimType",
-                table: "StandardClaims",
-                column: "ClaimType",
-                unique: true);
         }
 
         protected override void Down(MigrationBuilder migrationBuilder)
@@ -624,9 +603,6 @@ namespace Skoruba.IdentityServer4.Admin.EntityFramework.PostgreSQL.Migrations.Id
 
             migrationBuilder.DropTable(
                 name: "ApiResources");
-
-            migrationBuilder.DropTable(
-                name: "StandardClaims");
         }
     }
 }

--- a/src/Skoruba.IdentityServer4.Admin.EntityFramework.PostgreSQL/Migrations/IdentityServerConfiguration/20200420033718_StandardClaims.Designer.cs
+++ b/src/Skoruba.IdentityServer4.Admin.EntityFramework.PostgreSQL/Migrations/IdentityServerConfiguration/20200420033718_StandardClaims.Designer.cs
@@ -10,8 +10,8 @@ using Skoruba.IdentityServer4.Admin.EntityFramework.Shared.DbContexts;
 namespace Skoruba.IdentityServer4.Admin.EntityFramework.PostgreSQL.Migrations.IdentityServerConfiguration
 {
     [DbContext(typeof(IdentityServerConfigurationDbContext))]
-    [Migration("20200420033718_StandardScopes")]
-    partial class StandardScopes
+    [Migration("20200420033718_StandardClaims")]
+    partial class StandardClaims
     {
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {

--- a/src/Skoruba.IdentityServer4.Admin.EntityFramework.PostgreSQL/Migrations/IdentityServerConfiguration/20200420033718_StandardClaims.cs
+++ b/src/Skoruba.IdentityServer4.Admin.EntityFramework.PostgreSQL/Migrations/IdentityServerConfiguration/20200420033718_StandardClaims.cs
@@ -4,7 +4,7 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 namespace Skoruba.IdentityServer4.Admin.EntityFramework.PostgreSQL.Migrations.IdentityServerConfiguration
 {
-    public partial class StandardScopes : Migration
+    public partial class StandardClaims : Migration
     {
         protected override void Up(MigrationBuilder migrationBuilder)
         {
@@ -14,7 +14,7 @@ namespace Skoruba.IdentityServer4.Admin.EntityFramework.PostgreSQL.Migrations.Id
                 {
                     Id = table.Column<int>(nullable: false)
                         .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
-                    ClaimType = table.Column<string>(nullable: true),
+                    ClaimType = table.Column<string>(nullable: false),
                     LastUsedTimestamp = table.Column<DateTimeOffset>(nullable: true),
                     UseCount = table.Column<long>(nullable: false)
                 },

--- a/src/Skoruba.IdentityServer4.Admin.EntityFramework.PostgreSQL/Migrations/IdentityServerConfiguration/20200420033718_StandardScopes.Designer.cs
+++ b/src/Skoruba.IdentityServer4.Admin.EntityFramework.PostgreSQL/Migrations/IdentityServerConfiguration/20200420033718_StandardScopes.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Skoruba.IdentityServer4.Admin.EntityFramework.Shared.DbContexts;
@@ -9,9 +10,10 @@ using Skoruba.IdentityServer4.Admin.EntityFramework.Shared.DbContexts;
 namespace Skoruba.IdentityServer4.Admin.EntityFramework.PostgreSQL.Migrations.IdentityServerConfiguration
 {
     [DbContext(typeof(IdentityServerConfigurationDbContext))]
-    partial class IdentityServerConfigurationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20200420033718_StandardScopes")]
+    partial class StandardScopes
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Skoruba.IdentityServer4.Admin.EntityFramework.PostgreSQL/Migrations/IdentityServerConfiguration/20200420033718_StandardScopes.cs
+++ b/src/Skoruba.IdentityServer4.Admin.EntityFramework.PostgreSQL/Migrations/IdentityServerConfiguration/20200420033718_StandardScopes.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+namespace Skoruba.IdentityServer4.Admin.EntityFramework.PostgreSQL.Migrations.IdentityServerConfiguration
+{
+    public partial class StandardScopes : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "StandardClaims",
+                columns: table => new
+                {
+                    Id = table.Column<int>(nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    ClaimType = table.Column<string>(nullable: true),
+                    LastUsedTimestamp = table.Column<DateTimeOffset>(nullable: true),
+                    UseCount = table.Column<long>(nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_StandardClaims", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_StandardClaims_ClaimType",
+                table: "StandardClaims",
+                column: "ClaimType",
+                unique: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "StandardClaims");
+        }
+    }
+}

--- a/src/Skoruba.IdentityServer4.Admin.EntityFramework.Shared/Constants/TableConsts.cs
+++ b/src/Skoruba.IdentityServer4.Admin.EntityFramework.Shared/Constants/TableConsts.cs
@@ -9,5 +9,6 @@
         public const string IdentityUserLogins = "UserLogins";
         public const string IdentityUserClaims = "UserClaims";
         public const string IdentityUserTokens = "UserTokens";
+        public const string StandardClaims = "StandardClaims";
     }
 }

--- a/src/Skoruba.IdentityServer4.Admin.EntityFramework.Shared/DbContexts/IdentityServerConfigurationDbContext.cs
+++ b/src/Skoruba.IdentityServer4.Admin.EntityFramework.Shared/DbContexts/IdentityServerConfigurationDbContext.cs
@@ -4,6 +4,7 @@ using IdentityServer4.EntityFramework.Options;
 using Microsoft.EntityFrameworkCore;
 using Skoruba.IdentityServer4.Admin.EntityFramework.Entities;
 using Skoruba.IdentityServer4.Admin.EntityFramework.Interfaces;
+using Skoruba.IdentityServer4.Admin.EntityFramework.Shared.Constants;
 
 namespace Skoruba.IdentityServer4.Admin.EntityFramework.Shared.DbContexts
 {
@@ -47,5 +48,18 @@ namespace Skoruba.IdentityServer4.Admin.EntityFramework.Shared.DbContexts
         public DbSet<ClientProperty> ClientProperties { get; set; }
 
         public DbSet<StandardClaim> StandardClaims { get; set; }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+
+            modelBuilder.Entity<StandardClaim>(entityBuilder =>
+            {
+                entityBuilder.ToTable(TableConsts.StandardClaims);
+                entityBuilder.Property(e => e.Id).ValueGeneratedOnAdd();
+                entityBuilder.HasKey(e => e.Id);
+                entityBuilder.HasIndex(e => e.ClaimType).IsUnique();
+            });
+        }
     }
 }

--- a/src/Skoruba.IdentityServer4.Admin.EntityFramework.Shared/DbContexts/IdentityServerConfigurationDbContext.cs
+++ b/src/Skoruba.IdentityServer4.Admin.EntityFramework.Shared/DbContexts/IdentityServerConfigurationDbContext.cs
@@ -2,6 +2,7 @@
 using IdentityServer4.EntityFramework.Entities;
 using IdentityServer4.EntityFramework.Options;
 using Microsoft.EntityFrameworkCore;
+using Skoruba.IdentityServer4.Admin.EntityFramework.Entities;
 using Skoruba.IdentityServer4.Admin.EntityFramework.Interfaces;
 
 namespace Skoruba.IdentityServer4.Admin.EntityFramework.Shared.DbContexts
@@ -44,5 +45,7 @@ namespace Skoruba.IdentityServer4.Admin.EntityFramework.Shared.DbContexts
         public DbSet<ClientClaim> ClientClaims { get; set; }
 
         public DbSet<ClientProperty> ClientProperties { get; set; }
+
+        public DbSet<StandardClaim> StandardClaims { get; set; }
     }
 }

--- a/src/Skoruba.IdentityServer4.Admin.EntityFramework.SqlServer/Migrations/IdentityServerConfiguration/20191119163952_DbInit.cs
+++ b/src/Skoruba.IdentityServer4.Admin.EntityFramework.SqlServer/Migrations/IdentityServerConfiguration/20191119163952_DbInit.cs
@@ -439,6 +439,21 @@ namespace Skoruba.IdentityServer4.Admin.EntityFramework.SqlServer.Migrations.Ide
                         onDelete: ReferentialAction.Cascade);
                 });
 
+            migrationBuilder.CreateTable(
+                name: "StandardClaims",
+                columns: table => new
+                {
+                    Id = table.Column<int>(nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    ClaimType = table.Column<string>(maxLength: 200, nullable: false),
+                    LastUsedTimestamp = table.Column<DateTimeOffset>(nullable: true),
+                    UseCount = table.Column<long>(nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_StandardClaims", x => x.Id);
+                });
+
             migrationBuilder.CreateIndex(
                 name: "IX_ApiClaims_ApiResourceId",
                 table: "ApiClaims",
@@ -542,6 +557,12 @@ namespace Skoruba.IdentityServer4.Admin.EntityFramework.SqlServer.Migrations.Ide
                 table: "IdentityResources",
                 column: "Name",
                 unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_StandardClaims_ClaimType",
+                table: "StandardClaims",
+                column: "ClaimType",
+                unique: true);
         }
 
         protected override void Down(MigrationBuilder migrationBuilder)
@@ -602,6 +623,9 @@ namespace Skoruba.IdentityServer4.Admin.EntityFramework.SqlServer.Migrations.Ide
 
             migrationBuilder.DropTable(
                 name: "ApiResources");
+
+            migrationBuilder.DropTable(
+                name: "StandardClaims");
         }
     }
 }

--- a/src/Skoruba.IdentityServer4.Admin.EntityFramework.SqlServer/Migrations/IdentityServerConfiguration/20191119163952_DbInit.cs
+++ b/src/Skoruba.IdentityServer4.Admin.EntityFramework.SqlServer/Migrations/IdentityServerConfiguration/20191119163952_DbInit.cs
@@ -439,21 +439,6 @@ namespace Skoruba.IdentityServer4.Admin.EntityFramework.SqlServer.Migrations.Ide
                         onDelete: ReferentialAction.Cascade);
                 });
 
-            migrationBuilder.CreateTable(
-                name: "StandardClaims",
-                columns: table => new
-                {
-                    Id = table.Column<int>(nullable: false)
-                        .Annotation("SqlServer:Identity", "1, 1"),
-                    ClaimType = table.Column<string>(maxLength: 200, nullable: false),
-                    LastUsedTimestamp = table.Column<DateTimeOffset>(nullable: true),
-                    UseCount = table.Column<long>(nullable: false)
-                },
-                constraints: table =>
-                {
-                    table.PrimaryKey("PK_StandardClaims", x => x.Id);
-                });
-
             migrationBuilder.CreateIndex(
                 name: "IX_ApiClaims_ApiResourceId",
                 table: "ApiClaims",
@@ -557,12 +542,6 @@ namespace Skoruba.IdentityServer4.Admin.EntityFramework.SqlServer.Migrations.Ide
                 table: "IdentityResources",
                 column: "Name",
                 unique: true);
-
-            migrationBuilder.CreateIndex(
-                name: "IX_StandardClaims_ClaimType",
-                table: "StandardClaims",
-                column: "ClaimType",
-                unique: true);
         }
 
         protected override void Down(MigrationBuilder migrationBuilder)
@@ -623,9 +602,6 @@ namespace Skoruba.IdentityServer4.Admin.EntityFramework.SqlServer.Migrations.Ide
 
             migrationBuilder.DropTable(
                 name: "ApiResources");
-
-            migrationBuilder.DropTable(
-                name: "StandardClaims");
         }
     }
 }

--- a/src/Skoruba.IdentityServer4.Admin.EntityFramework.SqlServer/Migrations/IdentityServerConfiguration/20200420071504_StandardClaims.Designer.cs
+++ b/src/Skoruba.IdentityServer4.Admin.EntityFramework.SqlServer/Migrations/IdentityServerConfiguration/20200420071504_StandardClaims.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Skoruba.IdentityServer4.Admin.EntityFramework.Shared.DbContexts;
 
 namespace Skoruba.IdentityServer4.Admin.EntityFramework.SqlServer.Migrations.IdentityServerConfiguration
 {
     [DbContext(typeof(IdentityServerConfigurationDbContext))]
-    partial class IdentityServerConfigurationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20200420071504_StandardClaims")]
+    partial class StandardClaims
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Skoruba.IdentityServer4.Admin.EntityFramework.SqlServer/Migrations/IdentityServerConfiguration/20200420071504_StandardClaims.cs
+++ b/src/Skoruba.IdentityServer4.Admin.EntityFramework.SqlServer/Migrations/IdentityServerConfiguration/20200420071504_StandardClaims.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Skoruba.IdentityServer4.Admin.EntityFramework.SqlServer.Migrations.IdentityServerConfiguration
+{
+    public partial class StandardClaims : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "StandardClaims",
+                columns: table => new
+                {
+                    Id = table.Column<int>(nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    ClaimType = table.Column<string>(nullable: false),
+                    LastUsedTimestamp = table.Column<DateTimeOffset>(nullable: true),
+                    UseCount = table.Column<long>(nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_StandardClaims", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_StandardClaims_ClaimType",
+                table: "StandardClaims",
+                column: "ClaimType",
+                unique: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "StandardClaims");
+        }
+    }
+}

--- a/src/Skoruba.IdentityServer4.Admin.EntityFramework/Constants/ClientConsts.cs
+++ b/src/Skoruba.IdentityServer4.Admin.EntityFramework/Constants/ClientConsts.cs
@@ -18,31 +18,6 @@ namespace Skoruba.IdentityServer4.Admin.EntityFramework.Constants
             return secretTypes;
         }
 
-        public static List<string> GetStandardClaims()
-        {
-            //http://openid.net/specs/openid-connect-core-1_0.html#StandardClaims
-            var standardClaims = new List<string>
-            {
-                "name",
-                "given_name",
-                "family_name",
-                "middle_name",
-                "nickname",
-                "preferred_username",
-                "profile",
-                "picture",
-                "website",
-                "gender",
-                "birthdate",
-                "zoneinfo",
-                "locale",
-                "address",
-                "updated_at"
-            };
-
-            return standardClaims;
-        }
-
         public static List<string> GetGrantTypes()
         {
             var allowedGrantypes = new List<string>

--- a/src/Skoruba.IdentityServer4.Admin.EntityFramework/Entities/StandardClaim.cs
+++ b/src/Skoruba.IdentityServer4.Admin.EntityFramework/Entities/StandardClaim.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace Skoruba.IdentityServer4.Admin.EntityFramework.Entities
+{
+    public class StandardClaim
+    {
+        public int Id { get; set; }
+
+        public string ClaimType { get; set; }
+
+        public DateTimeOffset? LastUsedTimestamp { get; set; }
+
+        public long UseCount { get; set; }
+    }
+}

--- a/src/Skoruba.IdentityServer4.Admin.EntityFramework/Interfaces/IAdminConfigurationDbContext.cs
+++ b/src/Skoruba.IdentityServer4.Admin.EntityFramework/Interfaces/IAdminConfigurationDbContext.cs
@@ -1,6 +1,7 @@
 ﻿using IdentityServer4.EntityFramework.Entities;
 using IdentityServer4.EntityFramework.Interfaces;
 using Microsoft.EntityFrameworkCore;
+using Skoruba.IdentityServer4.Admin.EntityFramework.Entities;
 
 namespace Skoruba.IdentityServer4.Admin.EntityFramework.Interfaces
 {
@@ -37,5 +38,7 @@ namespace Skoruba.IdentityServer4.Admin.EntityFramework.Interfaces
         DbSet<IdentityResourceProperty> IdentityResourceProperties { get; set; }
 
         DbSet<ApiResourceProperty> ApiResourceProperties { get; set; }
+
+        DbSet<StandardClaim> StandardClaims { get; set; }
     }
 }

--- a/src/Skoruba.IdentityServer4.Admin.EntityFramework/Repositories/ClientRepository.cs
+++ b/src/Skoruba.IdentityServer4.Admin.EntityFramework/Repositories/ClientRepository.cs
@@ -100,15 +100,13 @@ namespace Skoruba.IdentityServer4.Admin.EntityFramework.Repositories
 
         public virtual async Task<List<string>> GetStandardClaimsAsync(string claim, int limit = 0)
         {
-            var filteredClaims = ClientConsts.GetStandardClaims()
-                .WhereIf(!string.IsNullOrWhiteSpace(claim), x => x.Contains(claim))
-                .TakeIf(x => x, limit > 0, limit)
-                .ToList();
-            if (limit == 0 || filteredClaims.Count < limit)
-            {
-                var usedClaims = await DbContext.ApiResourceClaims.Select(r => r.Type).WhereIf(!string.IsNullOrWhiteSpace(claim), x => x.Contains(claim)).Distinct().ToListAsync().ConfigureAwait(false);
-                filteredClaims = filteredClaims.Concat(usedClaims).Distinct().TakeIf(x => x, limit > 0, limit).ToList();
-            }
+            var filteredClaimsQuery = DbContext.StandardClaims
+                .WhereIf(!string.IsNullOrWhiteSpace(claim), x => x.ClaimType.Contains(claim))
+                .Select(x => x.ClaimType)
+                .TakeIf(x => x, limit > 0, limit);
+
+            var filteredClaims = await filteredClaimsQuery.ToListAsync().ConfigureAwait(false);
+
             return filteredClaims;
         }
 

--- a/src/Skoruba.IdentityServer4.Admin.EntityFramework/Repositories/ClientRepository.cs
+++ b/src/Skoruba.IdentityServer4.Admin.EntityFramework/Repositories/ClientRepository.cs
@@ -7,6 +7,7 @@ using IdentityServer4.EntityFramework.Entities;
 using IdentityServer4.Models;
 using Microsoft.EntityFrameworkCore;
 using Skoruba.IdentityServer4.Admin.EntityFramework.Constants;
+using Skoruba.IdentityServer4.Admin.EntityFramework.Entities;
 using Skoruba.IdentityServer4.Admin.EntityFramework.Extensions.Common;
 using Skoruba.IdentityServer4.Admin.EntityFramework.Extensions.Enums;
 using Skoruba.IdentityServer4.Admin.EntityFramework.Extensions.Extensions;
@@ -98,14 +99,44 @@ namespace Skoruba.IdentityServer4.Admin.EntityFramework.Repositories
             return secrets;
         }
 
-        public virtual async Task<List<string>> GetStandardClaimsAsync(string claim, int limit = 0)
+        public virtual async Task<List<string>> GetStandardClaimsAsync(string claim, int limit = 0, bool sortAscending = true, string sortBy = nameof(StandardClaim.ClaimType))
         {
             var filteredClaimsQuery = DbContext.StandardClaims
-                .WhereIf(!string.IsNullOrWhiteSpace(claim), x => x.ClaimType.Contains(claim))
-                .Select(x => x.ClaimType)
-                .TakeIf(x => x, limit > 0, limit);
+                .WhereIf(!string.IsNullOrWhiteSpace(claim), x => x.ClaimType.Contains(claim));
 
-            var filteredClaims = await filteredClaimsQuery.ToListAsync().ConfigureAwait(false);
+            if (!string.IsNullOrWhiteSpace(sortBy))
+            {
+                var parameter = Expression.Parameter(typeof(StandardClaim));
+                Expression<Func<StandardClaim, object>> sort;
+                try
+                {
+                    sort = Expression.Lambda<Func<StandardClaim, object>>(
+                        Expression.Convert(
+                            Expression.Property(parameter, sortBy),
+                            typeof(object)
+                        ),
+                        parameter
+                    );
+                }
+                catch (Exception ex)
+                {
+                    throw new InvalidOperationException($"The sort field '{sortBy}' has illegal value.", ex);
+                }
+                if (sortAscending)
+                {
+                    filteredClaimsQuery = filteredClaimsQuery.OrderBy(sort);
+                }
+                else
+                {
+                    filteredClaimsQuery = filteredClaimsQuery.OrderByDescending(sort);
+                }
+            }
+
+            var filteredClaims = await filteredClaimsQuery
+                .Select(x => x.ClaimType)
+                .TakeIf(x => x, limit > 0, limit)
+                .ToListAsync()
+                .ConfigureAwait(false);
 
             return filteredClaims;
         }

--- a/src/Skoruba.IdentityServer4.Admin.EntityFramework/Repositories/Interfaces/IClientRepository.cs
+++ b/src/Skoruba.IdentityServer4.Admin.EntityFramework/Repositories/Interfaces/IClientRepository.cs
@@ -47,7 +47,7 @@ namespace Skoruba.IdentityServer4.Admin.EntityFramework.Repositories.Interfaces
 
 	    List<SelectItem> GetSecretTypes();
 
-	    List<string> GetStandardClaims(string claim, int limit = 0);
+	    Task<List<string>> GetStandardClaimsAsync(string claim, int limit = 0);
 
         Task<int> AddClientSecretAsync(int clientId, ClientSecret clientSecret);
 

--- a/src/Skoruba.IdentityServer4.Admin.EntityFramework/Repositories/Interfaces/IClientRepository.cs
+++ b/src/Skoruba.IdentityServer4.Admin.EntityFramework/Repositories/Interfaces/IClientRepository.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 using IdentityServer4.EntityFramework.Entities;
+using Skoruba.IdentityServer4.Admin.EntityFramework.Entities;
 using Skoruba.IdentityServer4.Admin.EntityFramework.Extensions.Common;
 
 namespace Skoruba.IdentityServer4.Admin.EntityFramework.Repositories.Interfaces
@@ -47,7 +48,7 @@ namespace Skoruba.IdentityServer4.Admin.EntityFramework.Repositories.Interfaces
 
 	    List<SelectItem> GetSecretTypes();
 
-	    Task<List<string>> GetStandardClaimsAsync(string claim, int limit = 0);
+	    Task<List<string>> GetStandardClaimsAsync(string claim, int limit = 0, bool sortAscending = true, string sortBy = nameof(StandardClaim.ClaimType));
 
         Task<int> AddClientSecretAsync(int clientId, ClientSecret clientSecret);
 

--- a/src/Skoruba.IdentityServer4.Admin/Configuration/IdentityServerDataConfiguration.cs
+++ b/src/Skoruba.IdentityServer4.Admin/Configuration/IdentityServerDataConfiguration.cs
@@ -9,5 +9,6 @@ namespace Skoruba.IdentityServer4.Admin.Configuration
         public List<Client> Clients { get; set; } = new List<Client>();
         public List<IdentityResource> IdentityResources { get; set; } = new List<IdentityResource>();
         public List<ApiResource> ApiResources { get; set; } = new List<ApiResource>();
+        public HashSet<string> StandardClaims { get; set; } = new HashSet<string>();
     }
 }

--- a/src/Skoruba.IdentityServer4.Admin/Controllers/ConfigurationController.cs
+++ b/src/Skoruba.IdentityServer4.Admin/Controllers/ConfigurationController.cs
@@ -353,9 +353,9 @@ namespace Skoruba.IdentityServer4.Admin.Controllers
         }
 
         [HttpGet]
-        public IActionResult SearchClaims(string claim, int limit = 0)
+        public async Task<IActionResult> SearchClaims(string claim, int limit = 0)
         {
-            var claims = _clientService.GetStandardClaims(claim, limit);
+            var claims = await _clientService.GetStandardClaimsAsync(claim, limit);
 
             return Ok(claims);
         }

--- a/src/Skoruba.IdentityServer4.Admin/Helpers/DbMigrationHelpers.cs
+++ b/src/Skoruba.IdentityServer4.Admin/Helpers/DbMigrationHelpers.cs
@@ -12,6 +12,7 @@ using Skoruba.AuditLogging.EntityFramework.DbContexts;
 using Skoruba.AuditLogging.EntityFramework.Entities;
 using Skoruba.IdentityServer4.Admin.Configuration;
 using Skoruba.IdentityServer4.Admin.Configuration.Interfaces;
+using Skoruba.IdentityServer4.Admin.EntityFramework.Entities;
 using Skoruba.IdentityServer4.Admin.EntityFramework.Interfaces;
 
 namespace Skoruba.IdentityServer4.Admin.Helpers
@@ -28,7 +29,7 @@ namespace Skoruba.IdentityServer4.Admin.Helpers
             where TIdentityDbContext : DbContext
             where TPersistedGrantDbContext : DbContext, IAdminPersistedGrantDbContext
             where TLogDbContext : DbContext, IAdminLogDbContext
-            where TAuditLogDbContext: DbContext, IAuditLoggingDbContext<AuditLog>
+            where TAuditLogDbContext : DbContext, IAuditLoggingDbContext<AuditLog>
             where TDataProtectionDbContext : DbContext, IDataProtectionKeyContext
             where TUser : IdentityUser, new()
             where TRole : IdentityRole, new()
@@ -46,7 +47,7 @@ namespace Skoruba.IdentityServer4.Admin.Helpers
             where TPersistedGrantDbContext : DbContext
             where TConfigurationDbContext : DbContext
             where TLogDbContext : DbContext
-            where TAuditLogDbContext: DbContext
+            where TAuditLogDbContext : DbContext
             where TDataProtectionDbContext : DbContext
         {
             using (var scope = services.GetRequiredService<IServiceScopeFactory>().CreateScope())
@@ -213,6 +214,15 @@ namespace Skoruba.IdentityServer4.Admin.Helpers
 
                     await context.Clients.AddAsync(client.ToEntity());
                 }
+
+                await context.SaveChangesAsync();
+            }
+
+            if (!context.StandardClaims.Any())
+            {
+                var standardClaims = identityServerDataConfiguration.StandardClaims.Select(c => new StandardClaim { ClaimType = c });
+
+                await context.StandardClaims.AddRangeAsync(standardClaims);
 
                 await context.SaveChangesAsync();
             }

--- a/src/Skoruba.IdentityServer4.Admin/identityserverdata.json
+++ b/src/Skoruba.IdentityServer4.Admin/identityserverdata.json
@@ -122,6 +122,23 @@
         "AllowAccessTokensViaBrowser": true
 
       }
+    ],
+    "StandardClaims": [
+      "name",
+      "given_name",
+      "family_name",
+      "middle_name",
+      "nickname",
+      "preferred_username",
+      "profile",
+      "picture",
+      "website",
+      "gender",
+      "birthdate",
+      "zoneinfo",
+      "locale",
+      "address",
+      "updated_at"
     ]
   }
 }

--- a/tests/Skoruba.IdentityServer4.Admin.UnitTests/Mocks/ApiResourceDtoMock.cs
+++ b/tests/Skoruba.IdentityServer4.Admin.UnitTests/Mocks/ApiResourceDtoMock.cs
@@ -16,7 +16,7 @@ namespace Skoruba.IdentityServer4.Admin.UnitTests.Mocks
                 .RuleFor(o => o.Description, f => f.Random.Words(f.Random.Number(1, 5)))
                 .RuleFor(o => o.DisplayName, f => f.Random.Words(f.Random.Number(1, 5)))
                 .RuleFor(o => o.Enabled, f => f.Random.Bool())                
-                .RuleFor(o => o.UserClaims, f => Enumerable.Range(1, f.Random.Int(1, 10)).Select(x => f.PickRandom(ClientConsts.GetStandardClaims())).ToList());
+                .RuleFor(o => o.UserClaims, f => Enumerable.Range(1, f.Random.Int(1, 10)).Select(x => f.PickRandom(ClientMock.GetStandardClaims())).ToList());
             
             return fakerApiResource;
         }
@@ -65,7 +65,7 @@ namespace Skoruba.IdentityServer4.Admin.UnitTests.Mocks
                 .RuleFor(o => o.DisplayName, f => f.Random.Words(f.Random.Number(1, 5)))
                 .RuleFor(o => o.UserClaims,
                     f => Enumerable.Range(1, f.Random.Int(1, 10))
-                        .Select(x => f.PickRandom(ClientConsts.GetStandardClaims())).ToList())
+                        .Select(x => f.PickRandom(ClientMock.GetStandardClaims())).ToList())
                 .RuleFor(o => o.Emphasize, f => f.Random.Bool())
                 .RuleFor(o => o.Required, f => f.Random.Bool())
                 .RuleFor(o => o.ShowInDiscoveryDocument, f => f.Random.Bool());              

--- a/tests/Skoruba.IdentityServer4.Admin.UnitTests/Mocks/ClientDtoMock.cs
+++ b/tests/Skoruba.IdentityServer4.Admin.UnitTests/Mocks/ClientDtoMock.cs
@@ -122,7 +122,7 @@ namespace Skoruba.IdentityServer4.Admin.UnitTests.Mocks
 			var clientClaimFaker = new Faker<ClientClaimsDto>()
 				.StrictMode(false)
 				.RuleFor(o => o.ClientClaimId, id)
-				.RuleFor(o => o.Type, f => f.PickRandom(ClientConsts.GetStandardClaims()))
+				.RuleFor(o => o.Type, f => f.PickRandom(ClientMock.GetStandardClaims()))
 				.RuleFor(o => o.Value, f => Guid.NewGuid().ToString())
 				.RuleFor(o => o.ClientId, clientId);
 

--- a/tests/Skoruba.IdentityServer4.Admin.UnitTests/Mocks/ClientMock.cs
+++ b/tests/Skoruba.IdentityServer4.Admin.UnitTests/Mocks/ClientMock.cs
@@ -224,7 +224,7 @@ namespace Skoruba.IdentityServer4.Admin.UnitTests.Mocks
 			var clientClaimFaker = new Faker<ClientClaim>()
 				.StrictMode(false)
 				.RuleFor(o => o.Id, id)
-				.RuleFor(o => o.Type, f => f.PickRandom(ClientConsts.GetStandardClaims()))
+				.RuleFor(o => o.Type, f => f.PickRandom(ClientMock.GetStandardClaims()))
 				.RuleFor(o => o.Value, f => Guid.NewGuid().ToString());
 
 			return clientClaimFaker;
@@ -240,5 +240,30 @@ namespace Skoruba.IdentityServer4.Admin.UnitTests.Mocks
 
 			return clientPropertyFaker;
 		}
-	}
+
+        public static List<string> GetStandardClaims()
+        {
+            //http://openid.net/specs/openid-connect-core-1_0.html#StandardClaims
+            var standardClaims = new List<string>
+            {
+                "name",
+                "given_name",
+                "family_name",
+                "middle_name",
+                "nickname",
+                "preferred_username",
+                "profile",
+                "picture",
+                "website",
+                "gender",
+                "birthdate",
+                "zoneinfo",
+                "locale",
+                "address",
+                "updated_at"
+            };
+
+            return standardClaims;
+        }
+    }
 }

--- a/tests/Skoruba.IdentityServer4.Admin.UnitTests/Mocks/IdentityResourceDtoMock.cs
+++ b/tests/Skoruba.IdentityServer4.Admin.UnitTests/Mocks/IdentityResourceDtoMock.cs
@@ -19,7 +19,7 @@ namespace Skoruba.IdentityServer4.Admin.UnitTests.Mocks
                 .RuleFor(o => o.Emphasize, f => f.Random.Bool())
                 .RuleFor(o => o.ShowInDiscoveryDocument, f => f.Random.Bool())
                 .RuleFor(o => o.Required, f => f.Random.Bool())                
-                .RuleFor(o => o.UserClaims, f => Enumerable.Range(1, f.Random.Int(1, 10)).Select(x => f.PickRandom(ClientConsts.GetStandardClaims())).ToList());
+                .RuleFor(o => o.UserClaims, f => Enumerable.Range(1, f.Random.Int(1, 10)).Select(x => f.PickRandom(ClientMock.GetStandardClaims())).ToList());
 
             return fakerIdentityResource;
         }

--- a/tests/Skoruba.IdentityServer4.Admin.UnitTests/Repositories/ClientRepositoryTests.cs
+++ b/tests/Skoruba.IdentityServer4.Admin.UnitTests/Repositories/ClientRepositoryTests.cs
@@ -4,12 +4,14 @@ using System.Threading.Tasks;
 using FluentAssertions;
 using IdentityServer4.EntityFramework.Entities;
 using IdentityServer4.EntityFramework.Options;
+using IdentityServer4.EntityFramework.Mappers;
 using Microsoft.EntityFrameworkCore;
 using Skoruba.IdentityServer4.Admin.EntityFramework.Repositories;
 using Skoruba.IdentityServer4.Admin.EntityFramework.Repositories.Interfaces;
 using Skoruba.IdentityServer4.Admin.EntityFramework.Shared.DbContexts;
 using Skoruba.IdentityServer4.Admin.UnitTests.Mocks;
 using Xunit;
+using IdentityApiResource = IdentityServer4.Models.ApiResource;
 
 namespace Skoruba.IdentityServer4.Admin.UnitTests.Repositories
 {
@@ -198,7 +200,7 @@ namespace Skoruba.IdentityServer4.Admin.UnitTests.Repositories
                 ClientCloneCompare(cloneClientEntity, clientToCompare);
             }
         }
-        
+
         [Fact]
         public async Task CloneClientWithoutCorsAsync()
         {
@@ -767,17 +769,27 @@ namespace Skoruba.IdentityServer4.Admin.UnitTests.Repositories
         }
 
         [Fact]
-        public void GetStandardClaims()
+        public async Task GetStandardClaims()
         {
             using (var context = new IdentityServerConfigurationDbContext(_dbContextOptions, _storeOptions))
             {
+                const string claimName = "test-claim";
+                var apiResource = new IdentityApiResource("test-api") { Enabled = true };
+                apiResource.UserClaims.Add(claimName);
+
+                await context.AddAsync(apiResource.ToEntity());
+                await context.SaveChangesAsync();
+
                 var clientRepository = GetClientRepository(context);
 
                 //Try get some existing claims
                 var randomClientClaim = ClientMock.GenerateRandomClientClaim(0);
 
-                var grantTypes = clientRepository.GetStandardClaims(randomClientClaim.Type);
-                grantTypes.Contains(randomClientClaim.Type).Should().Be(true);
+                var standardClaims = await clientRepository.GetStandardClaimsAsync(randomClientClaim.Type);
+                standardClaims.Contains(randomClientClaim.Type).Should().Be(true);
+
+                standardClaims = await clientRepository.GetStandardClaimsAsync(claimName.Substring(0, 3), 5);
+                standardClaims.Contains(claimName).Should().BeTrue();
             }
         }
 
@@ -788,10 +800,10 @@ namespace Skoruba.IdentityServer4.Admin.UnitTests.Repositories
             {
                 var clientRepository = GetClientRepository(context);
                 var identityResourceRepository = GetIdentityResourceRepository(context);
-                
+
                 var identityResource = IdentityResourceMock.GenerateRandomIdentityResource(0);
                 await identityResourceRepository.AddIdentityResourceAsync(identityResource);
-                
+
                 var identityScopes = await clientRepository.GetScopesAsync(identityResource.Name);
 
                 identityScopes[0].Should().Be(identityResource.Name);
@@ -805,7 +817,7 @@ namespace Skoruba.IdentityServer4.Admin.UnitTests.Repositories
             {
                 var clientRepository = GetClientRepository(context);
                 var apiResourceRepository = GetApiResourceRepository(context);
-                
+
                 var apiResource = ApiResourceMock.GenerateRandomApiResource(0);
                 await apiResourceRepository.AddApiResourceAsync(apiResource);
 
@@ -819,7 +831,7 @@ namespace Skoruba.IdentityServer4.Admin.UnitTests.Repositories
                 apiScopes[0].Should().Be(apiScope.Name);
             }
         }
-        
+
         private void ClientCloneCompare(Client cloneClientEntity, Client clientToCompare, bool cloneClientCorsOrigins = true, bool cloneClientGrantTypes = true, bool cloneClientIdPRestrictions = true, bool cloneClientPostLogoutRedirectUris = true, bool cloneClientScopes = true, bool cloneClientRedirectUris = true, bool cloneClientClaims = true, bool cloneClientProperties = true)
         {
             //Assert cloned client

--- a/tests/Skoruba.IdentityServer4.Admin.UnitTests/Repositories/ClientRepositoryTests.cs
+++ b/tests/Skoruba.IdentityServer4.Admin.UnitTests/Repositories/ClientRepositoryTests.cs
@@ -770,7 +770,7 @@ namespace Skoruba.IdentityServer4.Admin.UnitTests.Repositories
         }
 
         [Fact]
-        public async Task GetStandardClaims()
+        public async Task GetStandardClaimsAsync()
         {
             using (var context = new IdentityServerConfigurationDbContext(_dbContextOptions, _storeOptions))
             {

--- a/tests/Skoruba.IdentityServer4.Admin.UnitTests/Repositories/ClientRepositoryTests.cs
+++ b/tests/Skoruba.IdentityServer4.Admin.UnitTests/Repositories/ClientRepositoryTests.cs
@@ -12,6 +12,7 @@ using Skoruba.IdentityServer4.Admin.EntityFramework.Shared.DbContexts;
 using Skoruba.IdentityServer4.Admin.UnitTests.Mocks;
 using Xunit;
 using IdentityApiResource = IdentityServer4.Models.ApiResource;
+using Skoruba.IdentityServer4.Admin.EntityFramework.Entities;
 
 namespace Skoruba.IdentityServer4.Admin.UnitTests.Repositories
 {
@@ -773,11 +774,8 @@ namespace Skoruba.IdentityServer4.Admin.UnitTests.Repositories
         {
             using (var context = new IdentityServerConfigurationDbContext(_dbContextOptions, _storeOptions))
             {
-                const string claimName = "test-claim";
-                var apiResource = new IdentityApiResource("test-api") { Enabled = true };
-                apiResource.UserClaims.Add(claimName);
+                await context.StandardClaims.AddRangeAsync(ClientMock.GetStandardClaims().Select(c => new StandardClaim { ClaimType = c }));
 
-                await context.AddAsync(apiResource.ToEntity());
                 await context.SaveChangesAsync();
 
                 var clientRepository = GetClientRepository(context);
@@ -788,8 +786,8 @@ namespace Skoruba.IdentityServer4.Admin.UnitTests.Repositories
                 var standardClaims = await clientRepository.GetStandardClaimsAsync(randomClientClaim.Type);
                 standardClaims.Contains(randomClientClaim.Type).Should().Be(true);
 
-                standardClaims = await clientRepository.GetStandardClaimsAsync(claimName.Substring(0, 3), 5);
-                standardClaims.Contains(claimName).Should().BeTrue();
+                standardClaims = await clientRepository.GetStandardClaimsAsync(randomClientClaim.Type.Substring(0, 3), 5);
+                standardClaims.Contains(randomClientClaim.Type).Should().BeTrue();
             }
         }
 


### PR DESCRIPTION
Hi,

I was adding a lot of claims lately and it was very annoying that it wasn't suggesting me the claim type  I entered just a second ago.

I've added logic to get the claims that are required by existing API resources.

*Thinking points:*
1. That logic might be out of place and should be somewhere a little higher in the food chain.
2. Maybe it should also prioritize by actual usage.
3. Should it have a list in the database that is manageable?