### PR TITLE
Fix serilog path to work both on Windows and Linux.

### DIFF
--- a/src/Skoruba.IdentityServer4.Admin.Api/serilog.json
+++ b/src/Skoruba.IdentityServer4.Admin.Api/serilog.json
@@ -13,7 +13,7 @@
             {
                 "Name": "File",
                 "Args": {
-                    "path": "Log\\skoruba_admin.txt",
+                    "path": "Log/skoruba_admin.txt",
                     "rollingInterval": "Day"
                 }
             },

--- a/src/Skoruba.IdentityServer4.Admin/serilog.json
+++ b/src/Skoruba.IdentityServer4.Admin/serilog.json
@@ -13,7 +13,7 @@
             {
                 "Name": "File",
                 "Args": {
-                    "path": "Log\\skoruba_admin.txt",
+                    "path": "Log/skoruba_admin.txt",
                     "rollingInterval": "Day"
                 }
             },

--- a/src/Skoruba.IdentityServer4.STS.Identity/serilog.json
+++ b/src/Skoruba.IdentityServer4.STS.Identity/serilog.json
@@ -13,7 +13,7 @@
             {
                 "Name": "File",
                 "Args": {
-                    "path": "Log\\skoruba_admin.txt",
+                    "path": "Log/skoruba_admin.txt",
                     "rollingInterval": "Day"
                 }
             },


### PR DESCRIPTION
Hi @skoruba, when I look at the **Skoruba.IdentityServer4.STS.Identity** deployment folder in my Linux server (CentOS 7), this is what it looks like:
```
-rw-r--r--  1 docker-user docker-user   13146 Dec 28 09:27 Log\skoruba_admin20201228.txt
-rw-r--r--  1 docker-user docker-user    1290 Jan  1 12:38 Log\skoruba_admin20210101.txt
-rw-r--r--  1 docker-user docker-user   36792 Jan  8 10:19 Log\skoruba_admin20210108.txt
-rw-r--r--  1 docker-user docker-user    1306 Jan  9 19:26 Log\skoruba_admin20210109.txt
-rw-r--r--  1 docker-user docker-user    1421 Jan 10 13:46 Log\skoruba_admin20210110.txt
-rw-r--r--  1 docker-user docker-user    3912 Jan 12 12:39 Log\skoruba_admin20210112.txt
-rw-r--r--  1 docker-user docker-user    1310 Jan 17 09:36 Log\skoruba_admin20210117.txt
-rw-r--r--  1 docker-user docker-user    1521 Jan 18 15:57 Log\skoruba_admin20210118.txt
-rw-r--r--  1 docker-user docker-user 8641141 Jan 19 10:40 Log\skoruba_admin20210119.txt
-rw-r--r--  1 docker-user docker-user    1300 Jan 22 13:01 Log\skoruba_admin20210122.txt
-rw-r--r--  1 docker-user docker-user    9198 Jan 23 10:33 Log\skoruba_admin20210123.txt
-rwxr--r--  1 docker-user docker-user   96120 Nov 16  2019 Microsoft.AspNetCore.Authentication.OpenIdConnect.dll
-rwxr--r--  1 docker-user docker-user   41336 Jun 17  2020 Microsoft.AspNetCore.Cryptography.Internal.dll
```

As you can see, the log files are not stored in the **Log** folder. This PR will fix that, and I've confirmed that it works the same on Windows too.

Regards,


Martinus
