### PR TITLE
Removed the EnvironmentVariables from the web.config of the Admin project

### DIFF
--- a/src/Skoruba.IdentityServer4.Admin/web.config
+++ b/src/Skoruba.IdentityServer4.Admin/web.config
@@ -8,11 +8,6 @@
       <add name="aspNetCore" path="*" verb="*" modules="AspNetCoreModuleV2" resourceType="Unspecified" />
     </handlers>
     <aspNetCore processPath="%LAUNCHER_PATH%" arguments="%LAUNCHER_ARGS%" stdoutLogEnabled="true" stdoutLogFile=".\log\stdout" forwardWindowsAuthToken="false" hostingModel="InProcess">
-      <environmentVariables>
-        <environmentVariable name="ASPNETCORE_ENVIRONMENT" value="Development" />
-        <environmentVariable name="COMPLUS_ForceENC" value="1" />
-        <environmentVariable name="ASPNETCORE_HTTPS_PORT" value="44303" />
-      </environmentVariables>
     </aspNetCore>
   </system.webServer>
 </configuration>


### PR DESCRIPTION

I also think that these are leftovers from development. Therefore these should not be in the repository.
This configuration interferes if you set the Environment Variables system wide. e.g. you want to set ASPNETCORE_ENVIRONMENT to "Production".