### PR TITLE
Override OpenId redirect uri only when there's a value on configuration

### DIFF
--- a/src/Skoruba.IdentityServer4.Admin.UI/Helpers/StartupHelpers.cs
+++ b/src/Skoruba.IdentityServer4.Admin.UI/Helpers/StartupHelpers.cs
@@ -414,14 +414,17 @@ namespace Skoruba.IdentityServer4.Admin.UI.Helpers
             context.Properties.IsPersistent = true;
             context.Properties.ExpiresUtc = new DateTimeOffset(DateTime.Now.AddHours(adminConfiguration.IdentityAdminCookieExpiresUtcHours));
 
-            return Task.FromResult(0);
+            return Task.CompletedTask;
         }
 
-        private static Task OnRedirectToIdentityProvider(RedirectContext n, AdminConfiguration adminConfiguration)
+        private static Task OnRedirectToIdentityProvider(RedirectContext context, AdminConfiguration adminConfiguration)
         {
-            n.ProtocolMessage.RedirectUri = adminConfiguration.IdentityAdminRedirectUri;
-
-            return Task.FromResult(0);
+            if (!string.IsNullOrEmpty(adminConfiguration.IdentityAdminRedirectUri))
+            {
+                context.ProtocolMessage.RedirectUri = adminConfiguration.IdentityAdminRedirectUri;
+            }
+            
+            return Task.CompletedTask;
         }
 
         public static void AddIdSHealthChecks<TConfigurationDbContext, TPersistedGrantDbContext, TIdentityDbContext,


### PR DESCRIPTION
With this change we allow to keep the default behavior unless the user explicitly tries to override the redirect uri if they have a custom configuration.

Fixes #842 