### PR TITLE
Add IdentityOptions configuration to appsettings.json 

### DIFF
--- a/src/Skoruba.IdentityServer4.Admin.Api/Configuration/Test/StartupTest.cs
+++ b/src/Skoruba.IdentityServer4.Admin.Api/Configuration/Test/StartupTest.cs
@@ -25,14 +25,8 @@ namespace Skoruba.IdentityServer4.Admin.Api.Configuration.Test
 
         public override void RegisterAuthentication(IServiceCollection services)
         {
-            var loginConfiguration = Configuration.GetSection(nameof(LoginConfiguration)).Get<LoginConfiguration>();
-            var registerConfiguration = Configuration.GetSection(nameof(RegisterConfiguration)).Get<RegisterConfiguration>();
-
-            services.AddIdentity<UserIdentity, UserIdentityRole>(options =>
-                {
-                    options.User.RequireUniqueEmail = loginConfiguration.RequireUniqueEmail;
-                    options.SignIn.RequireConfirmedAccount = registerConfiguration.RequireConfirmedAccount;
-                })
+            services
+                .AddIdentity<UserIdentity, UserIdentityRole>(options => Configuration.GetSection(nameof(IdentityOptions)).Bind(options))
                 .AddEntityFrameworkStores<AdminIdentityDbContext>()
                 .AddDefaultTokenProviders();
 

--- a/src/Skoruba.IdentityServer4.Admin.Api/Helpers/StartupHelpers.cs
+++ b/src/Skoruba.IdentityServer4.Admin.Api/Helpers/StartupHelpers.cs
@@ -183,14 +183,9 @@ namespace Skoruba.IdentityServer4.Admin.Api.Helpers
             where TUser : class
         {
             var adminApiConfiguration = configuration.GetSection(nameof(AdminApiConfiguration)).Get<AdminApiConfiguration>();
-            var loginConfiguration = configuration.GetSection(nameof(LoginConfiguration)).Get<LoginConfiguration>();
-            var registerConfiguration = configuration.GetSection(nameof(RegisterConfiguration)).Get<RegisterConfiguration>();
 
-            services.AddIdentity<TUser, TRole>(options =>
-                {
-                    options.User.RequireUniqueEmail = loginConfiguration.RequireUniqueEmail;
-                    options.SignIn.RequireConfirmedAccount = registerConfiguration.RequireConfirmedAccount;
-                })
+            services
+                .AddIdentity<TUser, TRole>(options => configuration.GetSection(nameof(IdentityOptions)).Bind(options))
                 .AddEntityFrameworkStores<TIdentityDbContext>()
                 .AddDefaultTokenProviders();
 

--- a/src/Skoruba.IdentityServer4.Admin.Api/appsettings.json
+++ b/src/Skoruba.IdentityServer4.Admin.Api/appsettings.json
@@ -28,10 +28,15 @@
         "SubjectNameClaim": "name",
         "ClientIdClaim": "client_id"
     },
-    "LoginConfiguration": {
-        "RequireUniqueEmail": true
-    },
-    "RegisterConfiguration": {
-        "RequireConfirmedAccount": false
+    "IdentityOptions": {
+        "Password": {
+          "RequiredLength": 8
+        },
+        "User": {
+          "RequireUniqueEmail": true
+        },
+        "SignIn": {
+          "RequireConfirmedAccount": false
+        }
     }
 }

--- a/src/Skoruba.IdentityServer4.Admin/Helpers/StartupHelpers.cs
+++ b/src/Skoruba.IdentityServer4.Admin/Helpers/StartupHelpers.cs
@@ -357,8 +357,6 @@ namespace Skoruba.IdentityServer4.Admin.Helpers
             where TContext : DbContext where TUserIdentity : class where TUserIdentityRole : class
         {
             var adminConfiguration = configuration.GetSection(nameof(AdminConfiguration)).Get<AdminConfiguration>();
-            var loginConfiguration = configuration.GetSection(nameof(LoginConfiguration)).Get<LoginConfiguration>();
-            var registerConfiguration = configuration.GetSection(nameof(RegisterConfiguration)).Get<RegisterConfiguration>();
 
             services.Configure<CookiePolicyOptions>(options =>
             {
@@ -370,11 +368,8 @@ namespace Skoruba.IdentityServer4.Admin.Helpers
                     AuthenticationHelpers.CheckSameSite(cookieContext.Context, cookieContext.CookieOptions);
             });
 
-            services.AddIdentity<TUserIdentity, TUserIdentityRole>(options =>
-                {
-                    options.User.RequireUniqueEmail = loginConfiguration.RequireUniqueEmail;
-                    options.SignIn.RequireConfirmedAccount = registerConfiguration.RequireConfirmedAccount;
-                })
+            services
+                .AddIdentity<TUserIdentity, TUserIdentityRole>(options => configuration.GetSection(nameof(IdentityOptions)).Bind(options))
                 .AddEntityFrameworkStores<TContext>()
                 .AddDefaultTokenProviders();
 

--- a/src/Skoruba.IdentityServer4.Admin/appsettings.json
+++ b/src/Skoruba.IdentityServer4.Admin/appsettings.json
@@ -49,10 +49,15 @@
         "DefaultCulture": null
     },
     "BasePath": "",
-    "LoginConfiguration": {
-        "RequireUniqueEmail": true
-    },
-    "RegisterConfiguration": {
+    "IdentityOptions": {
+        "Password": {
+          "RequiredLength": 8
+        },
+        "User": {
+          "RequireUniqueEmail": true
+        },
+      "SignIn": {
         "RequireConfirmedAccount": false
+      }
     }
 }

--- a/src/Skoruba.IdentityServer4.STS.Identity/Controllers/AccountController.cs
+++ b/src/Skoruba.IdentityServer4.STS.Identity/Controllers/AccountController.cs
@@ -49,6 +49,7 @@ namespace Skoruba.IdentityServer4.STS.Identity.Controllers
         private readonly IGenericControllerLocalizer<AccountController<TUser, TKey>> _localizer;
         private readonly LoginConfiguration _loginConfiguration;
         private readonly RegisterConfiguration _registerConfiguration;
+        private readonly IdentityOptions _identityOptions;
         private readonly ILogger<AccountController<TUser, TKey>> _logger;
 
         public AccountController(
@@ -63,6 +64,7 @@ namespace Skoruba.IdentityServer4.STS.Identity.Controllers
             IGenericControllerLocalizer<AccountController<TUser, TKey>> localizer,
             LoginConfiguration loginConfiguration,
             RegisterConfiguration registerConfiguration,
+            IdentityOptions identityOptions,
             ILogger<AccountController<TUser, TKey>> logger)
         {
             _userResolver = userResolver;
@@ -76,6 +78,7 @@ namespace Skoruba.IdentityServer4.STS.Identity.Controllers
             _localizer = localizer;
             _loginConfiguration = loginConfiguration;
             _registerConfiguration = registerConfiguration;
+            _identityOptions = identityOptions;
             _logger = logger;
         }
 
@@ -618,9 +621,9 @@ namespace Skoruba.IdentityServer4.STS.Identity.Controllers
 
                 await _emailSender.SendEmailAsync(model.Email, _localizer["ConfirmEmailTitle"], _localizer["ConfirmEmailBody", HtmlEncoder.Default.Encode(callbackUrl)]);
 
-                if (_registerConfiguration.RequireConfirmedAccount)
+                if (_identityOptions.SignIn.RequireConfirmedAccount)
                 {
-                    return RedirectToPage("RegisterConfirmation");
+                    return View("RegisterConfirmation");
                 }
                 else
                 {

--- a/src/Skoruba.IdentityServer4.STS.Identity/Helpers/StartupHelpers.cs
+++ b/src/Skoruba.IdentityServer4.STS.Identity/Helpers/StartupHelpers.cs
@@ -226,16 +226,14 @@ namespace Skoruba.IdentityServer4.STS.Identity.Helpers
         {
             var loginConfiguration = GetLoginConfiguration(configuration);
             var registrationConfiguration = GetRegistrationConfiguration(configuration);
+            var identityOptions = configuration.GetSection(nameof(IdentityOptions)).Get<IdentityOptions>();
 
             services
                 .AddSingleton(registrationConfiguration)
                 .AddSingleton(loginConfiguration)
+                .AddSingleton(identityOptions)
                 .AddScoped<UserResolver<TUserIdentity>>()
-                .AddIdentity<TUserIdentity, TUserIdentityRole>(options =>
-                {
-                    options.User.RequireUniqueEmail = loginConfiguration.RequireUniqueEmail;
-                    options.SignIn.RequireConfirmedEmail = registrationConfiguration.RequireConfirmedAccount;
-                })
+                .AddIdentity<TUserIdentity, TUserIdentityRole>(options => configuration.GetSection(nameof(IdentityOptions)).Bind(options))
                 .AddEntityFrameworkStores<TIdentityDbContext>()
                 .AddDefaultTokenProviders();
 

--- a/src/Skoruba.IdentityServer4.STS.Identity/appsettings.json
+++ b/src/Skoruba.IdentityServer4.STS.Identity/appsettings.json
@@ -30,8 +30,7 @@
         "ValidationCertificateThumbprint": ""
     },
     "RegisterConfiguration": {
-        "Enabled": true,
-        "RequireConfirmedAccount": false 
+        "Enabled": true
     },
     "ExternalProvidersConfiguration": {
         "UseGitHubProvider": false,
@@ -49,8 +48,7 @@
         "SourceName": ""
     },
     "LoginConfiguration": {
-        "ResolutionPolicy": "Username",
-        "RequireUniqueEmail": true 
+        "ResolutionPolicy": "Username"
     },
     "AdminConfiguration": {
         "PageTitle": "Skoruba IdentityServer4",
@@ -66,5 +64,16 @@
     "AdvancedConfiguration": {
         "PublicOrigin": ""
     },
-    "BasePath": ""
+    "BasePath": "",
+    "IdentityOptions": {
+        "Password": {
+          "RequiredLength": 8
+        },
+        "User": {
+          "RequireUniqueEmail": true
+        },
+        "SignIn": {
+          "RequireConfirmedAccount": false
+        }
+    }
 }

--- a/src/Skoruba.IdentityServer4.Shared/Configuration/Identity/LoginConfiguration.cs
+++ b/src/Skoruba.IdentityServer4.Shared/Configuration/Identity/LoginConfiguration.cs
@@ -3,7 +3,5 @@
     public class LoginConfiguration
     {
         public LoginResolutionPolicy ResolutionPolicy { get; set; } = LoginResolutionPolicy.Username;
-
-        public bool RequireUniqueEmail { get; set; } = true;
     }
 }

--- a/src/Skoruba.IdentityServer4.Shared/Configuration/Identity/RegisterConfiguration.cs
+++ b/src/Skoruba.IdentityServer4.Shared/Configuration/Identity/RegisterConfiguration.cs
@@ -3,7 +3,5 @@
     public class RegisterConfiguration
     {
         public bool Enabled { get; set; } = true;
-
-        public bool RequireConfirmedAccount { get; set; }
     }
 }


### PR DESCRIPTION
This adds IdentityOptions to configuration and make it possible to configure Password, SignIn, Lockout and User settings by using appsettings. 

Also this sets Password.RequiredLength from default 6 to 8 as this is standard today.

Best regards