### PR TITLE
Fix for #1028 - OpenIdConnectProtocolException  - caused by Forwarded Headers

### DIFF
--- a/src/Skoruba.IdentityServer4.STS.Identity/Helpers/StartupHelpers.cs
+++ b/src/Skoruba.IdentityServer4.STS.Identity/Helpers/StartupHelpers.cs
@@ -96,16 +96,6 @@ namespace Skoruba.IdentityServer4.STS.Identity.Helpers
         /// <param name="configuration"></param>
         public static void UseSecurityHeaders(this IApplicationBuilder app, IConfiguration configuration)
         {
-            var forwardingOptions = new ForwardedHeadersOptions()
-            {
-                ForwardedHeaders = ForwardedHeaders.All
-            };
-
-            forwardingOptions.KnownNetworks.Clear();
-            forwardingOptions.KnownProxies.Clear();
-
-            app.UseForwardedHeaders(forwardingOptions);
-
             app.UseReferrerPolicy(options => options.NoReferrer());
 
             // CSP Configuration to be able to use external resources

--- a/src/Skoruba.IdentityServer4.STS.Identity/Startup.cs
+++ b/src/Skoruba.IdentityServer4.STS.Identity/Startup.cs
@@ -13,6 +13,7 @@ using Skoruba.IdentityServer4.STS.Identity.Configuration.Interfaces;
 using Skoruba.IdentityServer4.STS.Identity.Helpers;
 using System;
 using Skoruba.IdentityServer4.Shared.Configuration.Helpers;
+using Microsoft.AspNetCore.HttpOverrides;
 
 namespace Skoruba.IdentityServer4.STS.Identity
 {
@@ -107,6 +108,16 @@ namespace Skoruba.IdentityServer4.STS.Identity
         {
             var rootConfiguration = CreateRootConfiguration();
             services.AddAuthorizationPolicies(rootConfiguration);
+        }
+
+        public virtual void RegisterForwardedHeaders(IServiceCollection services)
+        {
+            services.Configure<ForwardedHeadersOptions>(options =>
+            {
+                options.ForwardedHeaders = ForwardedHeaders.All;
+                options.KnownNetworks.Clear();
+                options.KnownProxies.Clear();
+            });
         }
 
         public virtual void UseAuthentication(IApplicationBuilder app)

--- a/src/Skoruba.IdentityServer4.STS.Identity/Startup.cs
+++ b/src/Skoruba.IdentityServer4.STS.Identity/Startup.cs
@@ -41,6 +41,8 @@ namespace Skoruba.IdentityServer4.STS.Identity
             // Add email senders which is currently setup for SendGrid and SMTP
             services.AddEmailSenders(Configuration);
 
+            RegisterForwardedHeaders(services);
+
             // Add services for authentication, including Identity model and external providers
             RegisterAuthentication(services);
 

--- a/src/Skoruba.IdentityServer4.STS.Identity/Startup.cs
+++ b/src/Skoruba.IdentityServer4.STS.Identity/Startup.cs
@@ -62,6 +62,7 @@ namespace Skoruba.IdentityServer4.STS.Identity
 
         public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
         {
+            app.UseForwardedHeaders();
             app.UseCookiePolicy();
 
             if (env.IsDevelopment())


### PR DESCRIPTION
Dear @skoruba, I've found the fix for issue #1028, please take a look and merge if you find it good.

Thanks and regards,

Martinus