### PR TITLE
Fixed Warning	CS0108: IAdminConfigurationDbContext.ApiScopes hides inherited member IConfigurationDbContext.ApiScopes

### DIFF
--- a/src/Skoruba.IdentityServer4.Admin.EntityFramework.Shared/DbContexts/IdentityServerConfigurationDbContext.cs
+++ b/src/Skoruba.IdentityServer4.Admin.EntityFramework.Shared/DbContexts/IdentityServerConfigurationDbContext.cs
@@ -19,8 +19,6 @@ namespace Skoruba.IdentityServer4.Admin.EntityFramework.Shared.DbContexts
 
         public DbSet<ApiResourceSecret> ApiSecrets { get; set; }
 
-        public DbSet<ApiScope> ApiScopes { get; set; }
-
         public DbSet<ApiScopeClaim> ApiScopeClaims { get; set; }
 
         public DbSet<IdentityResourceClaim> IdentityClaims { get; set; }
@@ -34,8 +32,6 @@ namespace Skoruba.IdentityServer4.Admin.EntityFramework.Shared.DbContexts
         public DbSet<ClientSecret> ClientSecrets { get; set; }
 
         public DbSet<ClientPostLogoutRedirectUri> ClientPostLogoutRedirectUris { get; set; }
-
-        public DbSet<ClientCorsOrigin> ClientCorsOrigins { get; set; }
 
         public DbSet<ClientIdPRestriction> ClientIdPRestrictions { get; set; }
 

--- a/src/Skoruba.IdentityServer4.Admin.EntityFramework/Interfaces/IAdminConfigurationDbContext.cs
+++ b/src/Skoruba.IdentityServer4.Admin.EntityFramework/Interfaces/IAdminConfigurationDbContext.cs
@@ -8,8 +8,6 @@ namespace Skoruba.IdentityServer4.Admin.EntityFramework.Interfaces
     {
         DbSet<ApiResourceSecret> ApiSecrets { get; set; }
 
-        DbSet<ApiScope> ApiScopes { get; set; }
-
         DbSet<ApiScopeClaim> ApiScopeClaims { get; set; }
 
         DbSet<IdentityResourceClaim> IdentityClaims { get; set; }
@@ -23,8 +21,6 @@ namespace Skoruba.IdentityServer4.Admin.EntityFramework.Interfaces
         DbSet<ClientSecret> ClientSecrets { get; set; }
 
         DbSet<ClientPostLogoutRedirectUri> ClientPostLogoutRedirectUris { get; set; }
-
-        DbSet<ClientCorsOrigin> ClientCorsOrigins { get; set; }
 
         DbSet<ClientIdPRestriction> ClientIdPRestrictions { get; set; }
 


### PR DESCRIPTION

Fixed Warning	CS0108	'IAdminConfigurationDbContext.ApiScopes' hides inherited member 'IConfigurationDbContext.ApiScopes'. Use the new keyword if hiding was intended.

I Removed the DbSet properties of ApiScopes and ClientCorsOrigin from the IAdminConfigurationDbContext interface because the same properties are available in the parent interface.
