### PR TITLE
Draft: Fix for appveyor test fail silently (database related exception)

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,5 @@
+image: Ubuntu
+build:
+  project: Skoruba.IdentityServer4.Admin.sln
+  verbosity: minimal
+version: '1.0.{build}'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,10 @@
 image: Ubuntu
 
+environment:
+  APPVEYOR_SSH_KEY: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIO331U/KDT0FmRuw7pRLRkCCkceP1eURu4T4V+dsK4Ky ed25519-appveyor
+
 init:
+  - curl -sflL 'https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-ssh.sh' | bash -e -
   - sudo sed -i 's!/var/lib/mysql!/dev/shm/mysql!' /etc/mysql/mysql.conf.d/mysqld.cnf
   - sudo sed -i 's!/var/lib/mysql!/dev/shm/mysql!' /etc/apparmor.d/usr.sbin.mysqld
   - sudo apparmor_parser -r /etc/apparmor.d/usr.sbin.mysqld

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,17 @@
 image: Ubuntu
+
+init:
+  - sudo sed -i 's!/var/lib/mysql!/dev/shm/mysql!' /etc/mysql/mysql.conf.d/mysqld.cnf
+  - sudo sed -i 's!/var/lib/mysql!/dev/shm/mysql!' /etc/apparmor.d/usr.sbin.mysqld
+  - sudo apparmor_parser -r /etc/apparmor.d/usr.sbin.mysqld
+  - sudo cp -rp /var/lib/mysql /dev/shm
+  - sudo mv /var/lib/mysql /var/lib/mysql.local
+
+services:
+  - mysql
+
 build:
   project: Skoruba.IdentityServer4.Admin.sln
   verbosity: minimal
+
 version: '1.0.{build}'

--- a/src/Skoruba.IdentityServer4.Admin.Api/Configuration/Test/StartupTest.cs
+++ b/src/Skoruba.IdentityServer4.Admin.Api/Configuration/Test/StartupTest.cs
@@ -1,5 +1,4 @@
-﻿using IdentityServer4.AccessTokenValidation;
-using Microsoft.AspNetCore.Authentication.Cookies;
+using IdentityServer4.AccessTokenValidation;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Identity;
@@ -9,6 +8,7 @@ using Skoruba.IdentityServer4.Admin.Api.Helpers;
 using Skoruba.IdentityServer4.Admin.Api.Middlewares;
 using Skoruba.IdentityServer4.Admin.EntityFramework.Shared.DbContexts;
 using Skoruba.IdentityServer4.Admin.EntityFramework.Shared.Entities.Identity;
+using Skoruba.IdentityServer4.Admin.EntityFramework.Shared.Helpers;
 
 namespace Skoruba.IdentityServer4.Admin.Api.Configuration.Test
 {
@@ -16,11 +16,6 @@ namespace Skoruba.IdentityServer4.Admin.Api.Configuration.Test
     {
         public StartupTest(IWebHostEnvironment env, IConfiguration configuration) : base(env, configuration)
         {
-        }
-
-        public override void RegisterDbContexts(IServiceCollection services)
-        {
-            services.RegisterDbContextsStaging<AdminIdentityDbContext, IdentityServerConfigurationDbContext, IdentityServerPersistedGrantDbContext, AdminLogDbContext, AdminAuditLogDbContext>();
         }
 
         public override void RegisterAuthentication(IServiceCollection services)
@@ -48,6 +43,11 @@ namespace Skoruba.IdentityServer4.Admin.Api.Configuration.Test
         {
             app.UseAuthentication();
             app.UseMiddleware<AuthenticatedTestRequestMiddleware>();
+        }
+
+        protected override void DoStartupPostProcessing(IApplicationBuilder app)
+        {
+            DbHelpers.ResetDb(app.ApplicationServices);
         }
     }
 }

--- a/src/Skoruba.IdentityServer4.Admin.Api/Startup.cs
+++ b/src/Skoruba.IdentityServer4.Admin.Api/Startup.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using HealthChecks.UI.Client;
 using Microsoft.AspNetCore.Builder;
@@ -134,6 +134,8 @@ namespace Skoruba.IdentityServer4.Admin.Api
                     ResponseWriter = UIResponseWriter.WriteHealthCheckUIResponse
                 });
             });
+
+            DoStartupPostProcessing(app);
         }
 
         public virtual void RegisterDbContexts(IServiceCollection services)
@@ -155,6 +157,10 @@ namespace Skoruba.IdentityServer4.Admin.Api
         public virtual void UseAuthentication(IApplicationBuilder app)
         {
             app.UseAuthentication();
+        }
+
+        protected virtual void DoStartupPostProcessing(IApplicationBuilder app)
+        {
         }
     }
 }

--- a/src/Skoruba.IdentityServer4.Admin.Api/appsettings.json
+++ b/src/Skoruba.IdentityServer4.Admin.Api/appsettings.json
@@ -1,10 +1,10 @@
 {
     "ConnectionStrings": {
-        "ConfigurationDbConnection": "server=localhost;port=3306;database=IdentityServer4Admin;user=root;password=Password12!;",
-        "PersistedGrantDbConnection": "server=localhost;port=3306;database=IdentityServer4Admin;user=root;password=Password12!;",
-        "IdentityDbConnection": "server=localhost;port=3306;database=IdentityServer4Admin;user=root;password=Password12!;",
-        "AdminLogDbConnection": "server=localhost;port=3306;database=IdentityServer4Admin;user=root;password=Password12!;",
-        "AdminAuditLogDbConnection": "server=localhost;port=3306;database=IdentityServer4Admin;user=root;password=Password12!;"
+        "ConfigurationDbConnection": "server=localhost;port=3306;database=configuration;user=root;password=Password12!;",
+        "PersistedGrantDbConnection": "server=localhost;port=3306;database=persistedgrant;user=root;password=Password12!;",
+        "IdentityDbConnection": "server=localhost;port=3306;database=identity;user=root;password=Password12!;",
+        "AdminLogDbConnection": "server=localhost;port=3306;database=adminlog;user=root;password=Password12!;",
+        "AdminAuditLogDbConnection": "server=localhost;port=3306;database=adminauditlog;user=root;password=Password12!;"
     },
     "DatabaseProviderConfiguration": {
         "ProviderType": "MySql"

--- a/src/Skoruba.IdentityServer4.Admin.Api/appsettings.json
+++ b/src/Skoruba.IdentityServer4.Admin.Api/appsettings.json
@@ -4,9 +4,9 @@
         "PersistedGrantDbConnection": "server=localhost;port=3306;database=persistedgrant;user=root;password=Password12!;",
         "IdentityDbConnection": "server=localhost;port=3306;database=identity;user=root;password=Password12!;",
         "AdminLogDbConnection": "server=localhost;port=3306;database=adminlog;user=root;password=Password12!;",
-        "AdminAuditLogDbConnection": "Server=(localdb)\\mssqllocaldb;Database=IdentityServer4Admin;Trusted_Connection=True;MultipleActiveResultSets=true",
-        "DataProtectionDbConnection": "Server=(localdb)\\mssqllocaldb;Database=IdentityServer4Admin;Trusted_Connection=True;MultipleActiveResultSets=true"
-    },
+        "AdminAuditLogDbConnection": "server=localhost;port=3306;database=adminauditlog;user=root;password=Password12!;",
+        "DataProtectionDbConnection": "server=localhost;port=3306;database=dataprotection;user=root;password=Password12!;"
+        },
     "DatabaseProviderConfiguration": {
         "ProviderType": "MySql"
     },

--- a/src/Skoruba.IdentityServer4.Admin.Api/appsettings.json
+++ b/src/Skoruba.IdentityServer4.Admin.Api/appsettings.json
@@ -1,10 +1,13 @@
 {
     "ConnectionStrings": {
-        "ConfigurationDbConnection": "Server=(localdb)\\mssqllocaldb;Database=IdentityServer4Admin;Trusted_Connection=True;MultipleActiveResultSets=true",
-        "PersistedGrantDbConnection": "Server=(localdb)\\mssqllocaldb;Database=IdentityServer4Admin;Trusted_Connection=True;MultipleActiveResultSets=true",
-        "IdentityDbConnection": "Server=(localdb)\\mssqllocaldb;Database=IdentityServer4Admin;Trusted_Connection=True;MultipleActiveResultSets=true",
-        "AdminLogDbConnection": "Server=(localdb)\\mssqllocaldb;Database=IdentityServer4Admin;Trusted_Connection=True;MultipleActiveResultSets=true",
-        "AdminAuditLogDbConnection": "Server=(localdb)\\mssqllocaldb;Database=IdentityServer4Admin;Trusted_Connection=True;MultipleActiveResultSets=true"
+        "ConfigurationDbConnection": "server=localhost;port=3306;database=IdentityServer4Admin;user=root;password=Password12!;",
+        "PersistedGrantDbConnection": "server=localhost;port=3306;database=IdentityServer4Admin;user=root;password=Password12!;",
+        "IdentityDbConnection": "server=localhost;port=3306;database=IdentityServer4Admin;user=root;password=Password12!;",
+        "AdminLogDbConnection": "server=localhost;port=3306;database=IdentityServer4Admin;user=root;password=Password12!;",
+        "AdminAuditLogDbConnection": "server=localhost;port=3306;database=IdentityServer4Admin;user=root;password=Password12!;"
+    },
+    "DatabaseProviderConfiguration": {
+        "ProviderType": "MySql"
     },
     "AdminApiConfiguration": {
         "ApiName": "Skoruba IdentityServer4 Admin Api",
@@ -17,9 +20,6 @@
         "RequireHttpsMetadata": false,
         "CorsAllowAnyOrigin": true,
         "CorsAllowOrigins": []
-    },
-    "DatabaseProviderConfiguration": {
-        "ProviderType": "SqlServer"
     },
     "AuditLoggingConfiguration": {
         "Source": "IdentityServer.Admin.Api",

--- a/src/Skoruba.IdentityServer4.Admin.EntityFramework.MySql/Extensions/DatabaseExtensions.cs
+++ b/src/Skoruba.IdentityServer4.Admin.EntityFramework.MySql/Extensions/DatabaseExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System.Reflection;
+using System.Reflection;
 using IdentityServer4.EntityFramework.Storage;
 using Microsoft.AspNetCore.DataProtection.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
@@ -26,11 +26,20 @@ namespace Skoruba.IdentityServer4.Admin.EntityFramework.MySql.Extensions
         /// <param name="persistedGrantConnectionString"></param>
         /// <param name="errorLoggingConnectionString"></param>
         /// <param name="auditLoggingConnectionString"></param>
-        public static void RegisterMySqlDbContexts<TIdentityDbContext, TConfigurationDbContext,
-            TPersistedGrantDbContext, TLogDbContext, TAuditLoggingDbContext, TDataProtectionDbContext>(this IServiceCollection services,
-            string identityConnectionString, string configurationConnectionString,
-            string persistedGrantConnectionString, string errorLoggingConnectionString,
-            string auditLoggingConnectionString, string dataProtectionConnectionString = null)
+        public static void RegisterMySqlDbContexts<
+            TIdentityDbContext, 
+            TConfigurationDbContext,
+            TPersistedGrantDbContext, 
+            TLogDbContext, 
+            TAuditLoggingDbContext, 
+            TDataProtectionDbContext>(
+                this IServiceCollection services,
+                string identityConnectionString, 
+                string configurationConnectionString,
+                string persistedGrantConnectionString, 
+                string errorLoggingConnectionString,
+                string auditLoggingConnectionString, 
+                string dataProtectionConnectionString = null)
             where TIdentityDbContext : DbContext
             where TPersistedGrantDbContext : DbContext, IAdminPersistedGrantDbContext
             where TConfigurationDbContext : DbContext, IAdminConfigurationDbContext
@@ -78,10 +87,16 @@ namespace Skoruba.IdentityServer4.Admin.EntityFramework.MySql.Extensions
         /// <param name="identityConnectionString"></param>
         /// <param name="configurationConnectionString"></param>
         /// <param name="persistedGrantConnectionString"></param>
-        public static void RegisterMySqlDbContexts<TIdentityDbContext, TConfigurationDbContext,
-            TPersistedGrantDbContext, TDataProtectionDbContext>(this IServiceCollection services,
-            string identityConnectionString, string configurationConnectionString,
-            string persistedGrantConnectionString, string dataProtectionConnectionString)
+        public static void RegisterMySqlDbContexts<
+            TIdentityDbContext, 
+            TConfigurationDbContext,
+            TPersistedGrantDbContext, 
+            TDataProtectionDbContext>(
+                this IServiceCollection services,
+                string identityConnectionString, 
+                string configurationConnectionString,
+                string persistedGrantConnectionString, 
+                string dataProtectionConnectionString)
             where TIdentityDbContext : DbContext
             where TPersistedGrantDbContext : DbContext, IAdminPersistedGrantDbContext
             where TConfigurationDbContext : DbContext, IAdminConfigurationDbContext

--- a/src/Skoruba.IdentityServer4.Admin.EntityFramework.Shared/Helpers/DbHelpers.cs
+++ b/src/Skoruba.IdentityServer4.Admin.EntityFramework.Shared/Helpers/DbHelpers.cs
@@ -1,0 +1,37 @@
+using System;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Skoruba.IdentityServer4.Admin.EntityFramework.Shared.DbContexts;
+
+namespace Skoruba.IdentityServer4.Admin.EntityFramework.Shared.Helpers
+{
+    public class DbHelpers
+    {
+        public static void ResetDb(IServiceProvider provider)
+        {
+            using (var scope = provider.GetRequiredService<IServiceScopeFactory>().CreateScope())
+            {
+                ResetDb(scope.ServiceProvider.GetService<AdminIdentityDbContext>());
+                ResetDb(scope.ServiceProvider.GetService<IdentityServerPersistedGrantDbContext>());
+                ResetDb(scope.ServiceProvider.GetService<IdentityServerConfigurationDbContext>());
+                ResetDb(scope.ServiceProvider.GetService<IdentityServerDataProtectionDbContext>());
+                ResetDb(scope.ServiceProvider.GetService<AdminLogDbContext>());
+                ResetDb(scope.ServiceProvider.GetService<AdminAuditLogDbContext>());
+            }
+        }
+
+        private static void ResetDb(DbContext context)
+        {
+            if (context == null)
+            {
+                return;
+            }
+
+            using (context)
+            {
+                context.Database.EnsureDeleted();
+                context.Database.EnsureCreated();
+            }
+        }
+    }
+}

--- a/src/Skoruba.IdentityServer4.Admin/Configuration/Test/StartupTest.cs
+++ b/src/Skoruba.IdentityServer4.Admin/Configuration/Test/StartupTest.cs
@@ -1,4 +1,4 @@
-using IdentityServer4.EntityFramework.DbContexts;
+using System;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
@@ -14,19 +14,6 @@ namespace Skoruba.IdentityServer4.Admin.Configuration.Test
     {
         public StartupTest(IWebHostEnvironment env, IConfiguration configuration) : base(env, configuration)
         {
-        }
-
-        public override void RegisterDbContexts(IServiceCollection services)
-        {
-            services.RegisterDbContexts<
-                AdminIdentityDbContext,
-                IdentityServerConfigurationDbContext,
-                IdentityServerPersistedGrantDbContext,
-                AdminLogDbContext,
-                AdminAuditLogDbContext,
-                IdentityServerDataProtectionDbContext>(Configuration);
-
-            EnsureDatabaseCreated(services);
         }
 
         public override void RegisterAuthentication(IServiceCollection services)
@@ -46,10 +33,13 @@ namespace Skoruba.IdentityServer4.Admin.Configuration.Test
             app.UseMiddleware<AuthenticatedTestRequestMiddleware>();
         }
 
-        private void EnsureDatabaseCreated(IServiceCollection services)
+        protected override void DoStartupPostProcessing(IApplicationBuilder app)
         {
-            ServiceProvider provider = services.BuildServiceProvider();
+            EnsureDatabaseCreated(app.ApplicationServices);
+        }
 
+        private void EnsureDatabaseCreated(IServiceProvider provider)
+        {
             using (var scope = provider.GetRequiredService<IServiceScopeFactory>().CreateScope())
             {
                 using (var context = scope.ServiceProvider.GetRequiredService<IdentityServerPersistedGrantDbContext>())

--- a/src/Skoruba.IdentityServer4.Admin/Configuration/Test/StartupTest.cs
+++ b/src/Skoruba.IdentityServer4.Admin/Configuration/Test/StartupTest.cs
@@ -1,11 +1,11 @@
 using System;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Skoruba.IdentityServer4.Admin.EntityFramework.Shared.DbContexts;
 using Skoruba.IdentityServer4.Admin.EntityFramework.Shared.Entities.Identity;
+using Skoruba.IdentityServer4.Admin.EntityFramework.Shared.Helpers;
 using Skoruba.IdentityServer4.Admin.Helpers;
 using Skoruba.IdentityServer4.Admin.Middlewares;
 
@@ -36,49 +36,7 @@ namespace Skoruba.IdentityServer4.Admin.Configuration.Test
 
         protected override void DoStartupPostProcessing(IApplicationBuilder app)
         {
-            ResetDb(app.ApplicationServices);
-        }
-
-        private void ResetDb(IServiceProvider provider)
-        {
-            using (var scope = provider.GetRequiredService<IServiceScopeFactory>().CreateScope())
-            {
-                using (var context = scope.ServiceProvider.GetRequiredService<IdentityServerPersistedGrantDbContext>())
-                {
-                    context.Database.EnsureDeleted();
-                    context.Database.EnsureCreated();
-                }
-
-                using (var context = scope.ServiceProvider.GetRequiredService<AdminIdentityDbContext>())
-                {
-                    context.Database.EnsureDeleted();
-                    context.Database.EnsureCreated();
-                }
-
-                using (var context = scope.ServiceProvider.GetRequiredService<IdentityServerConfigurationDbContext>())
-                {
-                    context.Database.EnsureDeleted();
-                    context.Database.EnsureCreated();
-                }
-
-                using (var context = scope.ServiceProvider.GetRequiredService<AdminLogDbContext>())
-                {
-                    context.Database.EnsureDeleted();
-                    context.Database.EnsureCreated();
-                }
-
-                using (var context = scope.ServiceProvider.GetRequiredService<AdminAuditLogDbContext>())
-                {
-                    context.Database.EnsureDeleted();
-                    context.Database.EnsureCreated();
-                }
-
-                using (var context = scope.ServiceProvider.GetRequiredService<IdentityServerDataProtectionDbContext>())
-                {
-                    context.Database.EnsureDeleted();
-                    context.Database.EnsureCreated();
-                }
-            }
+            DbHelpers.ResetDb(app.ApplicationServices);
         }
     }
 }

--- a/src/Skoruba.IdentityServer4.Admin/Configuration/Test/StartupTest.cs
+++ b/src/Skoruba.IdentityServer4.Admin/Configuration/Test/StartupTest.cs
@@ -15,6 +15,19 @@ namespace Skoruba.IdentityServer4.Admin.Configuration.Test
         {
         }
 
+        public override void RegisterDbContexts(IServiceCollection services)
+        {
+            services.RegisterDbContexts<
+                AdminIdentityDbContext, 
+                IdentityServerConfigurationDbContext, 
+                IdentityServerPersistedGrantDbContext, 
+                AdminLogDbContext, 
+                AdminAuditLogDbContext, 
+                IdentityServerDataProtectionDbContext>(Configuration);
+
+            EnsureDatabaseMigrated(services);
+        }
+
         public override void RegisterAuthentication(IServiceCollection services)
         {
             services.AddAuthenticationServicesStaging<AdminIdentityDbContext, UserIdentity, UserIdentityRole>();
@@ -30,6 +43,17 @@ namespace Skoruba.IdentityServer4.Admin.Configuration.Test
         {
             app.UseAuthentication();
             app.UseMiddleware<AuthenticatedTestRequestMiddleware>();
+        }
+
+        private async void EnsureDatabaseMigrated(IServiceCollection services)
+        {
+            await DbMigrationHelpers.EnsureDatabasesMigrated<
+                AdminIdentityDbContext,
+                IdentityServerConfigurationDbContext, 
+                IdentityServerPersistedGrantDbContext, 
+                AdminLogDbContext, 
+                AdminAuditLogDbContext, 
+                IdentityServerDataProtectionDbContext>(services.BuildServiceProvider());
         }
     }
 }

--- a/src/Skoruba.IdentityServer4.Admin/Configuration/Test/StartupTest.cs
+++ b/src/Skoruba.IdentityServer4.Admin/Configuration/Test/StartupTest.cs
@@ -36,41 +36,47 @@ namespace Skoruba.IdentityServer4.Admin.Configuration.Test
 
         protected override void DoStartupPostProcessing(IApplicationBuilder app)
         {
-            MigrateDb(app.ApplicationServices);
+            ResetDb(app.ApplicationServices);
         }
 
-        private void MigrateDb(IServiceProvider provider)
+        private void ResetDb(IServiceProvider provider)
         {
             using (var scope = provider.GetRequiredService<IServiceScopeFactory>().CreateScope())
             {
                 using (var context = scope.ServiceProvider.GetRequiredService<IdentityServerPersistedGrantDbContext>())
                 {
-                    context.Database.Migrate();
+                    context.Database.EnsureDeleted();
+                    context.Database.EnsureCreated();
                 }
 
                 using (var context = scope.ServiceProvider.GetRequiredService<AdminIdentityDbContext>())
                 {
-                    context.Database.Migrate();
+                    context.Database.EnsureDeleted();
+                    context.Database.EnsureCreated();
                 }
 
                 using (var context = scope.ServiceProvider.GetRequiredService<IdentityServerConfigurationDbContext>())
                 {
-                    context.Database.Migrate();
+                    context.Database.EnsureDeleted();
+                    context.Database.EnsureCreated();
                 }
 
                 using (var context = scope.ServiceProvider.GetRequiredService<AdminLogDbContext>())
                 {
-                    context.Database.Migrate();
+                    context.Database.EnsureDeleted();
+                    context.Database.EnsureCreated();
                 }
 
                 using (var context = scope.ServiceProvider.GetRequiredService<AdminAuditLogDbContext>())
                 {
-                    context.Database.Migrate();
+                    context.Database.EnsureDeleted();
+                    context.Database.EnsureCreated();
                 }
 
                 using (var context = scope.ServiceProvider.GetRequiredService<IdentityServerDataProtectionDbContext>())
                 {
-                    context.Database.Migrate();
+                    context.Database.EnsureDeleted();
+                    context.Database.EnsureCreated();
                 }
             }
         }

--- a/src/Skoruba.IdentityServer4.Admin/Configuration/Test/StartupTest.cs
+++ b/src/Skoruba.IdentityServer4.Admin/Configuration/Test/StartupTest.cs
@@ -1,6 +1,7 @@
 using System;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Skoruba.IdentityServer4.Admin.EntityFramework.Shared.DbContexts;
@@ -35,41 +36,41 @@ namespace Skoruba.IdentityServer4.Admin.Configuration.Test
 
         protected override void DoStartupPostProcessing(IApplicationBuilder app)
         {
-            EnsureDatabaseCreated(app.ApplicationServices);
+            MigrateDb(app.ApplicationServices);
         }
 
-        private void EnsureDatabaseCreated(IServiceProvider provider)
+        private void MigrateDb(IServiceProvider provider)
         {
             using (var scope = provider.GetRequiredService<IServiceScopeFactory>().CreateScope())
             {
                 using (var context = scope.ServiceProvider.GetRequiredService<IdentityServerPersistedGrantDbContext>())
                 {
-                    context.Database.EnsureCreated();
+                    context.Database.Migrate();
                 }
 
                 using (var context = scope.ServiceProvider.GetRequiredService<AdminIdentityDbContext>())
                 {
-                    context.Database.EnsureCreated();
+                    context.Database.Migrate();
                 }
 
                 using (var context = scope.ServiceProvider.GetRequiredService<IdentityServerConfigurationDbContext>())
                 {
-                    context.Database.EnsureCreated();
+                    context.Database.Migrate();
                 }
 
                 using (var context = scope.ServiceProvider.GetRequiredService<AdminLogDbContext>())
                 {
-                    context.Database.EnsureCreated();
+                    context.Database.Migrate();
                 }
 
                 using (var context = scope.ServiceProvider.GetRequiredService<AdminAuditLogDbContext>())
                 {
-                    context.Database.EnsureCreated();
+                    context.Database.Migrate();
                 }
 
                 using (var context = scope.ServiceProvider.GetRequiredService<IdentityServerDataProtectionDbContext>())
                 {
-                    context.Database.EnsureCreated();
+                    context.Database.Migrate();
                 }
             }
         }

--- a/src/Skoruba.IdentityServer4.Admin/Configuration/Test/StartupTest.cs
+++ b/src/Skoruba.IdentityServer4.Admin/Configuration/Test/StartupTest.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -13,11 +13,6 @@ namespace Skoruba.IdentityServer4.Admin.Configuration.Test
     {
         public StartupTest(IWebHostEnvironment env, IConfiguration configuration) : base(env, configuration)
         {
-        }
-
-        public override void RegisterDbContexts(IServiceCollection services)
-        {
-            services.RegisterDbContextsStaging<AdminIdentityDbContext, IdentityServerConfigurationDbContext, IdentityServerPersistedGrantDbContext, AdminLogDbContext, AdminAuditLogDbContext, IdentityServerDataProtectionDbContext>();
         }
 
         public override void RegisterAuthentication(IServiceCollection services)

--- a/src/Skoruba.IdentityServer4.Admin/Startup.cs
+++ b/src/Skoruba.IdentityServer4.Admin/Startup.cs
@@ -1,4 +1,4 @@
-﻿using System.IdentityModel.Tokens.Jwt;
+using System.IdentityModel.Tokens.Jwt;
 using HealthChecks.UI.Client;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
@@ -8,7 +8,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Skoruba.AuditLogging.EntityFramework.Entities;
-using Skoruba.IdentityServer4.Admin.BusinessLogic.Identity.Dtos.Identity;
 using Skoruba.IdentityServer4.Admin.Configuration.Interfaces;
 using Skoruba.IdentityServer4.Admin.EntityFramework.Shared.DbContexts;
 using Skoruba.IdentityServer4.Admin.EntityFramework.Shared.Entities.Identity;
@@ -122,6 +121,8 @@ namespace Skoruba.IdentityServer4.Admin
                     ResponseWriter = UIResponseWriter.WriteHealthCheckUIResponse
                 });
             });
+
+            DoStartupPostProcessing(app);
         }
 
         public virtual void RegisterDbContexts(IServiceCollection services)
@@ -154,6 +155,10 @@ namespace Skoruba.IdentityServer4.Admin
                 options.IncludeSubDomains = true;
                 options.MaxAge = TimeSpan.FromDays(365);
             });
+        }
+
+        protected virtual void DoStartupPostProcessing(IApplicationBuilder app)
+        {
         }
 
         protected IRootConfiguration CreateRootConfiguration()

--- a/src/Skoruba.IdentityServer4.Admin/appsettings.json
+++ b/src/Skoruba.IdentityServer4.Admin/appsettings.json
@@ -1,11 +1,11 @@
 {
   "ConnectionStrings": {
-    "ConfigurationDbConnection": "server=localhost;port=3306;database=IdentityServer4Admin;user=root;password=Password12!;",
-    "PersistedGrantDbConnection": "server=localhost;port=3306;database=IdentityServer4Admin;user=root;password=Password12!;",
-    "IdentityDbConnection": "server=localhost;port=3306;database=IdentityServer4Admin;user=root;password=Password12!;",
-    "AdminLogDbConnection": "server=localhost;port=3306;database=IdentityServer4Admin;user=root;password=Password12!;",
-    "AdminAuditLogDbConnection": "server=localhost;port=3306;database=IdentityServer4Admin;user=root;password=Password12!;",
-    "DataProtectionDbConnection": "server=localhost;port=3306;database=IdentityServer4Admin;user=root;password=Password12!;"
+    "ConfigurationDbConnection": "server=localhost;port=3306;database=configuration;user=root;password=Password12!;",
+    "PersistedGrantDbConnection": "server=localhost;port=3306;database=persistedgrant;user=root;password=Password12!;",
+    "IdentityDbConnection": "server=localhost;port=3306;database=identity;user=root;password=Password12!;",
+    "AdminLogDbConnection": "server=localhost;port=3306;database=adminlog;user=root;password=Password12!;",
+    "AdminAuditLogDbConnection": "server=localhost;port=3306;database=adminauditlog;user=root;password=Password12!;",
+    "DataProtectionDbConnection": "server=localhost;port=3306;database=dataprotection;user=root;password=Password12!;"
   },
   "DatabaseProviderConfiguration": {
     "ProviderType": "MySql"

--- a/src/Skoruba.IdentityServer4.Admin/appsettings.json
+++ b/src/Skoruba.IdentityServer4.Admin/appsettings.json
@@ -1,14 +1,14 @@
-﻿{
+{
   "ConnectionStrings": {
-    "ConfigurationDbConnection": "Server=(localdb)\\mssqllocaldb;Database=IdentityServer4Admin;Trusted_Connection=True;MultipleActiveResultSets=true",
-    "PersistedGrantDbConnection": "Server=(localdb)\\mssqllocaldb;Database=IdentityServer4Admin;Trusted_Connection=True;MultipleActiveResultSets=true",
-    "IdentityDbConnection": "Server=(localdb)\\mssqllocaldb;Database=IdentityServer4Admin;Trusted_Connection=True;MultipleActiveResultSets=true",
-    "AdminLogDbConnection": "Server=(localdb)\\mssqllocaldb;Database=IdentityServer4Admin;Trusted_Connection=True;MultipleActiveResultSets=true",
-    "AdminAuditLogDbConnection": "Server=(localdb)\\mssqllocaldb;Database=IdentityServer4Admin;Trusted_Connection=True;MultipleActiveResultSets=true",
-    "DataProtectionDbConnection": "Server=(localdb)\\mssqllocaldb;Database=IdentityServer4Admin;Trusted_Connection=True;MultipleActiveResultSets=true"
+    "ConfigurationDbConnection": "server=localhost;port=3306;database=IdentityServer4Admin;user=root;password=Password12!;",
+    "PersistedGrantDbConnection": "server=localhost;port=3306;database=IdentityServer4Admin;user=root;password=Password12!;",
+    "IdentityDbConnection": "server=localhost;port=3306;database=IdentityServer4Admin;user=root;password=Password12!;",
+    "AdminLogDbConnection": "server=localhost;port=3306;database=IdentityServer4Admin;user=root;password=Password12!;",
+    "AdminAuditLogDbConnection": "server=localhost;port=3306;database=IdentityServer4Admin;user=root;password=Password12!;",
+    "DataProtectionDbConnection": "server=localhost;port=3306;database=IdentityServer4Admin;user=root;password=Password12!;"
   },
   "DatabaseProviderConfiguration": {
-    "ProviderType": "SqlServer"
+    "ProviderType": "MySql"
   },
   "AdminConfiguration": {
     "PageTitle": "Skoruba IdentityServer4 Admin",

--- a/src/Skoruba.IdentityServer4.STS.Identity/appsettings.json
+++ b/src/Skoruba.IdentityServer4.STS.Identity/appsettings.json
@@ -1,12 +1,12 @@
-﻿{
+{
   "ConnectionStrings": {
-    "ConfigurationDbConnection": "Server=(localdb)\\mssqllocaldb;Database=IdentityServer4Admin;Trusted_Connection=True;MultipleActiveResultSets=true",
-    "PersistedGrantDbConnection": "Server=(localdb)\\mssqllocaldb;Database=IdentityServer4Admin;Trusted_Connection=True;MultipleActiveResultSets=true",
-    "IdentityDbConnection": "Server=(localdb)\\mssqllocaldb;Database=IdentityServer4Admin;Trusted_Connection=True;MultipleActiveResultSets=true",
-    "DataProtectionDbConnection": "Server=(localdb)\\mssqllocaldb;Database=IdentityServer4Admin;Trusted_Connection=True;MultipleActiveResultSets=true"
+    "ConfigurationDbConnection": "server=localhost;port=3306;database=IdentityServer4Admin;user=root;password=Password12!;",
+    "PersistedGrantDbConnection": "server=localhost;port=3306;database=IdentityServer4Admin;user=root;password=Password12!;",
+    "IdentityDbConnection": "server=localhost;port=3306;database=IdentityServer4Admin;user=root;password=Password12!;",
+    "DataProtectionDbConnection": "server=localhost;port=3306;database=IdentityServer4Admin;user=root;password=Password12!;"
   },
   "DatabaseProviderConfiguration": {
-    "ProviderType": "SqlServer"
+    "ProviderType": "MySql"
   },
   "CertificateConfiguration": {
 

--- a/src/Skoruba.IdentityServer4.STS.Identity/appsettings.json
+++ b/src/Skoruba.IdentityServer4.STS.Identity/appsettings.json
@@ -1,9 +1,9 @@
 {
   "ConnectionStrings": {
-    "ConfigurationDbConnection": "server=localhost;port=3306;database=IdentityServer4Admin;user=root;password=Password12!;",
-    "PersistedGrantDbConnection": "server=localhost;port=3306;database=IdentityServer4Admin;user=root;password=Password12!;",
-    "IdentityDbConnection": "server=localhost;port=3306;database=IdentityServer4Admin;user=root;password=Password12!;",
-    "DataProtectionDbConnection": "server=localhost;port=3306;database=IdentityServer4Admin;user=root;password=Password12!;"
+    "ConfigurationDbConnection": "server=localhost;port=3306;database=configuration;user=root;password=Password12!;",
+    "PersistedGrantDbConnection": "server=localhost;port=3306;database=persistedgrant;user=root;password=Password12!;",
+    "IdentityDbConnection": "server=localhost;port=3306;database=identity;user=root;password=Password12!;",
+    "DataProtectionDbConnection": "server=localhost;port=3306;database=dataprotection;user=root;password=Password12!;"
   },
   "DatabaseProviderConfiguration": {
     "ProviderType": "MySql"

--- a/tests/Skoruba.IdentityServer4.Admin.Api.IntegrationTests/Skoruba.IdentityServer4.Admin.Api.IntegrationTests.csproj
+++ b/tests/Skoruba.IdentityServer4.Admin.Api.IntegrationTests/Skoruba.IdentityServer4.Admin.Api.IntegrationTests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFramework>netcoreapp3.1</TargetFramework>
@@ -6,6 +6,10 @@
         <IsPackable>false</IsPackable>
         <DebugType>Full</DebugType>
     </PropertyGroup>
+
+    <ItemGroup>
+        <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
+    </ItemGroup>
 
     <ItemGroup>
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.1" />

--- a/tests/Skoruba.IdentityServer4.Admin.Api.IntegrationTests/xunit.runner.json
+++ b/tests/Skoruba.IdentityServer4.Admin.Api.IntegrationTests/xunit.runner.json
@@ -1,0 +1,7 @@
+{
+    "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
+    "diagnosticMessages": true,
+    "longRunningTestSeconds": 600,
+    "parallelizeTestCollections": false,
+    "methodDisplay": "method"
+}

--- a/tests/Skoruba.IdentityServer4.Admin.IntegrationTests/Skoruba.IdentityServer4.Admin.IntegrationTests.csproj
+++ b/tests/Skoruba.IdentityServer4.Admin.IntegrationTests/Skoruba.IdentityServer4.Admin.IntegrationTests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFramework>netcoreapp3.1</TargetFramework>
@@ -6,6 +6,10 @@
 		<IsPackable>false</IsPackable>
 		<DebugType>Full</DebugType>
 	</PropertyGroup>
+
+	<ItemGroup>
+		<Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
+	</ItemGroup>
 
 	<ItemGroup>
 		<PackageReference Include="coverlet.msbuild" Version="2.8.0">

--- a/tests/Skoruba.IdentityServer4.Admin.IntegrationTests/xunit.runner.json
+++ b/tests/Skoruba.IdentityServer4.Admin.IntegrationTests/xunit.runner.json
@@ -1,0 +1,7 @@
+{
+    "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
+    "diagnosticMessages": true,
+    "longRunningTestSeconds": 600,
+    "parallelizeTestCollections": false,
+    "methodDisplay": "method"
+}


### PR DESCRIPTION
I gonna make this a draft, since this was meant primarily as proof of concept for the fix to the silently failing (false success) integration test.

A few things to note: 
- There are lots of commits, since this was mostly trial and error approach to find out the problem.
- If so desired, I can create a "cleaner" PR (more structured and less commits).
- Db config was read from  appsettings.json, I'm thinking of using other .json (appveyorsettings.json?) to store the test db config. Not sure how to do that though, any inputs are welcome :)
- I got my SSH public key there, because one of the builds get stuck and timed out. That would need to be change to template, or the SSH access might/should be removed.

Regards, Martinus