### PR TITLE
Bugfix: Import All Windows User

### DIFF
--- a/src/Skoruba.IdentityServer4.STS.Identity/Helpers/StartupHelpers.cs
+++ b/src/Skoruba.IdentityServer4.STS.Identity/Helpers/StartupHelpers.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Globalization;
 using IdentityServer4.EntityFramework.Storage;
 using Microsoft.AspNetCore.Authentication;
@@ -225,6 +225,11 @@ namespace Skoruba.IdentityServer4.STS.Identity.Helpers
             });
 
             services.Configure<IISOptions>(iis =>
+            {
+                iis.AuthenticationDisplayName = "Windows";
+                iis.AutomaticAuthentication = false;
+            });
+            services.Configure<IISServerOptions>(iis =>
             {
                 iis.AuthenticationDisplayName = "Windows";
                 iis.AutomaticAuthentication = false;

--- a/src/Skoruba.IdentityServer4.STS.Identity/Views/Account/_StatusMessage.cshtml
+++ b/src/Skoruba.IdentityServer4.STS.Identity/Views/Account/_StatusMessage.cshtml
@@ -1,0 +1,10 @@
+﻿@model string
+
+@if (!String.IsNullOrEmpty(Model))
+{
+    var statusMessageClass = Model.StartsWith("Error") ? "danger" : "success";
+<div class="alert alert-@statusMessageClass alert-dismissible" role="alert">
+    <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+    @Model
+</div>
+}


### PR DESCRIPTION
The button to import all Windows Users from the AD is hidden when the In-Process hosting model is used.

If the in-proces hosting mode is used, IISServerOptions must be set. -> https://github.com/dotnet/AspNetCore.Docs/pull/9463#issue-228523235
So i added the options.

Added the missing partial view _StatusMessage.cshtml.