### PR TITLE
- fix identityserverdata.json in templates

### DIFF
--- a/templates/template-publish/content/shared/identityserverdata.json
+++ b/templates/template-publish/content/shared/identityserverdata.json
@@ -61,19 +61,22 @@
                 ]
             }
         ],
+        "ApiScopes": [
+            {
+                "Name": "skoruba_identity_admin_api",
+                "DisplayName": "skoruba_identity_admin_api",
+                "Required": true,
+                "UserClaims": [
+                    "role",
+                    "name"
+                ]
+            }
+        ],
         "ApiResources": [
             {
                 "Name": "skoruba_identity_admin_api",
                 "Scopes": [
-                    {
-                        "Name": "skoruba_identity_admin_api",
-                        "DisplayName": "skoruba_identity_admin_api",
-                        "Required": true,
-                        "UserClaims": [
-                            "role",
-                            "name"
-                        ]
-                    }
+                    "skoruba_identity_admin_api"
                 ]
             }
         ],


### PR DESCRIPTION
error in 'templates\template-publish\content\shared\identityserverdata.json' file, **ApiScopes** is incorrectly defined