### PR TITLE
Fix bugs and suggestions for callbacks when the cancel login

### DIFF
--- a/src/Skoruba.IdentityServer4.Admin/Controllers/HomeController.cs
+++ b/src/Skoruba.IdentityServer4.Admin/Controllers/HomeController.cs
@@ -21,6 +21,11 @@ namespace Skoruba.IdentityServer4.Admin.Controllers
             _logger = logger;
         }
 
+        /// <summary>
+        /// Anyone can visit the home page, if you don’t set this, keep clicking to cancel login will keep looping
+        /// </summary>
+        /// <returns></returns>
+        [AllowAnonymous]
         public IActionResult Index()
         {
             return View();

--- a/src/Skoruba.IdentityServer4.Admin/Helpers/StartupHelpers.cs
+++ b/src/Skoruba.IdentityServer4.Admin/Helpers/StartupHelpers.cs
@@ -182,7 +182,7 @@ namespace Skoruba.IdentityServer4.Admin.Helpers
             app.UseXContentTypeOptions();
             app.UseXfo(options => options.SameOrigin());
             app.UseReferrerPolicy(options => options.NoReferrer());
-           
+
             // CSP Configuration to be able to use external resources
             var cspTrustedDomains = new List<string>();
             configuration.GetSection(ConfigurationConsts.CspTrustedDomainsKey).Bind(cspTrustedDomains);
@@ -286,7 +286,7 @@ namespace Skoruba.IdentityServer4.Admin.Helpers
             where TUserChangePasswordDto : UserChangePasswordDto<TKey>
             where TRoleClaimsDto : RoleClaimsDto<TRoleClaimDto, TKey>
             where TUserClaimDto : UserClaimDto<TKey>
-            where TRoleClaimDto: RoleClaimDto<TKey>
+            where TRoleClaimDto : RoleClaimDto<TKey>
         {
             services.AddSingleton<ITempDataProvider, CookieTempDataProvider>();
 
@@ -433,7 +433,8 @@ namespace Skoruba.IdentityServer4.Admin.Helpers
                         options.Events = new OpenIdConnectEvents
                         {
                             OnMessageReceived = context => OnMessageReceived(context, adminConfiguration),
-                            OnRedirectToIdentityProvider = context => OnRedirectToIdentityProvider(context, adminConfiguration)
+                            OnRedirectToIdentityProvider = context => OnRedirectToIdentityProvider(context, adminConfiguration),
+                            OnRemoteFailure = OnRemoteFailure
                         };
                     });
         }
@@ -449,6 +450,19 @@ namespace Skoruba.IdentityServer4.Admin.Helpers
         private static Task OnRedirectToIdentityProvider(RedirectContext n, AdminConfiguration adminConfiguration)
         {
             n.ProtocolMessage.RedirectUri = adminConfiguration.IdentityAdminRedirectUri;
+
+            return Task.FromResult(0);
+        }
+
+        /// <summary>
+        /// Handle the event of clicking the cancel button on the authorized website
+        /// </summary>
+        /// <param name="context"></param>
+        /// <returns></returns>
+        private static Task OnRemoteFailure(RemoteFailureContext context)
+        {
+            context.Response.Redirect("/"); // Redirect to home page
+            context.HandleResponse();
 
             return Task.FromResult(0);
         }


### PR DESCRIPTION
The current user will report an error if he clicks to cancel the login, the error message is "OpenIdConnectProtocolException: Message contains error: 'access_denied', error_description: 'error_description is null', error_uri: 'error_uri is null'.",
so I add OnRemoteFailure event for fixed it.