### PR TITLE
Make correction towards the EF Core section

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ The following Gulp commands are available:
   - `AdminLogDbContext`: for logging
   - `IdentityServerConfigurationDbContext`: for IdentityServer configuration store
   - `IdentityServerPersistedGrantDbContext`: for IdentityServer operational store
-  - `AuditLoggingDbContext`: for Audit Logging
+  - `AdminAuditLogDbContext`: for Audit Logging
   - `IdentityServerDataProtectionDbContext`: for dataprotection
 
 ### Run entity framework migrations:


### PR DESCRIPTION
I noticed the database context name in the instruction is not correct. It should be `AdminAuditLogDbContext` instead of `AuditLoggingDbContext` 

Since not everyone is going to use that Powershell script to perform migrations, it will be great to rectify this part of the document. 

Thank you!