### PR TITLE
CSP Configuration Trusted Domains from appsettings.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,17 +385,27 @@ or using `Email`:
 
 ## How to configure an external provider in STS
 
-- In `Skoruba.IdentityServer4.STS.Identity/Helpers/StartupHelpers.cs` - is method called `AddExternalProviders` which contains the example with `GitHub` and in `appsettings.json`:
+- In `Skoruba.IdentityServer4.STS.Identity/Helpers/StartupHelpers.cs` - is method called `AddExternalProviders` which contains the example with `GitHub`, `AzureAD` configured in `appsettings.json`:
 
 ```
 "ExternalProvidersConfiguration": {
         "UseGitHubProvider": false,
         "GitHubClientId": "",
-        "GitHubClientSecret": ""
+        "GitHubClientSecret": "",
+        "UseAzureAdProvider": false,
+        "AzureAdClientId": "",
+        "AzureAdTenantId": "",
+        "AzureInstance": "",
+        "AzureAdSecret": "",
+        "AzureAdCallbackPath": "",
+        "AzureDomain": "" 
 }
 ```
 
 - It is possible to extend `ExternalProvidersConfiguration` with another configuration properties.
+- If you use DockerHub built image, you can use appsettings to configure these providers without changing the code
+  - GitHub
+  - AzureAD
 
 ### List of external providers for ASP.NET Core:
   - https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers

--- a/README.md
+++ b/README.md
@@ -441,6 +441,17 @@ In STS project - in `appsettings.json`:
     }
 ```
 
+## CSP - Content Security Policy
+
+- If you want to use favicon or logo not included/hosted on the same place, you need to declare trusted domain where ressources are hosted in appsettings.json.
+
+```
+  "CspTrustedDomains": [
+    "google.com",
+    "mydomain.com"
+  ],
+```
+
 ## Health checks
 
 - AdminUI, AdminUI Api and STS contain endpoint `health`, which check databases and IdentityServer.

--- a/src/Skoruba.IdentityServer4.Admin/Configuration/Constants/ConfigurationConsts.cs
+++ b/src/Skoruba.IdentityServer4.Admin/Configuration/Constants/ConfigurationConsts.cs
@@ -1,4 +1,6 @@
-﻿namespace Skoruba.IdentityServer4.Admin.Configuration.Constants
+﻿using System.Collections.Generic;
+
+namespace Skoruba.IdentityServer4.Admin.Configuration.Constants
 {
     public class ConfigurationConsts
     {
@@ -23,5 +25,8 @@
         public const string AdminAuditLogDbConnectionStringKey = "AdminAuditLogDbConnection";
 
         public const string DataProtectionDbConnectionStringKey = "DataProtectionDbConnection";
+
+        public const string CspTrustedDomainsKey = "CspTrustedDomains";
+
     }
 }

--- a/src/Skoruba.IdentityServer4.Admin/Helpers/StartupHelpers.cs
+++ b/src/Skoruba.IdentityServer4.Admin/Helpers/StartupHelpers.cs
@@ -165,7 +165,8 @@ namespace Skoruba.IdentityServer4.Admin.Helpers
         /// Using of Forwarded Headers, Hsts, XXssProtection and Csp
         /// </summary>
         /// <param name="app"></param>
-        public static void UseSecurityHeaders(this IApplicationBuilder app)
+        /// <param name="configuration"></param>
+        public static void UseSecurityHeaders(this IApplicationBuilder app, IConfiguration configuration)
         {
             var forwardingOptions = new ForwardedHeadersOptions()
             {
@@ -181,35 +182,40 @@ namespace Skoruba.IdentityServer4.Admin.Helpers
             app.UseXContentTypeOptions();
             app.UseXfo(options => options.SameOrigin());
             app.UseReferrerPolicy(options => options.NoReferrer());
-            var allowCspUrls = new List<string>
+           
+            // CSP Configuration to be able to use external resources
+            var cspTrustedDomains = new List<string>();
+            configuration.GetSection(ConfigurationConsts.CspTrustedDomainsKey).Bind(cspTrustedDomains);
+            if (cspTrustedDomains.Any())
             {
-                "https://fonts.googleapis.com/",
-                "https://fonts.gstatic.com/"
-            };
-
-            app.UseCsp(options =>
-            {
-                options.FontSources(configuration =>
+                app.UseCsp(csp =>
                 {
-                    configuration.SelfSrc = true;
-                    configuration.CustomSources = allowCspUrls;
+                    csp.ImageSources(options =>
+                    {
+                        options.SelfSrc = true;
+                        options.CustomSources = cspTrustedDomains;
+                        options.Enabled = true;
+                    });
+                    csp.FontSources(options =>
+                    {
+                        options.SelfSrc = true;
+                        options.CustomSources = cspTrustedDomains;
+                        options.Enabled = true;
+                    });
+                    csp.ScriptSources(options =>
+                    {
+                        options.SelfSrc = true;
+                        options.CustomSources = cspTrustedDomains;
+                        options.Enabled = true;
+                    });
+                    csp.DefaultSources(options =>
+                    {
+                        options.SelfSrc = true;
+                        options.CustomSources = cspTrustedDomains;
+                        options.Enabled = true;
+                    });
                 });
-
-                //TODO: consider remove unsafe sources - currently using for toastr inline scripts in Notification.cshtml
-                options.ScriptSources(configuration =>
-                {
-                    configuration.SelfSrc = true;
-                    configuration.UnsafeInlineSrc = true;
-                    configuration.UnsafeEvalSrc = true;
-                });
-
-                options.StyleSources(configuration =>
-                {
-                    configuration.SelfSrc = true;
-                    configuration.CustomSources = allowCspUrls;
-                    configuration.UnsafeInlineSrc = true;
-                });
-            });
+            }
         }
 
         /// <summary>

--- a/src/Skoruba.IdentityServer4.Admin/Helpers/StartupHelpers.cs
+++ b/src/Skoruba.IdentityServer4.Admin/Helpers/StartupHelpers.cs
@@ -207,6 +207,15 @@ namespace Skoruba.IdentityServer4.Admin.Helpers
                         options.SelfSrc = true;
                         options.CustomSources = cspTrustedDomains;
                         options.Enabled = true;
+                        options.UnsafeInlineSrc = true;
+                        options.UnsafeEvalSrc = true;
+                    });
+                    csp.StyleSources(options =>
+                    {
+                        options.SelfSrc = true;
+                        options.CustomSources = cspTrustedDomains;
+                        options.Enabled = true;
+                        options.UnsafeInlineSrc = true;
                     });
                     csp.DefaultSources(options =>
                     {

--- a/src/Skoruba.IdentityServer4.Admin/Startup.cs
+++ b/src/Skoruba.IdentityServer4.Admin/Startup.cs
@@ -107,7 +107,7 @@ namespace Skoruba.IdentityServer4.Admin
             app.UsePathBase(Configuration.GetValue<string>("BasePath"));
 
             // Add custom security headers
-            app.UseSecurityHeaders();
+            app.UseSecurityHeaders(Configuration);
 
             app.UseStaticFiles();
 

--- a/src/Skoruba.IdentityServer4.Admin/appsettings.json
+++ b/src/Skoruba.IdentityServer4.Admin/appsettings.json
@@ -1,85 +1,89 @@
 {
-    "ConnectionStrings": {
-        "ConfigurationDbConnection": "Server=(localdb)\\mssqllocaldb;Database=IdentityServer4Admin;Trusted_Connection=True;MultipleActiveResultSets=true",
-        "PersistedGrantDbConnection": "Server=(localdb)\\mssqllocaldb;Database=IdentityServer4Admin;Trusted_Connection=True;MultipleActiveResultSets=true",
-        "IdentityDbConnection": "Server=(localdb)\\mssqllocaldb;Database=IdentityServer4Admin;Trusted_Connection=True;MultipleActiveResultSets=true",
-        "AdminLogDbConnection": "Server=(localdb)\\mssqllocaldb;Database=IdentityServer4Admin;Trusted_Connection=True;MultipleActiveResultSets=true",
-        "AdminAuditLogDbConnection": "Server=(localdb)\\mssqllocaldb;Database=IdentityServer4Admin;Trusted_Connection=True;MultipleActiveResultSets=true",
-        "DataProtectionDbConnection": "Server=(localdb)\\mssqllocaldb;Database=IdentityServer4Admin;Trusted_Connection=True;MultipleActiveResultSets=true"
+  "ConnectionStrings": {
+    "ConfigurationDbConnection": "Server=(localdb)\\mssqllocaldb;Database=IdentityServer4Admin;Trusted_Connection=True;MultipleActiveResultSets=true",
+    "PersistedGrantDbConnection": "Server=(localdb)\\mssqllocaldb;Database=IdentityServer4Admin;Trusted_Connection=True;MultipleActiveResultSets=true",
+    "IdentityDbConnection": "Server=(localdb)\\mssqllocaldb;Database=IdentityServer4Admin;Trusted_Connection=True;MultipleActiveResultSets=true",
+    "AdminLogDbConnection": "Server=(localdb)\\mssqllocaldb;Database=IdentityServer4Admin;Trusted_Connection=True;MultipleActiveResultSets=true",
+    "AdminAuditLogDbConnection": "Server=(localdb)\\mssqllocaldb;Database=IdentityServer4Admin;Trusted_Connection=True;MultipleActiveResultSets=true",
+    "DataProtectionDbConnection": "Server=(localdb)\\mssqllocaldb;Database=IdentityServer4Admin;Trusted_Connection=True;MultipleActiveResultSets=true"
+  },
+  "SeedConfiguration": {
+    "ApplySeed": true
+  },
+  "DatabaseMigrationsConfiguration": {
+    "ApplyDatabaseMigrations": true
+  },
+  "DatabaseProviderConfiguration": {
+    "ProviderType": "SqlServer"
+  },
+  "AdminConfiguration": {
+    "PageTitle": "Skoruba IdentityServer4 Admin",
+    "FaviconUri": "~/favicon.ico",
+    "IdentityAdminRedirectUri": "https://localhost:44303/signin-oidc",
+    "IdentityServerBaseUrl": "https://localhost:44310",
+    "IdentityAdminCookieName": "IdentityServerAdmin",
+    "IdentityAdminCookieExpiresUtcHours": 12,
+    "RequireHttpsMetadata": false,
+    "TokenValidationClaimName": "name",
+    "TokenValidationClaimRole": "role",
+    "ClientId": "skoruba_identity_admin",
+    "ClientSecret": "skoruba_admin_client_secret",
+    "OidcResponseType": "code",
+    "Scopes": [
+      "openid",
+      "profile",
+      "email",
+      "roles"
+    ],
+    "AdministrationRole": "SkorubaIdentityAdminAdministrator",
+    "HideUIForMSSqlErrorLogging": false
+  },
+  "CspTrustedDomains": [
+    "https://fonts.googleapis.com/",
+    "https://fonts.gstatic.com/"
+  ],
+  "SmtpConfiguration": {
+    "Host": "",
+    "Login": "",
+    "Password": ""
+  },
+  "SendGridConfiguration": {
+    "ApiKey": "",
+    "SourceEmail": "",
+    "SourceName": ""
+  },
+  "AuditLoggingConfiguration": {
+    "Source": "IdentityServer.Admin.Web",
+    "SubjectIdentifierClaim": "sub",
+    "SubjectNameClaim": "name",
+    "IncludeFormVariables": false
+  },
+  "CultureConfiguration": {
+    "Cultures": [],
+    "DefaultCulture": null
+  },
+  "BasePath": "",
+  "IdentityOptions": {
+    "Password": {
+      "RequiredLength": 8
     },
-    "SeedConfiguration": {
-        "ApplySeed": true
+    "User": {
+      "RequireUniqueEmail": true
     },
-    "DatabaseMigrationsConfiguration": {
-        "ApplyDatabaseMigrations": true
-    },
-    "DatabaseProviderConfiguration": {
-        "ProviderType": "SqlServer"
-    },
-    "AdminConfiguration": {
-        "PageTitle": "Skoruba IdentityServer4 Admin",
-        "FaviconUri": "~/favicon.ico",
-        "IdentityAdminRedirectUri": "https://localhost:44303/signin-oidc",
-        "IdentityServerBaseUrl": "https://localhost:44310",
-        "IdentityAdminCookieName": "IdentityServerAdmin",
-        "IdentityAdminCookieExpiresUtcHours": 12,
-        "RequireHttpsMetadata": false,
-        "TokenValidationClaimName": "name",
-        "TokenValidationClaimRole": "role",
-        "ClientId": "skoruba_identity_admin",
-        "ClientSecret": "skoruba_admin_client_secret",
-        "OidcResponseType": "code",
-        "Scopes": [
-            "openid",
-            "profile",
-            "email",
-            "roles"
-        ],
-        "AdministrationRole": "SkorubaIdentityAdminAdministrator",
-        "HideUIForMSSqlErrorLogging": false
-    },
-    "SmtpConfiguration": {
-        "Host": "",
-        "Login": "",
-        "Password": ""
-    },
-    "SendGridConfiguration": {
-        "ApiKey": "",
-        "SourceEmail": "",
-        "SourceName": ""
-    },
-    "AuditLoggingConfiguration": {
-        "Source": "IdentityServer.Admin.Web",
-        "SubjectIdentifierClaim": "sub",
-        "SubjectNameClaim": "name",
-        "IncludeFormVariables": false
-    },
-    "CultureConfiguration": {
-        "Cultures": [],
-        "DefaultCulture": null
-    },
-    "BasePath": "",
-    "IdentityOptions": {
-        "Password": {
-            "RequiredLength": 8
-        },
-        "User": {
-            "RequireUniqueEmail": true
-        },
-        "SignIn": {
-            "RequireConfirmedAccount": false
-        }
-    },
-    "DataProtectionConfiguration": {
-        "ProtectKeysWithAzureKeyVault": false
-    },
-
-    "AzureKeyVaultConfiguration": {
-        "AzureKeyVaultEndpoint": "",
-        "ClientId": "",
-        "ClientSecret": "",
-        "UseClientCredentials": true,
-        "DataProtectionKeyIdentifier": "",
-        "ReadConfigurationFromKeyVault": false 
+    "SignIn": {
+      "RequireConfirmedAccount": false
     }
+  },
+  "DataProtectionConfiguration": {
+    "ProtectKeysWithAzureKeyVault": false
+  },
+
+  "AzureKeyVaultConfiguration": {
+    "AzureKeyVaultEndpoint": "",
+    "ClientId": "",
+    "ClientSecret": "",
+    "UseClientCredentials": true,
+    "DataProtectionKeyIdentifier": "",
+    "ReadConfigurationFromKeyVault": false
+  }
 }

--- a/src/Skoruba.IdentityServer4.Admin/appsettings.json
+++ b/src/Skoruba.IdentityServer4.Admin/appsettings.json
@@ -39,8 +39,8 @@
     "HideUIForMSSqlErrorLogging": false
   },
   "CspTrustedDomains": [
-    "https://fonts.googleapis.com/",
-    "https://fonts.gstatic.com/"
+    "fonts.googleapis.com",
+    "fonts.gstatic.com"
   ],
   "SmtpConfiguration": {
     "Host": "",

--- a/src/Skoruba.IdentityServer4.STS.Identity/Configuration/Constants/ConfigurationConsts.cs
+++ b/src/Skoruba.IdentityServer4.STS.Identity/Configuration/Constants/ConfigurationConsts.cs
@@ -19,5 +19,7 @@
         public const string RegisterConfigurationKey = "RegisterConfiguration";
 
         public const string AdvancedConfigurationKey = "AdvancedConfiguration";
+
+        public const string CspTrustedDomainsKey = "CspTrustedDomains";
     }
 }

--- a/src/Skoruba.IdentityServer4.STS.Identity/Helpers/StartupHelpers.cs
+++ b/src/Skoruba.IdentityServer4.STS.Identity/Helpers/StartupHelpers.cs
@@ -136,6 +136,13 @@ namespace Skoruba.IdentityServer4.STS.Identity.Helpers
                         options.CustomSources = cspTrustedDomains;
                         options.Enabled = true;
                     });
+                    csp.StyleSources(options =>
+                    {
+                        options.SelfSrc = true;
+                        options.CustomSources = cspTrustedDomains;
+                        options.Enabled = true;
+                        options.UnsafeInlineSrc = true;
+                    });
                     csp.DefaultSources(options =>
                     {
                         options.SelfSrc = true;

--- a/src/Skoruba.IdentityServer4.STS.Identity/Helpers/StartupHelpers.cs
+++ b/src/Skoruba.IdentityServer4.STS.Identity/Helpers/StartupHelpers.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Globalization;
 using IdentityServer4.EntityFramework.Storage;
 using Microsoft.AspNetCore.Authentication;
@@ -95,7 +96,8 @@ namespace Skoruba.IdentityServer4.STS.Identity.Helpers
         /// Using of Forwarded Headers and Referrer Policy
         /// </summary>
         /// <param name="app"></param>
-        public static void UseSecurityHeaders(this IApplicationBuilder app)
+        /// <param name="configuration"></param>
+        public static void UseSecurityHeaders(this IApplicationBuilder app, IConfiguration configuration)
         {
             var forwardingOptions = new ForwardedHeadersOptions()
             {
@@ -108,6 +110,21 @@ namespace Skoruba.IdentityServer4.STS.Identity.Helpers
             app.UseForwardedHeaders(forwardingOptions);
 
             app.UseReferrerPolicy(options => options.NoReferrer());
+
+            var cspTrustedDomains = configuration.GetValue<List<string>>(ConfigurationConsts.CspTrustedDomainsKey);
+            if (cspTrustedDomains.Any())
+            {
+                app.UseCsp(csp =>
+                {
+                    csp.ImageSources(option =>
+                    {
+                        option.SelfSrc = true;
+                        option.CustomSources = cspTrustedDomains;
+                        option.Enabled = true;
+                    });
+                });
+            }
+
         }
 
         /// <summary>

--- a/src/Skoruba.IdentityServer4.STS.Identity/Helpers/StartupHelpers.cs
+++ b/src/Skoruba.IdentityServer4.STS.Identity/Helpers/StartupHelpers.cs
@@ -111,16 +111,36 @@ namespace Skoruba.IdentityServer4.STS.Identity.Helpers
 
             app.UseReferrerPolicy(options => options.NoReferrer());
 
-            var cspTrustedDomains = configuration.GetValue<List<string>>(ConfigurationConsts.CspTrustedDomainsKey);
+            // CSP Configuration to be able to use external resources
+            var cspTrustedDomains = new List<string>();
+            configuration.GetSection(ConfigurationConsts.CspTrustedDomainsKey).Bind(cspTrustedDomains);
             if (cspTrustedDomains.Any())
             {
                 app.UseCsp(csp =>
                 {
-                    csp.ImageSources(option =>
+                    csp.ImageSources(options =>
                     {
-                        option.SelfSrc = true;
-                        option.CustomSources = cspTrustedDomains;
-                        option.Enabled = true;
+                        options.SelfSrc = true;
+                        options.CustomSources = cspTrustedDomains;
+                        options.Enabled = true;
+                    });
+                    csp.FontSources(options =>
+                    {
+                        options.SelfSrc = true;
+                        options.CustomSources = cspTrustedDomains;
+                        options.Enabled = true;
+                    });
+                    csp.ScriptSources(options =>
+                    {
+                        options.SelfSrc = true;
+                        options.CustomSources = cspTrustedDomains;
+                        options.Enabled = true;
+                    });
+                    csp.DefaultSources(options =>
+                    {
+                        options.SelfSrc = true;
+                        options.CustomSources = cspTrustedDomains;
+                        options.Enabled = true;
                     });
                 });
             }

--- a/src/Skoruba.IdentityServer4.STS.Identity/Skoruba.IdentityServer4.STS.Identity.csproj
+++ b/src/Skoruba.IdentityServer4.STS.Identity/Skoruba.IdentityServer4.STS.Identity.csproj
@@ -16,6 +16,7 @@
         <PackageReference Include="AspNetCore.HealthChecks.SqlServer" Version="3.1.1" />
         <PackageReference Include="AspNetCore.HealthChecks.UI" Version="3.1.1" />
         <PackageReference Include="AspNetCore.HealthChecks.UI.Client" Version="3.1.1" />
+        <PackageReference Include="Joonasw.AspNetCore.SecurityHeaders" Version="3.0.0" />
         <PackageReference Include="Microsoft.AspNetCore.Authentication.AzureAD.UI" Version="3.1.8" />
         <PackageReference Include="Microsoft.AspNetCore.DataProtection.EntityFrameworkCore" Version="3.1.6" />
         <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="3.1.6" />

--- a/src/Skoruba.IdentityServer4.STS.Identity/Skoruba.IdentityServer4.STS.Identity.csproj
+++ b/src/Skoruba.IdentityServer4.STS.Identity/Skoruba.IdentityServer4.STS.Identity.csproj
@@ -16,7 +16,6 @@
         <PackageReference Include="AspNetCore.HealthChecks.SqlServer" Version="3.1.1" />
         <PackageReference Include="AspNetCore.HealthChecks.UI" Version="3.1.1" />
         <PackageReference Include="AspNetCore.HealthChecks.UI.Client" Version="3.1.1" />
-        <PackageReference Include="Joonasw.AspNetCore.SecurityHeaders" Version="3.0.0" />
         <PackageReference Include="Microsoft.AspNetCore.Authentication.AzureAD.UI" Version="3.1.8" />
         <PackageReference Include="Microsoft.AspNetCore.DataProtection.EntityFrameworkCore" Version="3.1.6" />
         <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="3.1.6" />

--- a/src/Skoruba.IdentityServer4.STS.Identity/Startup.cs
+++ b/src/Skoruba.IdentityServer4.STS.Identity/Startup.cs
@@ -74,7 +74,7 @@ namespace Skoruba.IdentityServer4.STS.Identity
             app.UsePathBase(Configuration.GetValue<string>("BasePath"));
 
             // Add custom security headers
-            app.UseSecurityHeaders();
+            app.UseSecurityHeaders(Configuration);
 
             app.UseStaticFiles();
             UseAuthentication(app);

--- a/src/Skoruba.IdentityServer4.STS.Identity/Views/Home/Index.cshtml
+++ b/src/Skoruba.IdentityServer4.STS.Identity/Views/Home/Index.cshtml
@@ -4,7 +4,7 @@
 @inject IViewLocalizer Localizer
 @inject IRootConfiguration RootConfiguration
 <div class="welcome-block px-3 py-3 pt-md-5 pb-md-4 mx-auto text-center">
-    <h1 class="display-4"><img class="icon" alt="Logo" src="@UrlHelper.Content(RootConfiguration.AdminConfiguration.HomePageLogoUri)"><br />@RootConfiguration.AdminConfiguration.PageTitle</h1>
+    <h1 class="display-4"><img class="img-fluid" alt="Logo" src="@UrlHelper.Content(RootConfiguration.AdminConfiguration.HomePageLogoUri)"><br />@RootConfiguration.AdminConfiguration.PageTitle</h1>
     <p class="lead">@Localizer["SubTitle", RootConfiguration.AdminConfiguration.PageTitle]</p>
 </div>
 

--- a/src/Skoruba.IdentityServer4.STS.Identity/appsettings.json
+++ b/src/Skoruba.IdentityServer4.STS.Identity/appsettings.json
@@ -68,7 +68,9 @@
     "AdministrationRole": "SkorubaIdentityAdminAdministrator"
   },
   "CspTrustedDomains": [
-    "www.gravatar.com"
+    "www.gravatar.com",
+    "fonts.googleapis.com",
+    "fonts.gstatic.com"
   ],
   "CultureConfiguration": {
     "Cultures": [],

--- a/src/Skoruba.IdentityServer4.STS.Identity/appsettings.json
+++ b/src/Skoruba.IdentityServer4.STS.Identity/appsettings.json
@@ -67,7 +67,9 @@
     "IdentityAdminBaseUrl": "https://localhost:44303",
     "AdministrationRole": "SkorubaIdentityAdminAdministrator"
   },
-  "CspTrustedDomains": [],
+  "CspTrustedDomains": [
+    "gravatar.com"
+  ],
   "CultureConfiguration": {
     "Cultures": [],
     "DefaultCulture": null

--- a/src/Skoruba.IdentityServer4.STS.Identity/appsettings.json
+++ b/src/Skoruba.IdentityServer4.STS.Identity/appsettings.json
@@ -1,40 +1,40 @@
 {
-    "ConnectionStrings": {
-        "ConfigurationDbConnection": "Server=(localdb)\\mssqllocaldb;Database=IdentityServer4Admin;Trusted_Connection=True;MultipleActiveResultSets=true",
-        "PersistedGrantDbConnection": "Server=(localdb)\\mssqllocaldb;Database=IdentityServer4Admin;Trusted_Connection=True;MultipleActiveResultSets=true",
-        "IdentityDbConnection": "Server=(localdb)\\mssqllocaldb;Database=IdentityServer4Admin;Trusted_Connection=True;MultipleActiveResultSets=true",
-        "DataProtectionDbConnection": "Server=(localdb)\\mssqllocaldb;Database=IdentityServer4Admin;Trusted_Connection=True;MultipleActiveResultSets=true"
-    },
-    "DatabaseProviderConfiguration": {
-        "ProviderType": "SqlServer"
-    },
-    "CertificateConfiguration": {
+  "ConnectionStrings": {
+    "ConfigurationDbConnection": "Server=(localdb)\\mssqllocaldb;Database=IdentityServer4Admin;Trusted_Connection=True;MultipleActiveResultSets=true",
+    "PersistedGrantDbConnection": "Server=(localdb)\\mssqllocaldb;Database=IdentityServer4Admin;Trusted_Connection=True;MultipleActiveResultSets=true",
+    "IdentityDbConnection": "Server=(localdb)\\mssqllocaldb;Database=IdentityServer4Admin;Trusted_Connection=True;MultipleActiveResultSets=true",
+    "DataProtectionDbConnection": "Server=(localdb)\\mssqllocaldb;Database=IdentityServer4Admin;Trusted_Connection=True;MultipleActiveResultSets=true"
+  },
+  "DatabaseProviderConfiguration": {
+    "ProviderType": "SqlServer"
+  },
+  "CertificateConfiguration": {
 
-        "UseTemporarySigningKeyForDevelopment": true,
+    "UseTemporarySigningKeyForDevelopment": true,
 
-        "CertificateStoreLocation": "LocalMachine",
-        "CertificateValidOnly": true,
+    "CertificateStoreLocation": "LocalMachine",
+    "CertificateValidOnly": true,
 
-        "UseSigningCertificateThumbprint": false,
-        "SigningCertificateThumbprint": "",
+    "UseSigningCertificateThumbprint": false,
+    "SigningCertificateThumbprint": "",
 
-        "UseSigningCertificatePfxFile": false,
-        "SigningCertificatePfxFilePath": "",
-        "SigningCertificatePfxFilePassword": "",
+    "UseSigningCertificatePfxFile": false,
+    "SigningCertificatePfxFilePath": "",
+    "SigningCertificatePfxFilePassword": "",
 
-        "UseValidationCertificatePfxFile": false,
-        "ValidationCertificatePfxFilePath": "",
-        "ValidationCertificatePfxFilePassword": "",
+    "UseValidationCertificatePfxFile": false,
+    "ValidationCertificatePfxFilePath": "",
+    "ValidationCertificatePfxFilePassword": "",
 
-        "UseValidationCertificateThumbprint": false,
-        "ValidationCertificateThumbprint": "",
+    "UseValidationCertificateThumbprint": false,
+    "ValidationCertificateThumbprint": "",
 
-        "UseSigningCertificateForAzureKeyVault": false,
-        "UseValidationCertificateForAzureKeyVault": false
-    },
-    "RegisterConfiguration": {
-        "Enabled": true
-    },
+    "UseSigningCertificateForAzureKeyVault": false,
+    "UseValidationCertificateForAzureKeyVault": false
+  },
+  "RegisterConfiguration": {
+    "Enabled": true
+  },
   "ExternalProvidersConfiguration": {
     "UseGitHubProvider": false,
     "GitHubClientId": "",
@@ -45,57 +45,58 @@
     "AzureInstance": "",
     "AzureAdSecret": "",
     "AzureAdCallbackPath": "",
-    "AzureDomain": "" 
+    "AzureDomain": ""
   },
-    "SmtpConfiguration": {
-        "Host": "",
-        "Login": "",
-        "Password": ""
+  "SmtpConfiguration": {
+    "Host": "",
+    "Login": "",
+    "Password": ""
+  },
+  "SendGridConfiguration": {
+    "ApiKey": "",
+    "SourceEmail": "",
+    "SourceName": ""
+  },
+  "LoginConfiguration": {
+    "ResolutionPolicy": "Username"
+  },
+  "AdminConfiguration": {
+    "PageTitle": "Skoruba IdentityServer4",
+    "HomePageLogoUri": "~/images/skoruba-icon.png",
+    "FaviconUri": "~/favicon.ico",
+    "IdentityAdminBaseUrl": "https://localhost:44303",
+    "AdministrationRole": "SkorubaIdentityAdminAdministrator"
+  },
+  "CspTrustedDomains": [],
+  "CultureConfiguration": {
+    "Cultures": [],
+    "DefaultCulture": null
+  },
+  "AdvancedConfiguration": {
+    "PublicOrigin": ""
+  },
+  "BasePath": "",
+  "IdentityOptions": {
+    "Password": {
+      "RequiredLength": 8
     },
-    "SendGridConfiguration": {
-        "ApiKey": "",
-        "SourceEmail": "",
-        "SourceName": ""
+    "User": {
+      "RequireUniqueEmail": true
     },
-    "LoginConfiguration": {
-        "ResolutionPolicy": "Username"
-    },
-    "AdminConfiguration": {
-        "PageTitle": "Skoruba IdentityServer4",
-        "HomePageLogoUri": "~/images/skoruba-icon.png",
-        "FaviconUri": "~/favicon.ico",
-        "IdentityAdminBaseUrl": "https://localhost:44303",
-        "AdministrationRole": "SkorubaIdentityAdminAdministrator"
-    },
-    "CultureConfiguration": {
-        "Cultures": [],
-        "DefaultCulture": null
-    },
-    "AdvancedConfiguration": {
-        "PublicOrigin": ""
-    },
-    "BasePath": "",
-    "IdentityOptions": {
-        "Password": {
-            "RequiredLength": 8
-        },
-        "User": {
-            "RequireUniqueEmail": true
-        },
-        "SignIn": {
-            "RequireConfirmedAccount": false
-        }
-    },
-    "DataProtectionConfiguration": {
-        "ProtectKeysWithAzureKeyVault": false
-    },
-    "AzureKeyVaultConfiguration": {
-        "AzureKeyVaultEndpoint": "",
-        "ClientId": "",
-        "ClientSecret": "",
-        "UseClientCredentials": true,
-        "IdentityServerCertificateName": "",
-        "DataProtectionKeyIdentifier": "",
-        "ReadConfigurationFromKeyVault": false
+    "SignIn": {
+      "RequireConfirmedAccount": false
     }
+  },
+  "DataProtectionConfiguration": {
+    "ProtectKeysWithAzureKeyVault": false
+  },
+  "AzureKeyVaultConfiguration": {
+    "AzureKeyVaultEndpoint": "",
+    "ClientId": "",
+    "ClientSecret": "",
+    "UseClientCredentials": true,
+    "IdentityServerCertificateName": "",
+    "DataProtectionKeyIdentifier": "",
+    "ReadConfigurationFromKeyVault": false
+  }
 }

--- a/src/Skoruba.IdentityServer4.STS.Identity/appsettings.json
+++ b/src/Skoruba.IdentityServer4.STS.Identity/appsettings.json
@@ -45,47 +45,40 @@
     "AzureInstance": "",
     "AzureAdSecret": "",
     "AzureAdCallbackPath": "",
-    "AzureDomain": "" 
+    "AzureDomain": ""
   },
-    "SmtpConfiguration": {
-        "Host": "",
-        "Login": "",
-        "Password": ""
-    },
-    "SendGridConfiguration": {
-        "ApiKey": "",
-        "SourceEmail": "",
-        "SourceName": ""
-    },
-    "LoginConfiguration": {
-        "ResolutionPolicy": "Username"
-    },
-    "AdminConfiguration": {
-        "PageTitle": "Skoruba IdentityServer4",
-        "HomePageLogoUri": "~/images/skoruba-icon.png",
-        "FaviconUri": "~/favicon.ico",
-        "IdentityAdminBaseUrl": "https://localhost:44303",
-        "AdministrationRole": "SkorubaIdentityAdminAdministrator"
-    },
-    "CspTrustedDomains": [],
-    "CultureConfiguration": {
-        "Cultures": [],
-        "DefaultCulture": null
-    },
-    "AdvancedConfiguration": {
-        "PublicOrigin": ""
-    },
-    "BasePath": "",
-    "IdentityOptions": {
-        "Password": {
-            "RequiredLength": 8
-        },
-        "User": {
-            "RequireUniqueEmail": true
-        },
-        "SignIn": {
-            "RequireConfirmedAccount": false
-        }
+  "SmtpConfiguration": {
+    "Host": "",
+    "Login": "",
+    "Password": ""
+  },
+  "SendGridConfiguration": {
+    "ApiKey": "",
+    "SourceEmail": "",
+    "SourceName": ""
+  },
+  "LoginConfiguration": {
+    "ResolutionPolicy": "Username"
+  },
+  "AdminConfiguration": {
+    "PageTitle": "Skoruba IdentityServer4",
+    "HomePageLogoUri": "~/images/skoruba-icon.png",
+    "FaviconUri": "~/favicon.ico",
+    "IdentityAdminBaseUrl": "https://localhost:44303",
+    "AdministrationRole": "SkorubaIdentityAdminAdministrator"
+  },
+  "CspTrustedDomains": [],
+  "CultureConfiguration": {
+    "Cultures": [],
+    "DefaultCulture": null
+  },
+  "AdvancedConfiguration": {
+    "PublicOrigin": ""
+  },
+  "BasePath": "",
+  "IdentityOptions": {
+    "Password": {
+      "RequiredLength": 8
     },
     "User": {
       "RequireUniqueEmail": true
@@ -93,6 +86,12 @@
     "SignIn": {
       "RequireConfirmedAccount": false
     }
+  },
+  "User": {
+    "RequireUniqueEmail": true
+  },
+  "SignIn": {
+    "RequireConfirmedAccount": false
   },
   "DataProtectionConfiguration": {
     "ProtectKeysWithAzureKeyVault": false

--- a/src/Skoruba.IdentityServer4.STS.Identity/appsettings.json
+++ b/src/Skoruba.IdentityServer4.STS.Identity/appsettings.json
@@ -68,7 +68,7 @@
     "AdministrationRole": "SkorubaIdentityAdminAdministrator"
   },
   "CspTrustedDomains": [
-    "gravatar.com"
+    "www.gravatar.com"
   ],
   "CultureConfiguration": {
     "Cultures": [],


### PR DESCRIPTION
Hi all,

For people who using Docker images from dockerhub to create app instance, you probably got an issue if you want to customise favicon or logo caused by CSP.
To fix this issue i created configuration in appsettings.json to configure a list of "approved" domains who contains some ressources like logo, favicon or other stuff for future versions.

- Configuration Added in appsettings.json, list or uri
- Added CSP middleware with configuration for default, image, font, script
- Changed class of img element for logo to use responsive class for image "img-fluid"

In progress:

- [x]  Integration of CSP Configuration in admin project

- [x]  Integration of gravatar domain as trusted by default

- [x] Fix for inline css & script

Related to #209 

Enjoy