### PR TITLE
Enabling support for Date and Time type=local for PostgreSQL version 6.0

### DIFF
--- a/src/Skoruba.IdentityServer4.Admin.Api/Program.cs
+++ b/src/Skoruba.IdentityServer4.Admin.Api/Program.cs
@@ -21,6 +21,10 @@ namespace Skoruba.IdentityServer4.Admin.Api
             {
                 DockerHelpers.ApplyDockerConfiguration(configuration);
 
+                //Disable UTC only DateTime type for PostgreSQL >= 6.0
+                //See https://github.com/skoruba/IdentityServer4.Admin/issues/996 and https://www.npgsql.org/doc/types/datetime.html
+                AppContext.SetSwitch("Npgsql.EnableLegacyTimestampBehavior", true);
+
                 CreateHostBuilder(args).Build().Run();
             }
             catch (Exception ex)


### PR DESCRIPTION
Fix  #996 