### PR TITLE
Fix errors when a Windows (AD) user without email or displayName is logging on

### DIFF
--- a/src/Skoruba.IdentityServer4.STS.Identity/Configuration/WindowsAuthConfiguration.cs
+++ b/src/Skoruba.IdentityServer4.STS.Identity/Configuration/WindowsAuthConfiguration.cs
@@ -37,6 +37,8 @@ namespace Skoruba.IdentityServer4.STS.Identity.Configuration
         // Subnets specified here will always be considered external
         // (useful for testing purposes and for intranet machines not joined to the domain)
         public List<Subnet> ExcludedLocalSubnets { get; set; } = new List<Subnet>();
+
+        public string EmailFallback { get; set; } = String.Empty;
     }
 
     public class Subnet

--- a/src/Skoruba.IdentityServer4.STS.Identity/Controllers/AccountController.cs
+++ b/src/Skoruba.IdentityServer4.STS.Identity/Controllers/AccountController.cs
@@ -257,8 +257,8 @@ namespace Skoruba.IdentityServer4.STS.Identity.Controllers
 
             id.AddClaim(new Claim(JwtClaimTypes.Subject, name));
             id.AddClaim(new Claim(ClaimTypes.NameIdentifier, name));
-            id.AddClaim(new Claim(JwtClaimTypes.Name, adProperties.DisplayName));
-            id.AddClaim(new Claim(JwtClaimTypes.Email, adProperties.Email));
+            id.AddClaim(new Claim(JwtClaimTypes.Name, adProperties.DisplayName??name));
+            id.AddClaim(new Claim(JwtClaimTypes.Email, adProperties.Email?? _windowsAuthConfiguration.EmailFallback));
 
             // we will issue the external cookie and then redirect the
             // user back to the external callback, in essence, treating windows


### PR DESCRIPTION
We tried windows authentication but we ended up with an error when a user with no email and/or display name set.

A simple way to fix this error is included in this PR.
Of course, in order to work, you also need to set a value for the email-fallback on the STS appsettings.json

```json
"WindowsAuthConfiguration": {
    "EmailFallback": "address@domain.com"
  },
```

And also you need to switch off the RequireUniqueEmail settings:
```json
"IdentityOptions": {
    "User": {
      "RequireUniqueEmail": false
    }
}
```