### PR TITLE
Integration of configurable AzureAd Provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,17 +385,27 @@ or using `Email`:
 
 ## How to configure an external provider in STS
 
-- In `Skoruba.IdentityServer4.STS.Identity/Helpers/StartupHelpers.cs` - is method called `AddExternalProviders` which contains the example with `GitHub` and in `appsettings.json`:
+- In `Skoruba.IdentityServer4.STS.Identity/Helpers/StartupHelpers.cs` - is method called `AddExternalProviders` which contains the example with `GitHub`, `AzureAD` configured in `appsettings.json`:
 
 ```
 "ExternalProvidersConfiguration": {
         "UseGitHubProvider": false,
         "GitHubClientId": "",
-        "GitHubClientSecret": ""
+        "GitHubClientSecret": "",
+        "UseAzureAdProvider": false,
+        "AzureAdClientId": "",
+        "AzureAdTenantId": "",
+        "AzureInstance": "",
+        "AzureAdSecret": "",
+        "AzureAdCallbackPath": "",
+        "AzureDomain": "" 
 }
 ```
 
 - It is possible to extend `ExternalProvidersConfiguration` with another configuration properties.
+- If you use DockerHub built image, you can use appsettings to configure these providers without changing the code
+  - GitHub
+  - AzureAD
 
 ### List of external providers for ASP.NET Core:
   - https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers

--- a/src/Skoruba.IdentityServer4.STS.Identity/Configuration/ExternalProvidersConfiguration.cs
+++ b/src/Skoruba.IdentityServer4.STS.Identity/Configuration/ExternalProvidersConfiguration.cs
@@ -5,5 +5,13 @@
         public bool UseGitHubProvider { get; set; }
         public string GitHubClientId { get; set; }
         public string GitHubClientSecret { get; set; }
+
+        public bool UseAzureAdProvider { get; set; }
+        public string AzureAdClientId { get; set; }
+        public string AzureAdSecret { get; set; }
+        public string AzureAdTenantId { get; set; }
+        public string AzureInstance { get; set; }
+        public string AzureAdCallbackPath { get; set; }
+        public string AzureDomain { get; set; }
     }
 }

--- a/src/Skoruba.IdentityServer4.STS.Identity/Helpers/StartupHelpers.cs
+++ b/src/Skoruba.IdentityServer4.STS.Identity/Helpers/StartupHelpers.cs
@@ -22,6 +22,7 @@ using Skoruba.IdentityServer4.STS.Identity.Configuration.Constants;
 using Skoruba.IdentityServer4.STS.Identity.Configuration.Interfaces;
 using Skoruba.IdentityServer4.STS.Identity.Helpers.Localization;
 using System.Linq;
+using Microsoft.AspNetCore.Authentication.AzureAD.UI;
 using Skoruba.IdentityServer4.Admin.EntityFramework.Interfaces;
 using Skoruba.IdentityServer4.Admin.EntityFramework.MySql.Extensions;
 using Skoruba.IdentityServer4.Admin.EntityFramework.PostgreSQL.Extensions;
@@ -330,6 +331,20 @@ namespace Skoruba.IdentityServer4.STS.Identity.Helpers
                     options.ClientSecret = externalProviderConfiguration.GitHubClientSecret;
                     options.Scope.Add("user:email");
                 });
+            }
+
+            if (externalProviderConfiguration.UseAzureAdProvider)
+            {
+                authenticationBuilder.AddAzureAD(AzureADDefaults.AuthenticationScheme, AzureADDefaults.OpenIdScheme, AzureADDefaults.CookieScheme, AzureADDefaults.DisplayName,options =>
+                    {
+                        options.ClientSecret = externalProviderConfiguration.AzureAdSecret;
+                        options.ClientId = externalProviderConfiguration.AzureAdClientId;
+                        options.TenantId = externalProviderConfiguration.AzureAdTenantId;
+                        options.Instance = externalProviderConfiguration.AzureInstance;
+                        options.Domain = externalProviderConfiguration.AzureDomain;
+                        options.CallbackPath = externalProviderConfiguration.AzureAdCallbackPath;
+                        options.CookieSchemeName = IdentityConstants.ExternalScheme;
+                    });
             }
         }
 

--- a/src/Skoruba.IdentityServer4.STS.Identity/Skoruba.IdentityServer4.STS.Identity.csproj
+++ b/src/Skoruba.IdentityServer4.STS.Identity/Skoruba.IdentityServer4.STS.Identity.csproj
@@ -16,6 +16,7 @@
         <PackageReference Include="AspNetCore.HealthChecks.SqlServer" Version="3.1.1" />
         <PackageReference Include="AspNetCore.HealthChecks.UI" Version="3.1.1" />
         <PackageReference Include="AspNetCore.HealthChecks.UI.Client" Version="3.1.1" />
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.AzureAD.UI" Version="3.1.8" />
         <PackageReference Include="Microsoft.AspNetCore.DataProtection.EntityFrameworkCore" Version="3.1.6" />
         <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="3.1.6" />
         <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="3.1.6" />

--- a/src/Skoruba.IdentityServer4.STS.Identity/appsettings.json
+++ b/src/Skoruba.IdentityServer4.STS.Identity/appsettings.json
@@ -35,11 +35,18 @@
     "RegisterConfiguration": {
         "Enabled": true
     },
-    "ExternalProvidersConfiguration": {
-        "UseGitHubProvider": false,
-        "GitHubClientId": "",
-        "GitHubClientSecret": ""
-    },
+  "ExternalProvidersConfiguration": {
+    "UseGitHubProvider": false,
+    "GitHubClientId": "",
+    "GitHubClientSecret": "",
+    "UseAzureAdProvider": false,
+    "AzureAdClientId": "",
+    "AzureAdTenantId": "",
+    "AzureInstance": "",
+    "AzureAdSecret": "",
+    "AzureAdCallbackPath": "",
+    "AzureDomain": "" 
+  },
     "SmtpConfiguration": {
         "Host": "",
         "Login": "",


### PR DESCRIPTION
Hi,

Related to issue #701 

- Added AzureAd UI Dependency
- Integration of code as GitHub system already in-place
- Integration of configuration variables in appsettings

**Important Note: To prevent any breaking changes, i kept the externalprovider configuration structure but i think array structure will be better. We can imagine to add multiple providers configurable from appsettings.
Users can just use Docker image from docker hub instead of clone the project to change the code.**