### PR TITLE
Fix Azure AAD external authentication not working since change to .net 5

### DIFF
--- a/src/Skoruba.IdentityServer4.STS.Identity/Helpers/StartupHelpers.cs
+++ b/src/Skoruba.IdentityServer4.STS.Identity/Helpers/StartupHelpers.cs
@@ -381,7 +381,7 @@ namespace Skoruba.IdentityServer4.STS.Identity.Helpers
                     options.Instance = externalProviderConfiguration.AzureInstance;
                     options.Domain = externalProviderConfiguration.AzureDomain;
                     options.CallbackPath = externalProviderConfiguration.AzureAdCallbackPath;
-                });
+                },  cookieScheme: null);
             }
         }
 


### PR DESCRIPTION
This change fixes skoruba#863 and most likely also skoruba#701 in the latests versiones. Since the change to Microsoft Identity library the Azure AAD provider does not work by default.

The problem relies in that Microsft Identity Library creates it's own cookie scheme handler, thus bypassing Identity Server (or asp.net identity) one when authenticating externally. Based on the info in the Identity Web Library repo, we can bypass this cookie handler by setting cookieScheme parameter to null.

This pull requests adds it to the default AAD external configuration provider with IdentityServer Admin.