### PR TITLE
Optional LDAP Users & Authentication (Stable v1)

### DIFF
--- a/Skoruba.IdentityServer4.Admin.sln
+++ b/Skoruba.IdentityServer4.Admin.sln
@@ -55,7 +55,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Skoruba.IdentityServer4.Adm
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Skoruba.IdentityServer4.Admin.EntityFramework.Configuration", "src\Skoruba.IdentityServer4.Admin.EntityFramework.Configuration\Skoruba.IdentityServer4.Admin.EntityFramework.Configuration.csproj", "{45FB23BE-A7F9-4172-8868-B5E387007644}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Skoruba.IdentityServer4.Shared.Configuration", "src\Skoruba.IdentityServer4.Shared.Configuration\Skoruba.IdentityServer4.Shared.Configuration.csproj", "{D49A2D61-AEEB-457C-B3BA-D1322EB2F4EC}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Skoruba.IdentityServer4.Shared.Configuration", "src\Skoruba.IdentityServer4.Shared.Configuration\Skoruba.IdentityServer4.Shared.Configuration.csproj", "{D49A2D61-AEEB-457C-B3BA-D1322EB2F4EC}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/Skoruba.IdentityServer4.Admin.BusinessLogic.Identity/Dtos/Identity/Interfaces/IUserDto.cs
+++ b/src/Skoruba.IdentityServer4.Admin.BusinessLogic.Identity/Dtos/Identity/Interfaces/IUserDto.cs
@@ -5,6 +5,8 @@ namespace Skoruba.IdentityServer4.Admin.BusinessLogic.Identity.Dtos.Identity.Int
     public interface IUserDto : IBaseUserDto
     {
         string UserName { get; set; }
+        string UserNameView { get; set; }
+        string UserDomain { get; set; }
         string Email { get; set; }
         bool EmailConfirmed { get; set; }
         string PhoneNumber { get; set; }

--- a/src/Skoruba.IdentityServer4.Admin.BusinessLogic.Identity/Dtos/Identity/UserDto.cs
+++ b/src/Skoruba.IdentityServer4.Admin.BusinessLogic.Identity/Dtos/Identity/UserDto.cs
@@ -11,6 +11,10 @@ namespace Skoruba.IdentityServer4.Admin.BusinessLogic.Identity.Dtos.Identity
         [RegularExpression(@"^[a-zA-Z0-9_@\-\.\+]+$")]
         public string UserName { get; set; }
 
+        public string UserNameView { get; set; }
+
+        public string UserDomain { get; set; }
+
         [Required]
         [EmailAddress]
         public string Email { get; set; }

--- a/src/Skoruba.IdentityServer4.Admin.BusinessLogic.Identity/Mappers/IdentityMapperProfile.cs
+++ b/src/Skoruba.IdentityServer4.Admin.BusinessLogic.Identity/Mappers/IdentityMapperProfile.cs
@@ -42,7 +42,8 @@ namespace Skoruba.IdentityServer4.Admin.BusinessLogic.Identity.Mappers
         public IdentityMapperProfile()
         {
             // entity to model
-            CreateMap<TUser, TUserDto>(MemberList.Destination);
+            CreateMap<TUser, TUserDto>(MemberList.Destination)
+                .ForMember(x => x.UserNameView, opt => opt.MapFrom(src => GetUserNameView(src.UserName)));
 
             CreateMap<UserLoginInfo, TUserProviderDto>(MemberList.Destination);
 
@@ -110,6 +111,15 @@ namespace Skoruba.IdentityServer4.Admin.BusinessLogic.Identity.Mappers
             // model to entity
             CreateMap<TUserDto, TUser>(MemberList.Source)
                 .ForMember(dest => dest.Id, opt => opt.Condition(srs => srs.Id != null)); ;
+        }
+
+        public string GetUserNameView(string username)
+        {
+            var index = username.IndexOf('\\');
+            if (index > -1)
+                return username.Substring(++index, username.Length - index);
+            else
+                return username;
         }
     }
 }

--- a/src/Skoruba.IdentityServer4.Admin.EntityFramework.MySql/Migrations/Identity/20191120085611_DbInit.cs
+++ b/src/Skoruba.IdentityServer4.Admin.EntityFramework.MySql/Migrations/Identity/20191120085611_DbInit.cs
@@ -29,6 +29,7 @@ namespace Skoruba.IdentityServer4.Admin.EntityFramework.MySql.Migrations.Identit
                     Id = table.Column<string>(nullable: false),
                     UserName = table.Column<string>(maxLength: 256, nullable: true),
                     NormalizedUserName = table.Column<string>(maxLength: 256, nullable: true),
+                    UserDomain = table.Column<string>(maxLength: 256, nullable: true),
                     Email = table.Column<string>(maxLength: 256, nullable: true),
                     NormalizedEmail = table.Column<string>(maxLength: 256, nullable: true),
                     EmailConfirmed = table.Column<bool>(nullable: false),

--- a/src/Skoruba.IdentityServer4.Admin.EntityFramework.MySql/Migrations/Identity/AdminIdentityDbContextModelSnapshot.cs
+++ b/src/Skoruba.IdentityServer4.Admin.EntityFramework.MySql/Migrations/Identity/AdminIdentityDbContextModelSnapshot.cs
@@ -49,6 +49,10 @@ namespace Skoruba.IdentityServer4.Admin.EntityFramework.MySql.Migrations.Identit
                     b.Property<string>("NormalizedUserName")
                         .HasColumnType("varchar(256) CHARACTER SET utf8mb4")
                         .HasMaxLength(256);
+                    
+                    b.Property<string>("UserDomain")
+                        .HasColumnType("varchar(256) CHARACTER SET utf8mb4")
+                        .HasMaxLength(256);
 
                     b.Property<string>("PasswordHash")
                         .HasColumnType("longtext CHARACTER SET utf8mb4");

--- a/src/Skoruba.IdentityServer4.Admin.EntityFramework.PostgreSQL/Migrations/Identity/20191120100035_DbInit.cs
+++ b/src/Skoruba.IdentityServer4.Admin.EntityFramework.PostgreSQL/Migrations/Identity/20191120100035_DbInit.cs
@@ -29,6 +29,7 @@ namespace Skoruba.IdentityServer4.Admin.EntityFramework.PostgreSQL.Migrations.Id
                     Id = table.Column<string>(nullable: false),
                     UserName = table.Column<string>(maxLength: 256, nullable: true),
                     NormalizedUserName = table.Column<string>(maxLength: 256, nullable: true),
+                    UserDomain = table.Column<string>(maxLength: 256, nullable: true),
                     Email = table.Column<string>(maxLength: 256, nullable: true),
                     NormalizedEmail = table.Column<string>(maxLength: 256, nullable: true),
                     EmailConfirmed = table.Column<bool>(nullable: false),

--- a/src/Skoruba.IdentityServer4.Admin.EntityFramework.PostgreSQL/Migrations/Identity/AdminIdentityDbContextModelSnapshot.cs
+++ b/src/Skoruba.IdentityServer4.Admin.EntityFramework.PostgreSQL/Migrations/Identity/AdminIdentityDbContextModelSnapshot.cs
@@ -70,6 +70,10 @@ namespace Skoruba.IdentityServer4.Admin.EntityFramework.PostgreSQL.Migrations.Id
                     b.Property<string>("UserName")
                         .HasColumnType("character varying(256)")
                         .HasMaxLength(256);
+                    
+                    b.Property<string>("UserDomain")
+                        .HasColumnType("character varying(256)")
+                        .HasMaxLength(256);
 
                     b.HasKey("Id");
 

--- a/src/Skoruba.IdentityServer4.Admin.EntityFramework.Shared/Entities/Identity/UserIdentity.cs
+++ b/src/Skoruba.IdentityServer4.Admin.EntityFramework.Shared/Entities/Identity/UserIdentity.cs
@@ -4,6 +4,6 @@ namespace Skoruba.IdentityServer4.Admin.EntityFramework.Shared.Entities.Identity
 {
 	public class UserIdentity : IdentityUser
 	{
-		
+		public string UserDomain { get; set; }
 	}
 }

--- a/src/Skoruba.IdentityServer4.Admin.EntityFramework.SqlServer/Migrations/Identity/20191119163918_DbInit.cs
+++ b/src/Skoruba.IdentityServer4.Admin.EntityFramework.SqlServer/Migrations/Identity/20191119163918_DbInit.cs
@@ -28,6 +28,7 @@ namespace Skoruba.IdentityServer4.Admin.EntityFramework.SqlServer.Migrations.Ide
                     Id = table.Column<string>(nullable: false),
                     UserName = table.Column<string>(maxLength: 256, nullable: true),
                     NormalizedUserName = table.Column<string>(maxLength: 256, nullable: true),
+                    UserDomain = table.Column<string>(maxLength: 256, nullable: true),
                     Email = table.Column<string>(maxLength: 256, nullable: true),
                     NormalizedEmail = table.Column<string>(maxLength: 256, nullable: true),
                     EmailConfirmed = table.Column<bool>(nullable: false),

--- a/src/Skoruba.IdentityServer4.Admin.EntityFramework.SqlServer/Migrations/Identity/AdminIdentityDbContextModelSnapshot.cs
+++ b/src/Skoruba.IdentityServer4.Admin.EntityFramework.SqlServer/Migrations/Identity/AdminIdentityDbContextModelSnapshot.cs
@@ -80,6 +80,10 @@ namespace Skoruba.IdentityServer4.Admin.EntityFramework.SqlServer.Migrations.Ide
                         .IsUnique()
                         .HasName("UserNameIndex")
                         .HasFilter("[NormalizedUserName] IS NOT NULL");
+                    
+                    b.Property<string>("UserDomain")
+                        .HasColumnType("nvarchar(256)")
+                        .HasMaxLength(256);
 
                     b.ToTable("Users");
                 });

--- a/src/Skoruba.IdentityServer4.Admin.UI/Areas/AdminUI/Views/Identity/UserDelete.cshtml
+++ b/src/Skoruba.IdentityServer4.Admin.UI/Areas/AdminUI/Views/Identity/UserDelete.cshtml
@@ -30,6 +30,19 @@
 		<h5 class="card-header">@Localizer["PageTitle"]</h5>
 		<div class="card-body">
 
+			@if (!string.IsNullOrEmpty(Model.UserDomain))
+            {
+                <!--Input - text -->
+                <div class="form-group row">
+                    <label asp-for="UserDomain" class="col-sm-3 col-form-label">
+                        @await Html.PartialAsync("User/Section/Label", "UserUserDomain")
+                    </label>
+                    <div class="col-sm-9">
+                        <input type="text" class="form-control" disabled="disabled" asp-for="UserDomain">
+                    </div>
+                </div>
+            }
+
 			<!--Input - text -->
 			<div class="form-group row">
 				<label asp-for="UserName" class="col-sm-3 col-form-label">

--- a/src/Skoruba.IdentityServer4.Admin.UI/Areas/AdminUI/Views/Identity/UserProfile.cshtml
+++ b/src/Skoruba.IdentityServer4.Admin.UI/Areas/AdminUI/Views/Identity/UserProfile.cshtml
@@ -1,7 +1,9 @@
 ﻿@using Microsoft.AspNetCore.Mvc.Localization
 @using Skoruba.IdentityServer4.Admin.UI.Configuration.Constants
+@using Skoruba.IdentityServer4.Shared.Configuration.Configuration.Identity
 @model Skoruba.IdentityServer4.Admin.BusinessLogic.Identity.Dtos.Identity.Interfaces.IUserDto
 @inject IViewLocalizer Localizer
+@inject UserDomainsConfiguration UserDomainsConfiguration
 
 @{
     ViewBag.Title = Localizer["PageTitle"];
@@ -36,7 +38,10 @@
                 <a asp-area="@CommonConsts.AdminUIArea" asp-action="UserRoles" asp-route-id="@Model.Id" class="btn btn-outline-primary">@Localizer["ButtonManageUserRoles"]</a>
                 <a asp-area="@CommonConsts.AdminUIArea" asp-action="UserProviders" asp-route-id="@Model.Id" class="btn btn-outline-primary">@Localizer["ButtonManageUserExternalProviders"]</a>
                 <a asp-area="@CommonConsts.AdminUIArea" asp-action="AuditLog" asp-controller="Log" asp-route-subjectIdentifier="@Model.Id" class="btn btn-primary">@Localizer["Audit Log"]</a>
+                @if (!UserDomainsConfiguration.EnableUserDomains || !UserDomainsConfiguration.CheckIfDomainUsesLdapWebApi(Model.UserDomain))
+                {
                 <a asp-area="@CommonConsts.AdminUIArea" asp-action="UserChangePassword" asp-route-id="@Model.Id" class="btn btn-dark">@Localizer["ButtonChangePassword"]</a>
+                }
                 <a asp-area="@CommonConsts.AdminUIArea" asp-action="UserDelete" asp-route-id="@Model.Id" class="btn btn-danger">@Localizer["ButtonDeleteUser"]</a>
             </div>
         </div>
@@ -54,6 +59,18 @@
                     <img-gravatar email="@Model.Email" class="img-thumbnail" size="150" />
                 </div>
                 <div class="col-sm-10">
+                    @if (UserDomainsConfiguration.EnableUserDomains)
+                    {
+                        <div class="form-group row">
+                            <label asp-for="UserDomain" class="col-sm-3 col-form-label">
+                                @await Html.PartialAsync("User/Section/Label", "UserUserDomain")
+                            </label>
+                            <div class="col-sm-9">
+                                <select class="form-control" asp-for="UserDomain" asp-items="@(new SelectList(UserDomainsConfiguration.UserDomains,nameof(UserDomainsConfiguration.UserDomain.DomainId), nameof(UserDomainsConfiguration.UserDomain.DomainTitle)))">
+                                </select>
+                            </div>
+                        </div>
+                    }
                     <!--Input - text -->
                     <div class="form-group row">
                         <label asp-for="UserName" class="col-sm-3 col-form-label">

--- a/src/Skoruba.IdentityServer4.Admin.UI/Areas/AdminUI/Views/Identity/Users.cshtml
+++ b/src/Skoruba.IdentityServer4.Admin.UI/Areas/AdminUI/Views/Identity/Users.cshtml
@@ -1,8 +1,10 @@
 ﻿@using Microsoft.AspNetCore.Mvc.Localization
 @using Skoruba.IdentityServer4.Admin.BusinessLogic.Shared.Dtos.Common
 @using Skoruba.IdentityServer4.Admin.UI.Configuration.Constants
+@using Skoruba.IdentityServer4.Shared.Configuration.Configuration.Identity
 @model Skoruba.IdentityServer4.Admin.BusinessLogic.Identity.Dtos.Identity.Interfaces.IUsersDto
 @inject IViewLocalizer Localizer
+@inject UserDomainsConfiguration UserDomainsConfiguration
 
 @{
     ViewBag.Title = Localizer["Title"];
@@ -37,6 +39,10 @@
                         <th></th>
                         <th>@Localizer["UserId"]</th>
                         <th>@Localizer["UserName"]</th>
+                        @if (UserDomainsConfiguration.EnableUserDomains)
+                        {
+                        <th>@Localizer["UserDomain"]</th>
+                        }
                         <th>@Localizer["Email"]</th>
                         <th></th>
                     </tr>
@@ -53,7 +59,15 @@
                                 <img-gravatar email="@user.Email" class="gravatar-image img-thumbnail" />
                             </td>
                             <td class="align-middle">@user.Id</td>
-                            <td class="align-middle">@user.UserName</td>
+                            @if (UserDomainsConfiguration.EnableUserDomains)
+                            {
+                                <td class="align-middle">@user.UserNameView</td>
+                                <td class="align-middle">@user.UserDomain</td>
+                            }
+                            else
+                            {
+                                <td class="align-middle">@user.UserName</td>
+                            }
                             <td class="align-middle">@user.Email</td>
                             <td class="align-middle">
                                 <a asp-area="@CommonConsts.AdminUIArea" class="btn btn-danger" asp-action="UserDelete" asp-route-id="@user.Id"><span class="oi oi-x"></span></a>

--- a/src/Skoruba.IdentityServer4.Admin.UI/Resources/Areas/AdminUI/Views/Identity/User/Section/Label.en.resx
+++ b/src/Skoruba.IdentityServer4.Admin.UI/Resources/Areas/AdminUI/Views/Identity/User/Section/Label.en.resx
@@ -219,6 +219,12 @@
   <data name="UserTwoFactorEnabled_Label" xml:space="preserve">
     <value>User Two Factor Enabled</value>
   </data>
+  <data name="UserUserDomain_Info" xml:space="preserve">
+    <value>Domain that can be used to group users or to authenticate them in a network domain by using the LDAP Web Api.</value>
+  </data>
+  <data name="UserUserDomain_Label" xml:space="preserve">
+    <value>Domain</value>
+  </data>
   <data name="UserUserName_Info" xml:space="preserve">
     <value>User Name</value>
   </data>

--- a/src/Skoruba.IdentityServer4.Admin.UI/Resources/Areas/AdminUI/Views/Identity/User/Section/Label.es.resx
+++ b/src/Skoruba.IdentityServer4.Admin.UI/Resources/Areas/AdminUI/Views/Identity/User/Section/Label.es.resx
@@ -219,6 +219,12 @@
   <data name="UserTwoFactorEnabled_Label" xml:space="preserve">
     <value>User Two Factor habilitado</value>
   </data>
+  <data name="UserUserDomain_Info" xml:space="preserve">
+    <value>Dominio que se puede usar para agrupar usuarios o para autenticarlos en un dominio de red mediante LDAP Web Api.</value>
+  </data>
+  <data name="UserUserDomain_Label" xml:space="preserve">
+    <value>Dominio</value>
+  </data>
   <data name="UserUserName_Info" xml:space="preserve">
     <value>Nombre de usuario</value>
   </data>

--- a/src/Skoruba.IdentityServer4.Admin.UI/Resources/Areas/AdminUI/Views/Identity/Users.en.resx
+++ b/src/Skoruba.IdentityServer4.Admin.UI/Resources/Areas/AdminUI/Views/Identity/Users.en.resx
@@ -129,6 +129,9 @@
   <data name="Title" xml:space="preserve">
     <value>Users</value>
   </data>
+  <data name="UserDomain" xml:space="preserve">
+    <value>Domain</value>
+  </data>
   <data name="UserId" xml:space="preserve">
     <value>UserId</value>
   </data>

--- a/src/Skoruba.IdentityServer4.Admin.UI/Resources/Areas/AdminUI/Views/Identity/Users.es.resx
+++ b/src/Skoruba.IdentityServer4.Admin.UI/Resources/Areas/AdminUI/Views/Identity/Users.es.resx
@@ -129,6 +129,9 @@
   <data name="Title" xml:space="preserve">
     <value>Usuarios</value>
   </data>
+  <data name="UserDomain" xml:space="preserve">
+    <value>Dominio</value>
+  </data>
   <data name="UserId" xml:space="preserve">
     <value>ID de usuario</value>
   </data>

--- a/src/Skoruba.IdentityServer4.Admin/Startup.cs
+++ b/src/Skoruba.IdentityServer4.Admin/Startup.cs
@@ -42,6 +42,8 @@ namespace Skoruba.IdentityServer4.Admin
 
             // Add email senders which is currently setup for SendGrid and SMTP
             services.AddEmailSenders(Configuration);
+
+            services.AddUserDomainsConfiguration(Configuration);
         }
 
         public void Configure(IApplicationBuilder app, IWebHostEnvironment env, ILoggerFactory loggerFactory)

--- a/src/Skoruba.IdentityServer4.Admin/appsettings.json
+++ b/src/Skoruba.IdentityServer4.Admin/appsettings.json
@@ -40,7 +40,7 @@
     },
     "UserDomainsConfiguration": {
         "EnableUserDomains": true,
-        "UserDomainsZZZ": [
+        "UserDomains": [
             {
                 "DomainId": "",
                 "DomainTitle": "(No Domain)",

--- a/src/Skoruba.IdentityServer4.Admin/appsettings.json
+++ b/src/Skoruba.IdentityServer4.Admin/appsettings.json
@@ -38,6 +38,46 @@
         "AdministrationRole": "SkorubaIdentityAdminAdministrator",
         "HideUIForMSSqlErrorLogging": false
     },
+    "UserDomainsConfiguration": {
+        "EnableUserDomains": true,
+        "UserDomainsZZZ": [
+            {
+                "DomainId": "",
+                "DomainTitle": "(No Domain)",
+                "UseLdapWebApi": false
+            },
+            {
+                "DomainId": "CUSTOM-DOM1",
+                "DomainTitle": "CUSTOM DOMAIN #1",
+                "UseLdapWebApi": false
+            },
+            {
+                "DomainId": "CUSTOM-DOM2",
+                "DomainTitle": "CUSTOM DOMAIN #2",
+                "UseLdapWebApi": false
+            },
+            {
+                "DomainId": "CAMPANY1-DOM1",
+                "DomainTitle": "CAMPANY 1 DOM #1",
+                "UseLdapWebApi": true
+            },
+            {
+                "DomainId": "COMPANY1-DOM2",
+                "DomainTitle": "CAMPANY 1 DOM #2",
+                "UseLdapWebApi": true
+            },
+            {
+                "DomainId": "COMPANY2-DOM1",
+                "DomainTitle": "CAMPANY 2 DOM #1",
+                "UseLdapWebApi": true
+            },
+            {
+                "DomainName": "COMPANY2-DOM2",
+                "DomainTitle": "CAMPANY 2 DOM #2",
+                "UseLdapWebApi": true
+            }
+        ]
+    },
     "SecurityConfiguration": {
         "CspTrustedDomains": [
             "fonts.googleapis.com",
@@ -73,7 +113,8 @@
             "RequiredLength": 8
         },
         "User": {
-            "RequireUniqueEmail": true
+            "RequireUniqueEmail": true,
+            "AllowedUserNameCharacters": "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._@+\\"
         },
         "SignIn": {
             "RequireConfirmedAccount": false

--- a/src/Skoruba.IdentityServer4.STS.Identity/Configuration/LdapWebApiProviderConfiguration.cs
+++ b/src/Skoruba.IdentityServer4.STS.Identity/Configuration/LdapWebApiProviderConfiguration.cs
@@ -1,0 +1,111 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Skoruba.IdentityServer4.Admin.EntityFramework.Shared.Entities.Identity;
+
+namespace Skoruba.IdentityServer4.STS.Identity.Configuration
+{
+    public class LdapWebApiProviderConfiguration<TUserIdentity> where TUserIdentity : class
+    {
+        public bool UseLdapWebApiProvider { get; set; }
+        public LdapWebApiProfile[] LdapWebApiProfiles { get; set; }
+        public UserDomainProfile[] UserDomainProfiles { get; set; }
+
+
+        public LdapWebApiProviderConfiguration()
+        {
+            UseLdapWebApiProvider = false;
+            LdapWebApiProfiles = new LdapWebApiProfile[] { };
+            UserDomainProfiles = new UserDomainProfile[] { };
+        }
+
+
+        public void CheckConfigurationIntegrity()
+        {
+            if (!UseLdapWebApiProvider)
+                return;
+
+            if (UserDomainProfiles == null || UserDomainProfiles.Length == 0)
+                throw new Exception($"Error in {nameof(LdapWebApiProviderConfiguration<TUserIdentity>)} configuration section. {nameof(UseLdapWebApiProvider)} is enabled, but no Domain profile is defined in {nameof(UserDomainProfiles)}.");
+
+            if (LdapWebApiProfiles == null || LdapWebApiProfiles.Length == 0)
+                throw new Exception($"Error in {nameof(LdapWebApiProviderConfiguration<TUserIdentity>)} configuration section. {nameof(UseLdapWebApiProvider)} is enabled, but no LDAP Web Api profile is defined in {nameof(LdapWebApiProfiles)}.");
+
+            var repeatedWebApiProfileIds = LdapWebApiProfiles
+                .GroupBy(p => p.WebApiProfileId)
+                .Where(g => g.Count() > 1)
+                .Select(c => c.Key)
+                .ToArray();
+
+            if (repeatedWebApiProfileIds.Length > 0)
+                throw new Exception($"Error in {nameof(LdapWebApiProviderConfiguration<TUserIdentity>)} configuration section. Repeated {nameof(LdapWebApiProfile.WebApiProfileId)} identifier ({String.Join(", ", repeatedWebApiProfileIds)}) in {nameof(LdapWebApiProfiles)}. Take a look at the {nameof(LdapWebApiProviderConfiguration<TUserIdentity>)}.{nameof(LdapWebApiProfiles)} section.");
+
+            var repeatedDomainIds = UserDomainProfiles
+                .GroupBy(p => p.DomainId)
+                .Where(g => g.Count() > 1)
+                .Select(c => c.Key).ToArray();
+
+            if (repeatedDomainIds.Length > 0)
+                throw new Exception($"Error in {nameof(LdapWebApiProviderConfiguration<TUserIdentity>)} configuration section. Repeated {nameof(UserDomainProfile.DomainId)} identifier ({string.Join(", ", repeatedDomainIds)}) in {nameof(UserDomainProfiles)}. Take a look at the {nameof(LdapWebApiProviderConfiguration<TUserIdentity>)}.{nameof(UserDomainProfiles)} section.");
+
+            foreach (var udp in UserDomainProfiles)
+            {
+                if (!LdapWebApiProfiles.Any(f => f.WebApiProfileId == udp.WebApiProfileId))
+                {
+                    throw new Exception($"Error in {nameof(LdapWebApiProviderConfiguration<TUserIdentity>)} configuration section. {nameof(UserDomainProfile.WebApiProfileId)} \"{udp.WebApiProfileId}\" for {nameof(UserDomainProfile.DomainId)} \"{udp.DomainId}\" does not exist in {nameof(LdapWebApiProviderConfiguration<TUserIdentity>)}.{nameof(LdapWebApiProfiles)}");
+                }
+
+                udp.LdapWebApiProfile = LdapWebApiProfiles.Where(p => p.WebApiProfileId == udp.WebApiProfileId).Single();
+            }
+        }
+
+        public UserDomainProfile GetUserDomainProfile(TUserIdentity user)
+        {
+            return UserDomainProfiles.Where(i => i.DomainId == (user as UserIdentity).UserDomain).SingleOrDefault();
+        }
+
+
+
+        #region Inner classes
+        public class LdapWebApiProfile
+        {
+            public string WebApiProfileId { get; set; }
+            public string WebApiUrl { get; set; }
+            public Bitai.LDAPWebApi.Clients.WebApiSecurityDefinition WebApiSecurityDefinition { get; set; }
+        }
+
+        public class UserDomainProfile
+        {
+            private Bitai.LDAPWebApi.Clients.LDAPCredentialsClient<Bitai.LDAPWebApi.DTO.LDAPAccountAuthenticationStatus> _lapCredentialsClient;
+            private Bitai.LDAPWebApi.Clients.LDAPUserDirectoryClient<Bitai.LDAPHelper.DTO.LDAPSearchResult> _ldapUserDirectoryClient;
+
+
+
+            public string DomainId { get; set; }
+            public string WebApiProfileId { get; set; }
+            public string LdapServerProfile { get; set; }
+            public LdapWebApiProfile LdapWebApiProfile { internal set; get; }
+
+
+
+
+            public Bitai.LDAPWebApi.Clients.LDAPCredentialsClient<Bitai.LDAPWebApi.DTO.LDAPAccountAuthenticationStatus> GetLdapCredentialsClient()
+            {
+                if (_lapCredentialsClient == null)
+                    _lapCredentialsClient = new Bitai.LDAPWebApi.Clients.LDAPCredentialsClient<Bitai.LDAPWebApi.DTO.LDAPAccountAuthenticationStatus>(LdapWebApiProfile.WebApiUrl, LdapServerProfile, false, LdapWebApiProfile.WebApiSecurityDefinition);
+
+                return _lapCredentialsClient;
+            }
+
+            public Bitai.LDAPWebApi.Clients.LDAPUserDirectoryClient<Bitai.LDAPHelper.DTO.LDAPSearchResult> GetLdapUserDirectoryClient()
+            {
+                if (_ldapUserDirectoryClient == null)
+                    _ldapUserDirectoryClient = new Bitai.LDAPWebApi.Clients.LDAPUserDirectoryClient<Bitai.LDAPHelper.DTO.LDAPSearchResult>(LdapWebApiProfile.WebApiUrl, LdapServerProfile, false, LdapWebApiProfile.WebApiSecurityDefinition);
+
+                return _ldapUserDirectoryClient;
+            }
+        }
+        #endregion
+    }
+}

--- a/src/Skoruba.IdentityServer4.STS.Identity/Controllers/ManageController.cs
+++ b/src/Skoruba.IdentityServer4.STS.Identity/Controllers/ManageController.cs
@@ -630,8 +630,11 @@ namespace Skoruba.IdentityServer4.STS.Identity.Controllers
             var claims = await _userManager.GetClaimsAsync(user);
             var profile = OpenIdClaimHelpers.ExtractProfileInfo(claims);
 
+            var userIdentity = (user as Admin.EntityFramework.Shared.Entities.Identity.UserIdentity);
+
             var model = new IndexViewModel
             {
+                UserDomain = userIdentity.UserDomain,
                 Username = user.UserName,
                 Email = user.Email,
                 PhoneNumber = user.PhoneNumber,

--- a/src/Skoruba.IdentityServer4.STS.Identity/Helpers/StartupHelpers.cs
+++ b/src/Skoruba.IdentityServer4.STS.Identity/Helpers/StartupHelpers.cs
@@ -474,5 +474,18 @@ namespace Skoruba.IdentityServer4.STS.Identity.Helpers
                 }
             }
         }
+
+        public static void AddLdapWebApiProvider<TUser>(this IServiceCollection services, IConfiguration configuration)
+            where TUser : class
+        {
+            var ldapProviderConfiguration = configuration.GetSection(nameof(LdapWebApiProviderConfiguration<TUser>)).Get<LdapWebApiProviderConfiguration<TUser>>();
+
+            if (ldapProviderConfiguration == null)
+                ldapProviderConfiguration = new LdapWebApiProviderConfiguration<TUser>();
+
+            ldapProviderConfiguration.CheckConfigurationIntegrity();
+
+            services.AddSingleton(ldapProviderConfiguration);
+        }
     }
 }

--- a/src/Skoruba.IdentityServer4.STS.Identity/Resources/Views/Manage/Index.en.resx
+++ b/src/Skoruba.IdentityServer4.STS.Identity/Resources/Views/Manage/Index.en.resx
@@ -153,6 +153,9 @@
   <data name="Title" xml:space="preserve">
     <value>Profile</value>
   </data>
+  <data name="UserDomain" xml:space="preserve">
+    <value>Domain</value>
+  </data>
   <data name="UserName" xml:space="preserve">
     <value>UserName</value>
   </data>

--- a/src/Skoruba.IdentityServer4.STS.Identity/Resources/Views/Manage/Index.es.resx
+++ b/src/Skoruba.IdentityServer4.STS.Identity/Resources/Views/Manage/Index.es.resx
@@ -153,6 +153,9 @@
     <data name="Title" xml:space="preserve">
         <value>Perfil</value>
     </data>
+    <data name="UserDomain" xml:space="preserve">
+        <value>Dominio</value>
+    </data>
     <data name="UserName" xml:space="preserve">
         <value>Nombre de usuario</value>
     </data>

--- a/src/Skoruba.IdentityServer4.STS.Identity/Skoruba.IdentityServer4.STS.Identity.csproj
+++ b/src/Skoruba.IdentityServer4.STS.Identity/Skoruba.IdentityServer4.STS.Identity.csproj
@@ -16,6 +16,7 @@
         <PackageReference Include="AspNetCore.HealthChecks.SqlServer" Version="5.0.2" />
         <PackageReference Include="AspNetCore.HealthChecks.UI" Version="5.0.1" />
         <PackageReference Include="AspNetCore.HealthChecks.UI.Client" Version="5.0.1" />
+        <PackageReference Include="Bitai.LDAPWebApi.Clients" Version="3.0.0" />
         <PackageReference Include="Microsoft.AspNetCore.DataProtection.EntityFrameworkCore" Version="5.0.5" />
         <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="5.0.5" />
         <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="5.0.5" />

--- a/src/Skoruba.IdentityServer4.STS.Identity/Startup.cs
+++ b/src/Skoruba.IdentityServer4.STS.Identity/Startup.cs
@@ -55,6 +55,8 @@ namespace Skoruba.IdentityServer4.STS.Identity
             RegisterAuthorization(services);
 
             services.AddIdSHealthChecks<IdentityServerConfigurationDbContext, IdentityServerPersistedGrantDbContext, AdminIdentityDbContext, IdentityServerDataProtectionDbContext>(Configuration);
+
+            services.AddLdapWebApiProvider<UserIdentity>(Configuration);
         }
 
         public void Configure(IApplicationBuilder app, IWebHostEnvironment env)

--- a/src/Skoruba.IdentityServer4.STS.Identity/ViewModels/Manage/IndexViewModel.cs
+++ b/src/Skoruba.IdentityServer4.STS.Identity/ViewModels/Manage/IndexViewModel.cs
@@ -4,6 +4,8 @@ namespace Skoruba.IdentityServer4.STS.Identity.ViewModels.Manage
 {
     public class IndexViewModel
     {
+        public string UserDomain { get; set; }
+
         public string Username { get; set; }
 
         public bool IsEmailConfirmed { get; set; }

--- a/src/Skoruba.IdentityServer4.STS.Identity/Views/Manage/Index.cshtml
+++ b/src/Skoruba.IdentityServer4.STS.Identity/Views/Manage/Index.cshtml
@@ -14,6 +14,13 @@
     </div>
     <div class="col-sm-10">
         <form method="post">
+            @if (!string.IsNullOrEmpty(Model.UserDomain))
+            {
+                <div class="form-group">
+                    <label asp-for="UserDomain">@Localizer["UserDomain"]</label>
+                    <input asp-for="UserDomain" class="form-control" disabled />
+                </div>
+            }
             <div class="form-group">
                 <label asp-for="Username">@Localizer["UserName"]</label>
                 <input asp-for="Username" class="form-control" disabled />

--- a/src/Skoruba.IdentityServer4.STS.Identity/appsettings.json
+++ b/src/Skoruba.IdentityServer4.STS.Identity/appsettings.json
@@ -48,6 +48,53 @@
         "AzureAdCallbackPath": "",
         "AzureDomain": ""
     },
+    "LdapWebApiProviderConfiguration": {
+        "UseLdapWebApiProvider": true,
+        "LdapWebApiProfiles": [
+            {
+                "WebApiProfileId": "WebApi_1",
+                "WebApiUrl": "https://localhost:44331",
+                "WebApiSecurityDefinition": {
+                    "AuthorityUrl": "https://localhost:44310",
+                    "ApiScope": "Bitai.LdapWebApi.Scope.Global",
+                    "ClientId": "Bitai.LdapWebApi.Demo.Client",
+                    "ClientSecret": "2ef61cb6-9ca6-7418-c116-80784583d88f"
+                }
+            },
+            {
+                "WebApiProfileId": "WebApi_2",
+                "WebApiUrl": "https://anotherWebApiServer/anotherLdapWebApi",
+                "WebApiSecurityDefinition": {
+                    "AuthorityUrl": "https://anotherAuthorityServer",
+                    "ApiScope": "anotherApiScope",
+                    "ClientId": "anotherClientId",
+                    "ClientSecret": "anotherClientSecret"
+                }
+            }
+        ],
+        "UserDomainProfiles": [
+            {
+                "DomainId": "CAMPANY1-DOM1",
+                "WebApiProfileId": "WebApi_1",
+                "LdapServerProfile": "LDAPSVR1"
+            },
+            {
+                "DomainId": "CAMPANY1-DOM2",
+                "WebApiProfileId": "WebApi_1",
+                "LdapServerProfile": "LDAPSVR2"
+            },
+            {
+                "DomainId": "COMPANY2-DOM1",
+                "WebApiProfileId": "WebApi_2",
+                "LdapServerProfile": "SVR123"
+            },
+            {
+                "DomainId": "COMPANY2-DOM2",
+                "WebApiProfileId": "WebApi_2",
+                "LdapServerProfile": "SVRABC"
+            }
+        ]
+    },
     "SmtpConfiguration": {
         "Host": "",
         "Login": "",

--- a/src/Skoruba.IdentityServer4.Shared.Configuration/Configuration/Identity/UserDomainsConfiguration.cs
+++ b/src/Skoruba.IdentityServer4.Shared.Configuration/Configuration/Identity/UserDomainsConfiguration.cs
@@ -1,0 +1,107 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Linq;
+
+namespace Skoruba.IdentityServer4.Shared.Configuration.Configuration.Identity
+{
+    public class UserDomainsConfiguration
+    {
+        /// <summary>
+        /// Whether or not to allow the user administration to 
+        /// assign a domain to the user.
+        /// </summary>
+        public bool EnableUserDomains { get; set; }
+
+        /// <summary>
+        /// Array of <see cref="UserDomain"/>
+        /// </summary>
+        public UserDomain[] UserDomains { get; set; }
+
+
+        public UserDomainsConfiguration()
+        {
+            EnableUserDomains = false;
+            UserDomains = new UserDomain[] { };
+        }
+
+
+        /// <summary>
+        /// Check if the domain uses an Ldap Web Api
+        /// </summary>
+        /// <param name="domainId">Domain identifier. See <see cref="UserDomain"/> properties.</param>
+        /// <returns><see cref="Boolean"/></returns>
+        public bool CheckIfDomainUsesLdapWebApi(string domainId)
+        {
+            return UserDomains.Any(d => d.DomainId == (domainId ?? "") & d.UseLdapWebApi == true);
+        }
+
+        public void CheckConfigurationIntegrity()
+        {
+            if (!EnableUserDomains)
+                return;
+
+            if (UserDomains == null || UserDomains.Length == 0)
+                throw new Exception($"Error in {nameof(UserDomainsConfiguration)} configuration section. {nameof(EnableUserDomains)} is enable, but no Domain profile is defined in {nameof(UserDomains)}.");
+
+            var repeatedBlankDomainIds = UserDomains
+                .Where(d => d.DomainId == string.Empty)
+                .GroupBy(d => d.DomainId)
+                .Where(g => g.Count() > 1)
+                .Select(c => c.Key).ToArray();
+
+            if (repeatedBlankDomainIds.Length > 0)
+                throw new Exception($"Error in {nameof(UserDomainsConfiguration)} configuration section. Only one blank DomainId is allowed in {nameof(UserDomains)}. Take a look at {nameof(UserDomainsConfiguration)}.{nameof(UserDomains)} configuration section.");
+
+            var blankTitleCount = UserDomains
+                .Where(ud => ud.DomainId != string.Empty & ud.DomainTitle == string.Empty)
+                .Count();
+
+            if (blankTitleCount > 0)
+                throw new Exception($"Error in {nameof(UserDomainsConfiguration)} configuration section. Only the blank {nameof(UserDomain.DomainId)} can have the blank {nameof(UserDomain.DomainTitle)}.");
+
+            var repeatedDomainIds = UserDomains
+                .GroupBy(d => d.DomainId)
+                .Where(g => g.Count() > 1)
+                .Select(c => c.Key).ToArray();
+
+            if (repeatedDomainIds.Length > 0)
+                throw new Exception($"Error in {nameof(UserDomainsConfiguration)} configuration section. Repeated {nameof(UserDomain.DomainId)} ({string.Join(", ", repeatedDomainIds)}) in {nameof(UserDomains)}. Take a look at {nameof(UserDomainsConfiguration)}.{nameof(UserDomains)} configuration section.");
+
+            var repeatedDomainTitles = UserDomains
+                .GroupBy(d => d.DomainTitle)
+                .Where(g => g.Count() > 1)
+                .Select(c => c.Key).ToArray();
+
+            if (repeatedDomainTitles.Length > 0)
+                throw new Exception($"Error in {nameof(UserDomainsConfiguration)} configuration section. Repeated {nameof(UserDomain.DomainTitle)} ({string.Join(", ", repeatedDomainTitles)}) in {nameof(UserDomains)}. Take a look at {nameof(UserDomainsConfiguration)}.{nameof(UserDomains)} configuration section.");
+        }
+
+        #region Inner classs
+        /// <summary>
+        /// Domain that can be assigned to a user.
+        /// </summary>
+        public class UserDomain
+        {
+            /// <summary>
+            /// Identifier in appsettings file. Can be empty value.
+            /// </summary>
+            public string DomainId { get; set; }
+
+            /// <summary>
+            /// Descriptive title of the Domain Id
+            /// </summary>
+            public string DomainTitle { get; set; }
+
+            /// <summary>
+            /// If true, the users marked with the Domain Id 
+            /// will authenticate in the corresponding LDAP Web Api.
+            /// If false, users marked with the domain id will continue
+            /// to authenticate with the regular method, based on the 
+            /// data stored in the local repository.
+            /// </summary>
+            public bool UseLdapWebApi { get; set; }
+        }
+        #endregion
+    }
+}

--- a/src/Skoruba.IdentityServer4.Shared.Configuration/Helpers/StartupHelpers.cs
+++ b/src/Skoruba.IdentityServer4.Shared.Configuration/Helpers/StartupHelpers.cs
@@ -11,6 +11,7 @@ using Microsoft.Extensions.Configuration.AzureKeyVault;
 using Microsoft.Extensions.DependencyInjection;
 using SendGrid;
 using Skoruba.IdentityServer4.Shared.Configuration.Configuration.Common;
+using Skoruba.IdentityServer4.Shared.Configuration.Configuration.Identity;
 using Skoruba.IdentityServer4.Shared.Configuration.Configuration.Email;
 using Skoruba.IdentityServer4.Shared.Configuration.Email;
 
@@ -101,6 +102,18 @@ namespace Skoruba.IdentityServer4.Shared.Configuration.Helpers
                     }
                 }
             }
+        }
+
+        public static void AddUserDomainsConfiguration(this IServiceCollection services, IConfiguration configuration)
+        {
+            var userDomainsConfiguration = configuration.GetSection(nameof(UserDomainsConfiguration)).Get<UserDomainsConfiguration>();
+
+            if (userDomainsConfiguration == null)
+                userDomainsConfiguration = new UserDomainsConfiguration();
+
+            userDomainsConfiguration.CheckConfigurationIntegrity();
+
+            services.AddSingleton(userDomainsConfiguration);
         }
     }
 }

--- a/tests/Skoruba.IdentityServer4.Admin.UnitTests/Controllers/IdentityControllerTests.cs
+++ b/tests/Skoruba.IdentityServer4.Admin.UnitTests/Controllers/IdentityControllerTests.cs
@@ -30,6 +30,7 @@ using Skoruba.IdentityServer4.Admin.UI.Helpers;
 using Skoruba.IdentityServer4.Admin.UI.Helpers.Localization;
 using Xunit;
 using System.Security.Claims;
+using Skoruba.IdentityServer4.Shared.Configuration.Configuration.Identity;
 
 namespace Skoruba.IdentityServer4.Admin.UnitTests.Controllers
 {
@@ -566,6 +567,7 @@ namespace Skoruba.IdentityServer4.Admin.UnitTests.Controllers
             var logger = serviceProvider.GetRequiredService<ILogger<ConfigurationController>>();
             var tempDataDictionaryFactory = serviceProvider.GetRequiredService<ITempDataDictionaryFactory>();
             var identityService = GetIdentityService(serviceProvider);
+            var userDomainsConfiguration = serviceProvider.GetRequiredService<UserDomainsConfiguration>();
 
             //Get Controller
             var controller = new IdentityController<UserDto<string>, RoleDto<string>,
@@ -573,7 +575,7 @@ namespace Skoruba.IdentityServer4.Admin.UnitTests.Controllers
                 UserIdentityUserLogin, UserIdentityRoleClaim, UserIdentityUserToken,
                 UsersDto<UserDto<string>, string>, RolesDto<RoleDto<string>, string>, UserRolesDto<RoleDto<string>, string>,
                 UserClaimsDto<UserClaimDto<string>, string>, UserProviderDto<string>, UserProvidersDto<UserProviderDto<string>, string>, UserChangePasswordDto<string>,
-                RoleClaimsDto<RoleClaimDto<string>, string>, UserClaimDto<string>, RoleClaimDto<string>>(identityService, logger, localizer);
+                RoleClaimsDto<RoleClaimDto<string>, string>, UserClaimDto<string>, RoleClaimDto<string>>(identityService, logger, localizer, userDomainsConfiguration);
 
             //Setup TempData for notification in basecontroller
             var httpContext = serviceProvider.GetRequiredService<IHttpContextAccessor>().HttpContext;
@@ -651,6 +653,9 @@ namespace Skoruba.IdentityServer4.Admin.UnitTests.Controllers
                 });
 
             services.AddLogging();
+
+            //User domains feature configuration
+            services.AddSingleton<UserDomainsConfiguration>();
 
             return services.BuildServiceProvider();
         }

--- a/tests/Skoruba.IdentityServer4.Admin.UnitTests/Mocks/IdentityDtoMock.cs
+++ b/tests/Skoruba.IdentityServer4.Admin.UnitTests/Mocks/IdentityDtoMock.cs
@@ -8,9 +8,10 @@ namespace Skoruba.IdentityServer4.Admin.UnitTests.Mocks
     {
         public static Faker<UserDto<TKey>> GetUserFaker(TKey id)
         {
+            var newGuid = Guid.NewGuid().ToString();
             var userFaker = new Faker<UserDto<TKey>>()
                 .RuleFor(o => o.Id, id)
-                .RuleFor(o => o.UserName, f => Guid.NewGuid().ToString())
+                .RuleFor(o => o.UserName, f => newGuid)
                 .RuleFor(o => o.Email, f => f.Internet.Email())
                 .RuleFor(o => o.AccessFailedCount, f => f.Random.Int())
                 .RuleFor(o => o.EmailConfirmed, f => f.Random.Bool())
@@ -18,7 +19,9 @@ namespace Skoruba.IdentityServer4.Admin.UnitTests.Mocks
                 .RuleFor(o => o.TwoFactorEnabled, f => f.Random.Bool())
                 .RuleFor(o => o.LockoutEnd, f => f.Date.Future())
                 .RuleFor(o => o.LockoutEnabled, f => true)
-                .RuleFor(o => o.PhoneNumber, f => f.Random.Number().ToString());
+                .RuleFor(o => o.PhoneNumber, f => f.Random.Number().ToString())
+                .RuleFor(o => o.UserNameView, f => newGuid)
+                .RuleFor(o => o.UserDomain, f=> null);
 
             return userFaker;
         }


### PR DESCRIPTION
Hello Skoruba.

This branch has the option to enable or not the assignment of a Domain to the user. If the domain is LDAP, the user will be able to authenticate with their network credentials. User authentication follows the standard flow as specified by the SigningManager.
If this functionality is disabled in the configuration, everything remains as is. I have followed the entire structure of the solution projects.

How does STS.Identity connect or authenticate to an LDAP server?
There is a Web Api that helps in the authentication flow. Depending on the domain the user belongs to, the Web Api is selected.

I would like to investigate, help and maybe collaborate on your project.

Thank you

Viko.