### PR TITLE
Add Cors configuration to STS

### DIFF
--- a/src/Skoruba.IdentityServer4.STS.Identity/Configuration/Constants/ConfigurationConsts.cs
+++ b/src/Skoruba.IdentityServer4.STS.Identity/Configuration/Constants/ConfigurationConsts.cs
@@ -21,5 +21,7 @@
         public const string AdvancedConfigurationKey = "AdvancedConfiguration";
 
         public const string CspTrustedDomainsKey = "CspTrustedDomains";
+
+        public const string CorsConfigurationKey = "CorsConfiguration";
     }
 }

--- a/src/Skoruba.IdentityServer4.STS.Identity/Configuration/CorsConfiguration.cs
+++ b/src/Skoruba.IdentityServer4.STS.Identity/Configuration/CorsConfiguration.cs
@@ -1,0 +1,9 @@
+﻿namespace Skoruba.IdentityServer4.STS.Identity.Configuration
+{
+    public class CorsConfiguration
+    {
+        public bool CorsAllowAnyOrigin { get; set; }
+
+        public string[] CorsAllowOrigins { get; set; }
+    }
+}

--- a/src/Skoruba.IdentityServer4.STS.Identity/Helpers/StartupHelpers.cs
+++ b/src/Skoruba.IdentityServer4.STS.Identity/Helpers/StartupHelpers.cs
@@ -87,6 +87,30 @@ namespace Skoruba.IdentityServer4.STS.Identity.Helpers
 
             return mvcBuilder;
         }
+                
+        public static void UseCors(this IApplicationBuilder app, IConfiguration configuration)
+        {
+            CorsConfiguration corsConfiguration = new CorsConfiguration();
+            configuration.GetSection(ConfigurationConsts.CorsConfigurationKey).Bind(corsConfiguration);
+
+            if (corsConfiguration.CorsAllowAnyOrigin || corsConfiguration.CorsAllowOrigins?.Count() > 0)
+            {
+                app.UseCors(builder =>
+                {
+                    if (corsConfiguration.CorsAllowAnyOrigin)
+                    {
+                        builder.AllowAnyOrigin();
+                    }
+                    else
+                    {
+                        builder.WithOrigins(corsConfiguration.CorsAllowOrigins);
+                    }
+
+                    builder.AllowAnyHeader();
+                    builder.AllowAnyMethod();
+                });
+            }
+        }
 
         /// <summary>
         /// Using of Forwarded Headers and Referrer Policy

--- a/src/Skoruba.IdentityServer4.STS.Identity/Startup.cs
+++ b/src/Skoruba.IdentityServer4.STS.Identity/Startup.cs
@@ -58,7 +58,7 @@ namespace Skoruba.IdentityServer4.STS.Identity
         }
 
         public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
-        {
+        {            
             app.UseCookiePolicy();
 
             if (env.IsDevelopment())
@@ -76,10 +76,14 @@ namespace Skoruba.IdentityServer4.STS.Identity
             app.UseSecurityHeaders(Configuration);
 
             app.UseStaticFiles();
+
+            app.UseCors(Configuration);
+
             UseAuthentication(app);
             app.UseMvcLocalizationServices();
 
             app.UseRouting();
+
             app.UseAuthorization();
             app.UseEndpoints(endpoint =>
             {

--- a/src/Skoruba.IdentityServer4.STS.Identity/Startup.cs
+++ b/src/Skoruba.IdentityServer4.STS.Identity/Startup.cs
@@ -55,10 +55,12 @@ namespace Skoruba.IdentityServer4.STS.Identity
             RegisterAuthorization(services);
 
             services.AddIdSHealthChecks<IdentityServerConfigurationDbContext, IdentityServerPersistedGrantDbContext, AdminIdentityDbContext, IdentityServerDataProtectionDbContext>(Configuration);
+            
+            services.AddSTSCors(Configuration);
         }
 
         public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
-        {            
+        {
             app.UseCookiePolicy();
 
             if (env.IsDevelopment())
@@ -76,8 +78,6 @@ namespace Skoruba.IdentityServer4.STS.Identity
             app.UseSecurityHeaders(Configuration);
 
             app.UseStaticFiles();
-
-            app.UseCors(Configuration);
 
             UseAuthentication(app);
             app.UseMvcLocalizationServices();

--- a/src/Skoruba.IdentityServer4.STS.Identity/appsettings.json
+++ b/src/Skoruba.IdentityServer4.STS.Identity/appsettings.json
@@ -75,6 +75,10 @@
         "fonts.googleapis.com",
         "fonts.gstatic.com"
     ],
+    "CorsConfiguration": {
+        "AllowAnyOrigin": true,
+        "CorsAllowOrigins": null
+    },
     "CultureConfiguration": {
         "Cultures": [],
         "DefaultCulture": null


### PR DESCRIPTION
This PR is to add support in the STS for Cors headers to be configured. This is required to resolve some errors with .Net 5 Blazor authentication which enforces a check on the Cors headers.