### PR TITLE
Fix failed test - NullReferenceException at HashClientSharedSecret(ClientSecretsDto clientSecret)

### DIFF
--- a/src/Skoruba.IdentityServer4.Admin.Api/Dtos/Clients/ClientSecretApiDto.cs
+++ b/src/Skoruba.IdentityServer4.Admin.Api/Dtos/Clients/ClientSecretApiDto.cs
@@ -1,5 +1,6 @@
 using System;
 using System.ComponentModel.DataAnnotations;
+using Skoruba.IdentityServer4.Admin.EntityFramework.Helpers;
 
 namespace Skoruba.IdentityServer4.Admin.Api.Dtos.Clients
 {
@@ -17,6 +18,21 @@ namespace Skoruba.IdentityServer4.Admin.Api.Dtos.Clients
 
         public string HashType { get; set; }
 
-        public DateTime? Expiration { get; set; }       
+        public HashType HashTypeEnum
+        {
+            get
+            {
+                HashType result;
+
+                if (Enum.TryParse(HashType, true, out result))
+                {
+                    return result;
+                }
+
+                return EntityFramework.Helpers.HashType.Sha256;
+            }
+        }
+
+        public DateTime? Expiration { get; set; }
     }
 }

--- a/src/Skoruba.IdentityServer4.Admin.BusinessLogic/Dtos/Configuration/ApiSecretsDto.cs
+++ b/src/Skoruba.IdentityServer4.Admin.BusinessLogic/Dtos/Configuration/ApiSecretsDto.cs
@@ -1,7 +1,8 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using Skoruba.IdentityServer4.Admin.BusinessLogic.Shared.Dtos.Common;
+using Skoruba.IdentityServer4.Admin.EntityFramework.Helpers;
 
 namespace Skoruba.IdentityServer4.Admin.BusinessLogic.Dtos.Configuration
 {
@@ -29,6 +30,21 @@ namespace Skoruba.IdentityServer4.Admin.BusinessLogic.Dtos.Configuration
         public string Value { get; set; }
 
 		public string HashType { get; set; }
+
+        public HashType HashTypeEnum
+        {
+            get
+            {
+                HashType result;
+
+                if (Enum.TryParse(HashType, true, out result))
+                {
+                    return result;
+                }
+
+                return EntityFramework.Helpers.HashType.Sha256;
+            }
+        }
 
 		public List<SelectItemDto> HashTypes { get; set; }
 

--- a/src/Skoruba.IdentityServer4.Admin.BusinessLogic/Dtos/Configuration/ClientSecretsDto.cs
+++ b/src/Skoruba.IdentityServer4.Admin.BusinessLogic/Dtos/Configuration/ClientSecretsDto.cs
@@ -1,7 +1,8 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using Skoruba.IdentityServer4.Admin.BusinessLogic.Shared.Dtos.Common;
+using Skoruba.IdentityServer4.Admin.EntityFramework.Helpers;
 
 namespace Skoruba.IdentityServer4.Admin.BusinessLogic.Dtos.Configuration
 {
@@ -29,6 +30,21 @@ namespace Skoruba.IdentityServer4.Admin.BusinessLogic.Dtos.Configuration
 		public string Value { get; set; }
 
 		public string HashType { get; set; }
+
+        public HashType HashTypeEnum
+        {
+            get
+            {
+                HashType result;
+
+                if (Enum.TryParse(HashType, true, out result))
+                {
+                    return result;
+                }
+
+                return EntityFramework.Helpers.HashType.Sha256;
+            }
+        }
 
 		public List<SelectItemDto> HashTypes { get; set; }
 

--- a/src/Skoruba.IdentityServer4.Admin.BusinessLogic/Services/ApiResourceService.cs
+++ b/src/Skoruba.IdentityServer4.Admin.BusinessLogic/Services/ApiResourceService.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 using System.Threading.Tasks;
 using IdentityServer4.Models;
 using Skoruba.AuditLogging.Services;
@@ -112,11 +112,11 @@ namespace Skoruba.IdentityServer4.Admin.BusinessLogic.Services
         {
             if (apiSecret.Type != SharedSecret) return;
 
-            if (apiSecret.HashType == ((int)HashType.Sha256).ToString())
+            if (apiSecret.HashTypeEnum == HashType.Sha256)
             {
                 apiSecret.Value = apiSecret.Value.Sha256();
             }
-            else if (apiSecret.HashType == ((int)HashType.Sha512).ToString())
+            else if (apiSecret.HashTypeEnum == HashType.Sha512)
             {
                 apiSecret.Value = apiSecret.Value.Sha512();
             }

--- a/src/Skoruba.IdentityServer4.Admin.BusinessLogic/Services/ClientService.cs
+++ b/src/Skoruba.IdentityServer4.Admin.BusinessLogic/Services/ClientService.cs
@@ -36,13 +36,11 @@ namespace Skoruba.IdentityServer4.Admin.BusinessLogic.Services
         {
             if (clientSecret.Type != SharedSecret) return;
 
-            if (clientSecret.HashType == ((int)HashType.Sha256).ToString() ||
-                clientSecret.HashType.Equals(HashType.Sha256.ToString(), StringComparison.InvariantCultureIgnoreCase))
+            if (clientSecret.HashTypeEnum == HashType.Sha256)
             {
                 clientSecret.Value = clientSecret.Value.Sha256();
             }
-            else if (clientSecret.HashType == ((int)HashType.Sha512).ToString() ||
-                clientSecret.HashType.Equals(HashType.Sha512.ToString(), StringComparison.InvariantCultureIgnoreCase))
+            else if (clientSecret.HashTypeEnum == HashType.Sha512)
             {
                 clientSecret.Value = clientSecret.Value.Sha512();
             }


### PR DESCRIPTION
I'm proposing this to simplify comparison of HashType. 

Hopefully this will also solve the failing test
```
[xUnit.net 00:00:04.72]     Skoruba.IdentityServer4.Admin.UnitTests.Services.ClientServiceTests.GetClientSecretAsync [FAIL]
  X Skoruba.IdentityServer4.Admin.UnitTests.Services.ClientServiceTests.GetClientSecretAsync [56ms]
  Error Message:
   System.NullReferenceException : Object reference not set to an instance of an object.
  Stack Trace:
     at Skoruba.IdentityServer4.Admin.BusinessLogic.Services.ClientService.HashClientSharedSecret(ClientSecretsDto clientSecret) in C:\projects\identityserver4-admin\src\Skoruba.IdentityServer4.Admin.BusinessLogic\Services\ClientService.cs:line 39
```

I'll create this as draft. Feel free to check.

Regards, Martinus