### PR TITLE
Few improvements when checking if a request is coming from a local subnet

### DIFF
--- a/src/Skoruba.IdentityServer4.STS.Identity/Configuration/WindowsAuthConfiguration.cs
+++ b/src/Skoruba.IdentityServer4.STS.Identity/Configuration/WindowsAuthConfiguration.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using System.Threading.Tasks;
 
 namespace Skoruba.IdentityServer4.STS.Identity.Configuration
@@ -32,5 +33,18 @@ namespace Skoruba.IdentityServer4.STS.Identity.Configuration
         public string DomainUserPassword { get; set; } = null;
 
         public bool GetPhotoThumbnailFromAD { get; set; } = false;
+
+        // Subnets specified here will always be considered external
+        // (useful for testing purposes and for intranet machines not joined to the domain)
+        public List<Subnet> ExcludedLocalSubnets { get; set; } = new List<Subnet>();
+    }
+
+    public class Subnet
+    {
+        public string SubnetAddress { get; set; }
+        public string SubnetMask { get; set; }
+
+        public IPAddress SubnetIPAddress => IPAddress.Parse(SubnetAddress);
+        public IPAddress SubnetIPMask => IPAddress.Parse(SubnetMask);
     }
 }

--- a/src/Skoruba.IdentityServer4.STS.Identity/Controllers/AccountController.cs
+++ b/src/Skoruba.IdentityServer4.STS.Identity/Controllers/AccountController.cs
@@ -97,7 +97,7 @@ namespace Skoruba.IdentityServer4.STS.Identity.Controllers
         [AllowAnonymous]
         public async Task<IActionResult> Login(string returnUrl, bool forceLoginScreen = false)
         {
-            if (_windowsAuthConfiguration.AutomaticWindowsLogin && !forceLoginScreen && Request.IsFromLocalSubnet())
+            if (_windowsAuthConfiguration.AutomaticWindowsLogin && !forceLoginScreen && Request.IsFromLocalSubnet(_windowsAuthConfiguration.ExcludedLocalSubnets, _logger))
             {
                 return RedirectToAction("ExternalLogin", new { provider = AccountOptions.WindowsAuthenticationSchemeName, returnUrl });
             }
@@ -1014,7 +1014,7 @@ namespace Skoruba.IdentityServer4.STS.Identity.Controllers
             {
                 return await IssueExternalCookie(returnUrl, wp.Identity);
             }
-            else if (Request.IsFromLocalSubnet())
+            else if (Request.IsFromLocalSubnet(_windowsAuthConfiguration.ExcludedLocalSubnets, _logger))
             {
                 // trigger windows auth
                 // since windows auth don't support the redirect uri,

--- a/src/Skoruba.IdentityServer4.STS.Identity/Helpers/HttpRequestExtensions.cs
+++ b/src/Skoruba.IdentityServer4.STS.Identity/Helpers/HttpRequestExtensions.cs
@@ -1,66 +1,102 @@
 ﻿using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Skoruba.IdentityServer4.STS.Identity.Configuration;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
-using System.Net.NetworkInformation;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 
 namespace Skoruba.IdentityServer4.STS.Identity.Helpers
 {
     public static class HttpRequestExtensions
     {
-        public static bool IsLocal(this HttpRequest req)
+        const string _PrivateAddressRegex = @"(^192\.168\.([0-9]|[0-9][0-9]|[0-2][0-9][0-9])\.([0-9]|[0-9][0-9]|[0-2][0-9][0-9])$)|(^172\.([1][6-9]|[2][0-9]|[3][0-1])\.([0-9]|[0-9][0-9]|[0-2][0-9][0-9])\.([0-9]|[0-9][0-9]|[0-2][0-9][0-9])$)|(^10\.([0-9]|[0-9][0-9]|[0-2][0-9][0-9])\.([0-9]|[0-9][0-9]|[0-2][0-9][0-9])\.([0-9]|[0-9][0-9]|[0-2][0-9][0-9])$)";
+        public static bool IsLocal(this HttpRequest req, ILogger logger = null)
         {
+            bool ret = false;
             var connection = req.HttpContext.Connection;
+
             if (connection.RemoteIpAddress != null)
             {
                 if (connection.RemoteIpAddress.ToString() == "::1" || connection.RemoteIpAddress.ToString() == "127.0.0.1")
-                    return true;
-
-                if (connection.LocalIpAddress != null)
                 {
-                    return connection.RemoteIpAddress.Equals(connection.LocalIpAddress);
+                    if (logger != null)
+                        logger.LogDebug("Remote IP address is local: {0}", connection.RemoteIpAddress.ToString());
+                    ret = true;
                 }
                 else
                 {
-                    return IPAddress.IsLoopback(connection.RemoteIpAddress);
+                    if (connection.LocalIpAddress != null)
+                    {
+                        ret = connection.RemoteIpAddress.Equals(connection.LocalIpAddress);
+
+                        if (logger != null)
+                            logger.LogDebug("RemoteIpAddress = LocalIpAddress?: {0}", ret.ToString());
+                    }
+                    else
+                    {
+                        ret = IPAddress.IsLoopback(connection.RemoteIpAddress);
+                        if (logger != null)
+                            logger.LogDebug("RemoteIpAddress is loopback?: {0}", ret.ToString());
+                    }
                 }
             }
-
             // for in memory TestServer or when dealing with default connection info
-            if (connection.RemoteIpAddress == null && connection.LocalIpAddress == null)
+            else if (connection.RemoteIpAddress == null && connection.LocalIpAddress == null)
             {
-                return true;
+                ret = true;
+                logger.LogDebug("No RemoteIpAddress nor LocalIpAddress present in the connection, assuming local test server");
             }
 
-            return false;
+            return ret;
         }
 
-        public static bool IsFromLocalSubnet(this HttpRequest req)
+        public static bool IsFromLocalSubnet(this HttpRequest req, IEnumerable<Subnet> excludedLocalSubnets = null, ILogger logger = null)
         {
-            if (req.IsLocal())
+            if (req.IsLocal(logger))
                 return true;
 
             var connection = req.HttpContext.Connection;
-            if (connection.RemoteIpAddress != null)
+            var remoteIpAddress = connection.RemoteIpAddress;
+            if (req.Headers.ContainsKey("X-Forwarded-For"))
             {
-                var clientIPv4 = connection.RemoteIpAddress.MapToIPv4();
+                bool correctHeaderFormat = IPAddress.TryParse(req.Headers["X-Forwarded-For"][0], out remoteIpAddress);
+                logger.LogDebug("Found X-Forwarded-For header: {0}; will it be used? {1}", req.Headers["X-Forwarded-For"][0], correctHeaderFormat);
+            }
 
-                foreach (NetworkInterface ni in NetworkInterface.GetAllNetworkInterfaces())
+            if (remoteIpAddress != null)
+            {
+                var clientIPv4 = remoteIpAddress.MapToIPv4();
+                if (excludedLocalSubnets != null)
                 {
-                    if (ni.OperationalStatus == OperationalStatus.Up)
+                    foreach (var localSubnet in excludedLocalSubnets)
                     {
-                        foreach (UnicastIPAddressInformation uipi in ni.GetIPProperties().UnicastAddresses)
+                        if (clientIPv4.IsInSameSubnet(localSubnet.SubnetIPAddress, localSubnet.SubnetIPMask))
                         {
-                            if (clientIPv4.IsInSameSubnet(uipi.Address.MapToIPv4(), uipi.IPv4Mask))
-                                return true;
+                            if (logger != null)
+                                logger.LogDebug("Remote IP address is one of the excluded subnet addresses, so it will be considered as NOT LOCAL.");
+                            return false;
                         }
                     }
                 }
 
+                if (Regex.IsMatch(clientIPv4.ToString(), _PrivateAddressRegex))
+                {
+                    if (logger != null)
+                        logger.LogDebug("Remote IP address {0} matches a private address, it will be considered as LOCAL", clientIPv4.ToString());
+
+                    return true;
+                }
+
+                if (logger != null)
+                    logger.LogDebug("Remote IP address {0} will be considered as NOT LOCAL", clientIPv4.ToString());
                 return false;
             }
+
+            if (logger != null)
+                logger.LogDebug("Remote IP address is null, so it will be considered as NOT LOCAL");
             return false;
         }
     }

--- a/src/Skoruba.IdentityServer4.STS.Identity/appsettings.json
+++ b/src/Skoruba.IdentityServer4.STS.Identity/appsettings.json
@@ -80,7 +80,8 @@
     "SyncUserProfileWithWindows": true,
     "DomainUserName": "",
     "DomainUserPassword": "",
-    "GetPhotoThumbnailFromAD": false
+    "GetPhotoThumbnailFromAD": false,
+    "ExcludedLocalSubnets": []
   },
   "AdminConfiguration": {
     "IdentityAdminBaseUrl": "http://localhost:9000",


### PR DESCRIPTION
- checking for X-Forwarded-For header
- instead of scanning the network interfaces where the Identity Server is installed, we now check the request IP against a regular expression to identify private addresses (basically 192.169.*.*, 172.16-31.*.*, 10.*.*.* addresses will be considered private)
- added possibility to exclude in the configuration subnets from those that would normally be considered local
- added debug logging to help investigate why a request is considered local or not