### PR TITLE
Add base path for deployment in folder

### DIFF
--- a/src/Skoruba.IdentityServer4.Admin/Startup.cs
+++ b/src/Skoruba.IdentityServer4.Admin/Startup.cs
@@ -1,4 +1,4 @@
-﻿using System.IdentityModel.Tokens.Jwt;
+using System.IdentityModel.Tokens.Jwt;
 using HealthChecks.UI.Client;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
@@ -101,6 +101,8 @@ namespace Skoruba.IdentityServer4.Admin
                 app.UseExceptionHandler("/Home/Error");
                 app.UseHsts();
             }
+
+            app.UsePathBase(Configuration.GetValue<string>("BasePath"));
 
             // Add custom security headers
             app.UseSecurityHeaders();

--- a/src/Skoruba.IdentityServer4.Admin/appsettings.json
+++ b/src/Skoruba.IdentityServer4.Admin/appsettings.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "ConnectionStrings": {
     "ConfigurationDbConnection": "Server=(localdb)\\mssqllocaldb;Database=IdentityServer4Admin;Trusted_Connection=True;MultipleActiveResultSets=true",
     "PersistedGrantDbConnection": "Server=(localdb)\\mssqllocaldb;Database=IdentityServer4Admin;Trusted_Connection=True;MultipleActiveResultSets=true",
@@ -40,5 +40,6 @@
   "CultureConfiguration": {
     "Cultures": [],
     "DefaultCulture": null
-  }
+  },
+  "BasePath":  ""
 }

--- a/src/Skoruba.IdentityServer4.STS.Identity/Startup.cs
+++ b/src/Skoruba.IdentityServer4.STS.Identity/Startup.cs
@@ -1,4 +1,4 @@
-﻿using HealthChecks.UI.Client;
+using HealthChecks.UI.Client;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.AspNetCore.Hosting;
@@ -72,6 +72,8 @@ namespace Skoruba.IdentityServer4.STS.Identity
                 app.UseHsts();
             }
 
+            app.UsePathBase(Configuration.GetValue<string>("BasePath"));
+
             // Add custom security headers
             app.UseSecurityHeaders();
 
@@ -81,8 +83,8 @@ namespace Skoruba.IdentityServer4.STS.Identity
 
             app.UseRouting();
             app.UseAuthorization();
-            app.UseEndpoints(endpoint => 
-            { 
+            app.UseEndpoints(endpoint =>
+            {
                 endpoint.MapDefaultControllerRoute();
                 endpoint.MapHealthChecks("/health", new HealthCheckOptions
                 {

--- a/src/Skoruba.IdentityServer4.STS.Identity/appsettings.json
+++ b/src/Skoruba.IdentityServer4.STS.Identity/appsettings.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "ConnectionStrings": {
     "ConfigurationDbConnection": "Server=(localdb)\\mssqllocaldb;Database=IdentityServer4Admin;Trusted_Connection=True;MultipleActiveResultSets=true",
     "PersistedGrantDbConnection": "Server=(localdb)\\mssqllocaldb;Database=IdentityServer4Admin;Trusted_Connection=True;MultipleActiveResultSets=true",
@@ -63,5 +63,6 @@
   },
   "AdvancedConfiguration": {
     "PublicOrigin":  ""
-  }
+  },
+  "BasePath":  ""
 }


### PR DESCRIPTION
This will allow for deployment in folder (https://www.example.com/stsidentity) for the token service and admin.
For token service, if behind reverse proxy, then need to set PublicOrigin to https://www.example.com too.

Regards, Martinus